### PR TITLE
[CKEditor 5] Removing MathType equation which is being edited results in a crash

### DIFF
--- a/demos/html5/ckeditor5/package.json
+++ b/demos/html5/ckeditor5/package.json
@@ -24,7 +24,7 @@
     "@ckeditor/ckeditor5-essentials": ">=22.0.0",
     "@ckeditor/ckeditor5-paragraph": ">=22.0.0",
     "@ckeditor/ckeditor5-theme-lark": ">=22.0.0",
-    "@wiris/mathtype-ckeditor5": "^7.23.0",
+    "@wiris/mathtype-ckeditor5": "^7.24.0",
     "postcss-loader": "^3.0.0",
     "webpack-dev-server": "^3.10.3"
   },

--- a/packages/mathtype-ckeditor5/src/integration.js
+++ b/packages/mathtype-ckeditor5/src/integration.js
@@ -254,11 +254,18 @@ export default class CKEditor5Integration extends IntegrationModel {
             } );
 
         } else {
-            returnObject.node = this.editorObject.editing.view.domConverter.viewToDom(
-                this.editorObject.editing.mapper.toViewElement(
-                    this.insertMathml( mathml )
-                ), windowTarget.document
-            );
+            try {
+                returnObject.node = this.editorObject.editing.view.domConverter.viewToDom(
+                    this.editorObject.editing.mapper.toViewElement(
+                        this.insertMathml( mathml )
+                    ), windowTarget.document
+                );
+            }  catch ( e ) {
+                const x = e.toString();
+                if( ( x ).includes( "CKEditorError: Cannot read property 'parent' of undefined" ) ) {
+                    this.core.modalDialog.cancelAction();
+                }
+            }
         }
 
         /* Due to PLUGINS-1329, we add the onChange event to the CK4 insertFormula.


### PR DESCRIPTION
## How to reproduce
See original issue: https://github.com/wiris/html-integrations/issues/94

## Description
The code for this pull request solves a problem with the wiris modal in the ckeditor5: appears an error when deleting a formula on the editor that is being edited in the wiris modal.

In order to accept this review you must check that the code is reliable, that it follows good practices, that it solves the problem mentioned, and that it does not break other aspects of the plugin.