### PR TITLE
Kb 2259: Fix multiple issues on the MathType editor on iOS devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Mono-repository for the MathType Web plugins and their dependencies. &nbsp; <img src="resources/img/logo.jpg" width="40"> 
 
-[![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](CONTRIBUITING.md) &nbsp; &nbsp; &nbsp; 
-[![Updated](https://img.shields.io/badge/Updated%3F-yes-green.svg)](CONTRIBUITING.md) &nbsp; &nbsp; &nbsp; 
-[![Downloads](https://img.shields.io/static/v1.svg?label=Downloads&message=40&color=blue)](https://github.com/wiris/html-integrations/graphs/traffic)
+[![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](CONTRIBUITING.md)&nbsp;[![Updated](https://img.shields.io/badge/Updated%3F-yes-green.svg)](CONTRIBUITING.md)&nbsp;[![Downloads](https://img.shields.io/static/v1.svg?label=Downloads&message=40&color=blue)](https://github.com/wiris/html-integrations/graphs/traffic)
 
 Mono-repository for the [MathType](http://www.wiris.com/en/mathtype) Web plugins and their dependencies. 
 
@@ -303,7 +301,7 @@ because they need to have the source replaced before building.
 ## Examples for developers
 
 In order to manually test each plugin, there's a set of technical demos on
-the 'demos/' folder.
+the ['demos/'](./demos/) folder on this project.
 
 Refer to the [README](demos/README.md) file for more information.
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -89,9 +89,20 @@ designed for maintaining multiple npm packages in a single git repository.
 
 To work with Lerna and try out the packages, with your local changes instead of the published packages, you'd need to copy the contents from `lerna.demos.json` to `lerna.json`.
 
+```sh
+html-integrations$ cp lerna.demos.json lerna.json
+```
+Before running the demo, you must first 'bootstrap' and 'compile' the libraries. Follow the instructions on the [README.md](./README.md) file.
+
+```sh
+html-integrations$ npm install
+html-integrations$ npm start
+```
+
+
 ### How to run a demo with the local package
 
-Before running the demo, you must first go to the desired folder for a framework and editor.<br>
+Go to the desired folder for the framework and editor of your choice and run the 'build-dev' command.<br>
 
 ```sh
 $ cd demos/[technology]/[editor]

--- a/demos/angular/ckeditor5/README.md
+++ b/demos/angular/ckeditor5/README.md
@@ -22,7 +22,7 @@ Open [http://localhost:4200/](http://localhost:4200/) to view it in the browser.
 The page will reload if you make edits.<br />
 You will also see any lint errors in the console.
 
-## How to add MathType to TinyMCE from scratch
+## How to add MathType to CKEditor from scratch
 
 1. Run the following through the terminal
 

--- a/demos/angular/froala3/README.md
+++ b/demos/angular/froala3/README.md
@@ -22,7 +22,7 @@ Open [http://localhost:4200/](http://localhost:4200/) to view it in the browser.
 The page will reload if you make edits.<br />
 You will also see any lint errors in the console.
 
-## How to add MathType to TinyMCE from scratch
+## How to add MathType to Froala from scratch
 
 1. Run the following through the terminal
 

--- a/demos/html5/ckeditor4/webpack.config.js
+++ b/demos/html5/ckeditor4/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8001,
+    host: '0.0.0.0'
   },
   resolve: {
     modules: ['node_modules'],

--- a/demos/html5/ckeditor5/webpack.config.js
+++ b/demos/html5/ckeditor5/webpack.config.js
@@ -18,6 +18,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8002,
+    host: '0.0.0.0'
   },
 
   module: {

--- a/demos/html5/froala2/webpack.config.js
+++ b/demos/html5/froala2/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8003,
+    host: '0.0.0.0'
   },
   resolve: {
     modules: ['node_modules'],

--- a/demos/html5/froala3/webpack.config.js
+++ b/demos/html5/froala3/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8004,
+    host: '0.0.0.0'
   },
   resolve: {
     modules: ['node_modules'],

--- a/demos/html5/generic/webpack.config.js
+++ b/demos/html5/generic/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8007,
+    host: '0.0.0.0'
   },
   resolve: {
     modules: ['node_modules'],

--- a/demos/html5/tinymce4/webpack.config.js
+++ b/demos/html5/tinymce4/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8005,
+    host: '0.0.0.0'
   },
   resolve: {
     modules: ['node_modules'],

--- a/demos/html5/tinymce5/webpack.config.js
+++ b/demos/html5/tinymce5/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8006,
+    host: '0.0.0.0'
   },
   resolve: {
     modules: ['node_modules'],

--- a/packages/mathtype-html-integration-devkit/src/contentmanager.js
+++ b/packages/mathtype-html-integration-devkit/src/contentmanager.js
@@ -187,7 +187,12 @@ export default class ContentManager {
 
       // iOS events.
       if (this.modalDialogInstance.deviceProperties.isIOS) {
-        setTimeout(function hide() { this.modalDialogInstance.hideKeyboard(); }, 400);
+        setTimeout(function hide() { 
+          // Make sure the modalDialogInstance is available when the timeout is over
+          // to avoid throw errors and stop execution.
+          if(this.hasOwnProperty('modalDialogInstance')) this.modalDialogInstance.hideKeyboard(); 
+        }, 400);
+
         const formulaDisplayDiv = document.getElementsByClassName('wrs_formulaDisplay')[0];
         Util.addEvent(formulaDisplayDiv, 'focus', this.modalDialogInstance.handleOpenedIosSoftkeyboard);
         Util.addEvent(formulaDisplayDiv, 'blur', this.modalDialogInstance.handleClosedIosSoftkeyboard);

--- a/packages/mathtype-html-integration-devkit/src/contentmanager.js
+++ b/packages/mathtype-html-integration-devkit/src/contentmanager.js
@@ -90,7 +90,8 @@ export default class ContentManager {
      */
     this.deviceProperties = {};
     this.deviceProperties.isAndroid = this.ua.indexOf('android') > -1;
-    this.deviceProperties.isIOS = ((this.ua.indexOf('ipad') > -1) || (this.ua.indexOf('iphone') > -1));
+    this.deviceProperties.isIOS = ContentManager.isIOS();
+  
 
     /**
      * Custom editor toolbar.
@@ -304,6 +305,23 @@ export default class ContentManager {
     }
 
     return stats;
+  }
+
+  /**
+   * Returns true if device is iOS. Otherwise, false.
+   * @returns {Boolean}
+   */
+  static isIOS() {
+    return [
+      'iPad Simulator',
+      'iPhone Simulator',
+      'iPod Simulator',
+      'iPad',
+      'iPhone',
+      'iPod'
+    ].includes(navigator.platform)
+    // iPad on iOS 13 detection
+    || (navigator.userAgent.includes("Mac") && "ontouchend" in document);
   }
 
   /**

--- a/packages/mathtype-html-integration-devkit/src/modal.js
+++ b/packages/mathtype-html-integration-devkit/src/modal.js
@@ -41,7 +41,7 @@ export default class ModalDialog {
     // Metrics.
     const ua = navigator.userAgent.toLowerCase();
     const isAndroid = ua.indexOf('android') > -1;
-    const isIOS = ((ua.indexOf('ipad') > -1) || (ua.indexOf('iphone') > -1));
+    const isIOS = ContentManager.isIOS();
     this.iosSoftkeyboardOpened = false;
     this.iosMeasureUnit = ua.indexOf('crios') === -1 ? '%' : 'vh';
     this.iosDivHeight = `100%${this.iosMeasureUnit}`;

--- a/packages/mathtype-html-integration-devkit/src/modal.js
+++ b/packages/mathtype-html-integration-devkit/src/modal.js
@@ -367,6 +367,7 @@ export default class ModalDialog {
     document.body.appendChild(this.overlay);
 
     if (this.deviceProperties.isDesktop) { // Desktop.
+
       this.createModalWindowDesktop();
       this.createResizeButtons();
 
@@ -377,7 +378,7 @@ export default class ModalDialog {
       }
     } else if (this.deviceProperties.isAndroid) {
       this.createModalWindowAndroid();
-    } else if (this.deviceProperties.isIOS && !this.deviceProperties.isMobile) {
+    } else if (this.deviceProperties.isIOS) {
       this.createModalWindowIos();
     }
 


### PR DESCRIPTION
### Fix errors affecting UserAgent simulation scenario

An error stops execution when opening MathType with some
iOs simulated user agent. The error differs depending on the browser.

On real iOS devices everything works as expected and there are no errors
on the console, though.

The bug is fixed by making sure the 'modalDialogInstance' is available on
execution time.

### Load the editor in fullscreen mode on iOs devices

Fixed by improving the browse detection method for iOs devices
on the contentmanager class.

### Also

- Update demos: Set the right editor name on the title's section
- Update README: Refrain some instructions for better understanding
- Make devserver accessible on all html5 demos

> In order to test this on actual mobile devices, one must expose the
> demos to the local network. To do this, just modify the
> webpack.config.js file for the desired demo so as to include
> host: '0.0.0.0'  in the devServer section.


