### PR TITLE
KB-5030:  Clicking outside MathType modal window results in error

### DIFF
--- a/packages/mathtype-html-integration-devkit/src/popupmessage.js
+++ b/packages/mathtype-html-integration-devkit/src/popupmessage.js
@@ -117,7 +117,7 @@ export default class PopUpMessage {
       this.closeButton.focus();
     } else {
       this.overlayWrapper.style.display = 'none';
-      _wrs_modalWindow.focus();
+      // _wrs_modalWindow.focus(); This throws an error of not existing _wrs_modalWindow
     }
   }
 


### PR DESCRIPTION
This error is solved in the devkit package. 

The error was reproducable with
1. Click MathType toolbar icon
2. Make MathType window full-screen
3. Type something
4. Click twice outside the modal window
5. Get the error: Uncaught ReferenceError: _wrs_modalWindow is not defined    at Yb.show (popupmessage.js:120)    at Kb.showPopUpMessage (modal.js:1407)    at Kb.cancelAction (modal.js:285)

This pull requests solves this error, it stops appearing and the modal window works as expected.
You'll have to test if the error does not appear any more in any browser or editor (since the error was in the devkit package) and that the modal window does not do anything weird and works as expected