### PR TITLE
Update CKEditor demos to the most recent SDK version

### DIFF
--- a/demos/angular/ckeditor5/package.json
+++ b/demos/angular/ckeditor5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-angular-ckeditor5",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "A simple Angular App integrating WIRIS MathType in a CKEditor rich text editor.",
   "scripts": {
     "ng": "ng",
@@ -35,7 +35,7 @@
     "@ckeditor/ckeditor5-link": ">=22.0.0",
     "@ckeditor/ckeditor5-list": ">=22.0.0",
     "@ckeditor/ckeditor5-paragraph": ">=22.0.0",
-    "@wiris/mathtype-ckeditor5": "^7.24.1",
+    "@wiris/mathtype-ckeditor5": "^7.20.0",
     "resources": "file:../../../resources",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",

--- a/demos/angular/ckeditor5/package.json
+++ b/demos/angular/ckeditor5/package.json
@@ -1,18 +1,18 @@
 {
   "name": "demo-angular-ckeditor5",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A simple Angular App integrating WIRIS MathType in a CKEditor rich text editor.",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --open",
-    "serve": "ng serve",
+    "start": "ng serve --host 0.0.0.0 --open",
+    "serve": "ng serve --host 0.0.0.0 ",
     "build-dev": "lerna bootstrap && cd ../../../packages/mathtype-ckeditor5/ && filename=$( npm pack --quiet ) && cd - && npm install ../../../packages/mathtype-ckeditor5/$filename && ng serve",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"
   },
-  "author": "Carla Lara",
+  "author": "WIRIS Team (http://www.wiris.com)",
   "license": "MIT",
   "private": true,
   "dependencies": {
@@ -35,7 +35,7 @@
     "@ckeditor/ckeditor5-link": ">=22.0.0",
     "@ckeditor/ckeditor5-list": ">=22.0.0",
     "@ckeditor/ckeditor5-paragraph": ">=22.0.0",
-    "@wiris/mathtype-ckeditor5": "^7.20.0",
+    "@wiris/mathtype-ckeditor5": "^7.24.1",
     "resources": "file:../../../resources",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",

--- a/demos/angular/ckeditor5/src/app/app.component.ts
+++ b/demos/angular/ckeditor5/src/app/app.component.ts
@@ -9,8 +9,8 @@ import * as Generic from 'resources/demos/angular-imports';
 import { version as pluginVersion } from '@wiris/mathtype-ckeditor5/package.json';
 
 // Apply specific demo names to all the objects.
-document.getElementById('header_title_name').innerHTML = 'Mathtype for CKeditor';
-document.getElementById('version_editor').innerHTML = 'CKeditor editor: ';
+document.getElementById('header_title_name').innerHTML = 'Mathtype for CKEditor';
+document.getElementById('version_editor').innerHTML = 'CKEditor editor: ';
 
 // Create the initial editor content.
 const editorContent = '<p class="text"> Double click on the following formula to edit it.</p><p style="text-align:center;"><math><mi>x</mi><mo>=</mo><mfrac><mrow><mo>-</mo><mi>b</mi><mo>&PlusMinus;</mo><msqrt><msup><mi>b</mi><mn>2</mn></msup><mo>-</mo><mn>4</mn><mi>a</mi><mi>c</mi></msqrt></mrow><mrow><mn>2</mn><mi>a</mi></mrow></mfrac></math></p>';

--- a/demos/angular/ckeditor5/src/index.html
+++ b/demos/angular/ckeditor5/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Ckeditor5</title>
+  <title>CKEditor5 demo on Angular</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/demos/angular/froala3/package.json
+++ b/demos/angular/froala3/package.json
@@ -4,8 +4,8 @@
   "description": "A simple Angular App integrating WIRIS MathType in a Froala rich text editor.",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --open",
-    "serve": "ng serve",
+    "start": "ng serve --host 0.0.0.0 --open",
+    "serve": "ng serve --host 0.0.0.0 ",
     "compile-package": "cd ../../../packages/mathtype-froala3/ && npm run compile -- npm --dev",
     "build-dev": "lerna bootstrap && npm run compile-package && ng serve",
     "build": "ng build",
@@ -13,7 +13,7 @@
     "lint": "ng lint",
     "e2e": "ng e2e"
   },
-  "author": "Carla Lara",
+  "author": "WIRIS Team (http://www.wiris.com)",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/demos/angular/generic/package.json
+++ b/demos/angular/generic/package.json
@@ -4,8 +4,8 @@
   "description": "A simple Angular App integrating WIRIS MathType in a Generic integration.",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --open",
-    "serve": "ng serve",
+    "start": "ng serve --host 0.0.0.0 --open",
+    "serve": "ng serve --host 0.0.0.0 ",
     "compile-package": "cd ../../../packages/mathtype-generic/ && npm run compile -- npm --dev",
     "build-dev": "lerna bootstrap && npm run compile-package && ng serve",
     "build": "ng build",
@@ -13,7 +13,7 @@
     "lint": "ng lint",
     "e2e": "ng e2e"
   },
