### PR TITLE
[CKEditor 4] onChange event is getting called before aplying mathtype changes

### DIFF
--- a/demos/html5/ckeditor4/package-lock.json
+++ b/demos/html5/ckeditor4/package-lock.json
@@ -1965,6 +1965,11 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wiris/mathtype-ckeditor4": {
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@wiris/mathtype-ckeditor4/-/mathtype-ckeditor4-7.24.0.tgz",
+      "integrity": "sha512-upFaKjhsDZ/OcWbMjsWKvDLcU+galagY12Zt//VHF+XZCv3KHT0wzvTPaHJnzMTEtXAEh/uUL1aOJVaATQQB6A=="
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",

--- a/packages/mathtype-ckeditor4/plugin.src.js
+++ b/packages/mathtype-ckeditor4/plugin.src.js
@@ -253,8 +253,9 @@ export class CKEditor4Integration extends IntegrationModel {
         // Due to insertFormula adds an image using pure JavaScript functions,
         // it is needed notificate to the editorObject that placeholder status
         // has to be updated.
+        const formula = super.insertFormula(focusElement, windowTarget, mathml, wirisProperties);
         this.editorObject.fire('change');
-        return super.insertFormula(focusElement, windowTarget, mathml, wirisProperties);
+        return formula;
     }
 
 


### PR DESCRIPTION
### **Description**

This pull request fixes issue #115, which calls the event onChange bero aplying the mathtype formula changes on CKEditor4

### **How to reproduce**

1. Open https://ckeditor.com/docs/ckeditor4/latest/examples/mathtype.html
2. Handle 'change' event of editor, paste in dev console:
3. CKEDITOR.instances.editor1.on( 'change', function() { console.log( 'change event data', this.getData() ); } );
4. Delete all content in ckeditor
5. Launch mathtype from the editor
6. Add math formula and click insert
7. Editor 'change event is fired, when you click insert button on mathtype.
8. call editor.getData(), returns empty result
9. Formula is is inserted into ckeditor.
10. Solved changing the order when calling on change event.

Expected: when call step 7 above, expected to get the mathml code as data.
Actual: returns empty.

For more details see #115 .