### PR TITLE
Fix formula generator in parser

### DIFF
--- a/packages/mathtype-html-integration-devkit/src/parser.js
+++ b/packages/mathtype-html-integration-devkit/src/parser.js
@@ -318,12 +318,11 @@ export default class Parser {
    * @returns {Object} JSON object containing showimage response.
    */
   static createShowImageSrc(data, language) {
-    const dataMd5 = [];
+    const dataMd5 = {};
     const renderParams = ['mml', 'color', 'centerbaseline', 'zoom', 'dpi', 'fontSize', 'fontFamily', 'defaultStretchy', 'backgroundColor', 'format'];
     renderParams.forEach((key) => {
-      const param = renderParams[key];
-      if (typeof data[param] !== 'undefined') {
-        dataMd5[param] = data[param];
+      if (typeof data[key] !== 'undefined') {
+        dataMd5[key] = data[key];
       }
     });
     // Data variables to get.


### PR DESCRIPTION
The `forEach()` method executes a provided function once for each array element. It means that `const param = renderParams[key];` line is redundant, because `key` returns parameter name.

This bug causes the issues with formula – `dataMd5` is always empty and `dataObject.formula` is always equal to "d41d8cd98f00b204e9800998ecf8427e".