-  "author": "Carla Lara",
+  "author": "WIRIS Team (http://www.wiris.com)",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/demos/angular/tinymce5/package.json
+++ b/demos/angular/tinymce5/package.json
@@ -4,8 +4,8 @@
   "description": "A simple Angular App integrating WIRIS MathType in a TinyMCE rich text editor.",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --open",
-    "serve": "ng serve",
+    "start": "ng serve --host 0.0.0.0 --open",
+    "serve": "ng serve --host 0.0.0.0 ",
     "compile-package": "cd ../../../packages/mathtype-tinymce5/ && npm run compile -- npm --dev",
     "build-dev": "lerna bootstrap && npm run compile-package && ng serve",
     "build": "ng build",
@@ -13,7 +13,7 @@
     "lint": "ng lint",
     "e2e": "ng e2e"
   },
-  "author": "Carla Lara",
+  "author": "WIRIS Team (http://www.wiris.com)",
   "license": "MIT",
   "private": true,
   "dependencies": {

--- a/demos/html5/ckeditor4/index.html
+++ b/demos/html5/ckeditor4/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
     <head>
-        <title> Demo CKeditor4 </title>
+        <title> Demo CKEditor4 </title>
         <meta http-equiv="content-type" content="text/html; charset=UTF-8">
         <script src="./node_modules/ckeditor4/ckeditor.js"></script>
     </head>

--- a/demos/html5/ckeditor4/package.json
+++ b/demos/html5/ckeditor4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-html5-ckeditor4",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A simple html5 App integrating WIRIS MathType in a CKEditor4 rich text editor.",
   "main": "app.js",
   "scripts": {
@@ -14,12 +14,11 @@
     "stylelint": "npx stylelint '**/*.css'",
     "linthtml": "html-validate index.html"
   },
-  "author": "Carla Lara",
+  "author": "WIRIS Team (http://www.wiris.com)",
   "license": "MIT",
   "dependencies": {
-    "@wiris/mathtype-ckeditor4": "^7.20.0",
-    "ckeditor4": "^4.14.0",
-    "webpack-dev-server": "^3.11.0"
+    "@wiris/mathtype-ckeditor4": "^7.24.1",
+    "ckeditor4": "^4.14.0"
   },
   "devDependencies": {
     "css-loader": "^3.5.3",

--- a/demos/html5/ckeditor4/package.json
+++ b/demos/html5/ckeditor4/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-html5-ckeditor4",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "A simple html5 App integrating WIRIS MathType in a CKEditor4 rich text editor.",
   "main": "app.js",
   "scripts": {
@@ -17,7 +17,7 @@
   "author": "WIRIS Team (http://www.wiris.com)",
   "license": "MIT",
   "dependencies": {
-    "@wiris/mathtype-ckeditor4": "^7.24.1",
+    "@wiris/mathtype-ckeditor4": "^7.20.0",
     "ckeditor4": "^4.14.0"
   },
   "devDependencies": {

--- a/demos/html5/ckeditor4/src/app.js
+++ b/demos/html5/ckeditor4/src/app.js
@@ -8,8 +8,8 @@ import './static/style.css';
 import * as Generic from '../../../../resources/demos/imports';
 
 // Apply specific demo names to all the objects.
-document.getElementById('header_title_name').innerHTML = 'Mathtype for CKeditor';
-document.getElementById('version_editor').innerHTML = 'CKeditor editor: ';
+document.getElementById('header_title_name').innerHTML = 'Mathtype for CKEditor';
+document.getElementById('version_editor').innerHTML = 'CKEditor editor: ';
 
 // Copy the editor content before initializing it.
 Generic.copyContentFromxToy('editor', 'transform_content');

--- a/demos/html5/ckeditor5/package.json
+++ b/demos/html5/ckeditor5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-html5-ckeditor5",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple html5 App integrating WIRIS MathType in a CKEditor5 rich text editor.",
   "main": "app.js",
   "scripts": {
@@ -14,7 +14,7 @@
     "stylelint": "npx stylelint '**/*.css'",
     "linthtml": "html-validate index.html"
   },
-  "author": "Carla Lara",
+  "author": "WIRIS Team (http://www.wiris.com)",
   "license": "MIT",
   "dependencies": {
     "@ckeditor/ckeditor5-alignment": ">=22.0.0",
@@ -24,9 +24,7 @@
     "@ckeditor/ckeditor5-essentials": ">=22.0.0",
     "@ckeditor/ckeditor5-paragraph": ">=22.0.0",
     "@ckeditor/ckeditor5-theme-lark": ">=22.0.0",
-    "@wiris/mathtype-ckeditor5": "^7.24.0",
-    "postcss-loader": "^3.0.0",
-    "webpack-dev-server": "^3.10.3"
+    "@wiris/mathtype-ckeditor5": "^7.24.1"
   },
   "devDependencies": {
     "css-loader": "^3.5.3",
@@ -38,6 +36,7 @@
     "stylelint-config-standard": "^20.0.0",
     "jest": "^26.1.0",
     "jest-html-reporter": "^3.1.3",
+    "postcss-loader": "^3.0.0",
     "puppeteer": "^5.0.0",
     "html-validate": "^2.20.0",
     "html-loader": "^1.1.0",

--- a/demos/html5/ckeditor5/package.json
+++ b/demos/html5/ckeditor5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-html5-ckeditor5",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "A simple html5 App integrating WIRIS MathType in a CKEditor5 rich text editor.",
   "main": "app.js",
   "scripts": {
@@ -24,7 +24,7 @@
     "@ckeditor/ckeditor5-essentials": ">=22.0.0",
     "@ckeditor/ckeditor5-paragraph": ">=22.0.0",
     "@ckeditor/ckeditor5-theme-lark": ">=22.0.0",
-    "@wiris/mathtype-ckeditor5": "^7.24.1"
+    "@wiris/mathtype-ckeditor5": "^7.20.0"
   },
   "devDependencies": {
     "css-loader": "^3.5.3",

--- a/demos/react/ckeditor5/package.json
+++ b/demos/react/ckeditor5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-react-ckeditor5",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A simple ReactJS App integrating WIRIS MathType in a CKEditor rich text editor.",
   "private": true,
   "dependencies": {
@@ -18,7 +18,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
-    "@wiris/mathtype-ckeditor5": "^7.20.0",
+    "@wiris/mathtype-ckeditor5": "^7.24.1",
     "ckeditor5": ">=22.0.0",
     "cross-env": "^7.0.2",
     "html-loader": "^1.1.0",
@@ -38,14 +38,14 @@
     "html-validate": "^2.20.0"
   },
   "scripts": {
-    "start": "cross-env PORT=3002 react-scripts start",
-    "serve": "BROWSER=none cross-env PORT=3002 react-scripts start",
+    "start": "cross-env PORT=3002 HOST=0.0.0.0 react-scripts start",
+    "serve": "BROWSER=none cross-env HOST=0.0.0.0 PORT=3002 react-scripts start",
     "build-dev": "lerna bootstrap && cd ../../../packages/mathtype-ckeditor5/ && filename=$( npm pack --quiet ) && cd - && npm install ../../../packages/mathtype-ckeditor5/$filename && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
-  "author": "Carla Lara",
+  "author": "WIRIS Team (http://www.wiris.com)",
   "license": "MIT",
   "browserslist": {
     "production": [

--- a/demos/react/ckeditor5/package.json
+++ b/demos/react/ckeditor5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo-react-ckeditor5",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "A simple ReactJS App integrating WIRIS MathType in a CKEditor rich text editor.",
   "private": true,
   "dependencies": {
@@ -18,7 +18,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
-    "@wiris/mathtype-ckeditor5": "^7.24.1",
+    "@wiris/mathtype-ckeditor5": "^7.20.0",
     "ckeditor5": ">=22.0.0",
     "cross-env": "^7.0.2",
     "html-loader": "^1.1.0",


### PR DESCRIPTION
This pull request adds some changes to make the CKEeditor demos 
always use the latest version of the MathType SDK package.

This last version solves the issue https://github.com/wiris/html-integrations/issues/38.

With these changes, we'll can answer the reporter of the issue with step-by-step
instructions to validate the solution for himself by testing any of the CKEditor
demos included on this repository.

Also, some minor changes have been added, too:

- Use branded name for CKEditor.
- Update 'author' field to the whole team on most demos.
- Make the CKEditor demo accesible through the net.
- Make angular demos accesible through the net.
- Update dependencies on some demos.
- Update React demos to use latest SDK version.
- Make React/CKEditor demo through the net.