### PR TITLE
[CKEditor 5] Not able to insert new line after MathType equation in Firefox

### DIFF
--- a/packages/mathtype-ckeditor5/src/plugin.js
+++ b/packages/mathtype-ckeditor5/src/plugin.js
@@ -7,7 +7,7 @@ import ClickObserver from '@ckeditor/ckeditor5-engine/src/view/observer/clickobs
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import XmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/xmldataprocessor';
 import UpcastWriter from '@ckeditor/ckeditor5-engine/src/view/upcastwriter'
-import { toWidget } from '@ckeditor/ckeditor5-widget/src/utils';
+import { toWidget, viewToModelPositionOutsideModelElement } from '@ckeditor/ckeditor5-widget/src/utils';
 import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 
 // MathType API imports
@@ -397,6 +397,12 @@ export default class MathType extends Plugin {
             return viewWriter.createEmptyElement( 'img', imgElement.getAttributes() );
 
         }
+
+        // This stops the view selection getting into the <span>s and messing up caret movement
+        editor.editing.mapper.on(
+            'viewToModelPosition',
+            viewToModelPositionOutsideModelElement( editor.model, viewElement => viewElement.hasClass( 'ck-math-widget' ) )
+        );
 
     }
 


### PR DESCRIPTION
## Description

This pull request fixes issue #96, which stops the user from inserting a new line after a MathType formula in CKEditor 5.

## How to reproduce

1. Add MathType equation as last element in the editor
2. Try to navigate to the end of the equation and press `enter`

Expected: a new line is inserted.
Actual: no new line is inserted, and the caret disappears.

For more details see #96.