### PR TITLE
Fix a typo in the ckeditor5 plugin upcaster

### DIFF
--- a/packages/mathtype-ckeditor5/src/plugin.js
+++ b/packages/mathtype-ckeditor5/src/plugin.js
@@ -211,7 +211,7 @@ export default class MathType extends Plugin {
         editor.conversion.for( 'upcast' ).elementToElement( {
             view: {
                 name: 'span',
-                class: 'ck-math-widget',
+                classes: 'ck-math-widget',
             },
             model: ( viewElement, modelWriter ) => {
                 const formula = MathML.safeXmlDecode( viewElement.getChild( 0 ).getAttribute( 'data-mathml' ) );


### PR DESCRIPTION
This will limit upcast conversions only to elements with class="ck-math-widget"

This fixes https://github.com/wiris/html-integrations/issues/17