### PR TITLE
[CKEditor4] click on source the second time breaks mathtype

### DIFF
--- a/packages/mathtype-ckeditor4/package-lock.json
+++ b/packages/mathtype-ckeditor4/package-lock.json
@@ -2112,24 +2112,6 @@
 				"@xtuc/long": "4.2.2"
 			}
 		},
-		"@wiris/mathtype-html-integration-devkit": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@wiris/mathtype-html-integration-devkit/-/mathtype-html-integration-devkit-1.4.1.tgz",
-			"integrity": "sha512-upUae4Q28Xno8KCUT2ybm/n/lNJz/Dr50awys/5dVRZH+TEUFtJpBHSdG0zUq2puY8vIgEf3VnYKp7tVD1L/wg==",
-			"dev": true,
-			"requires": {
-				"jest-css-modules-transform": "^4.0.1",
-				"uuid": "^8.1.0"
-			},
-			"dependencies": {
-				"uuid": {
-					"version": "8.3.0",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-					"integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
-					"dev": true
-				}
-			}
-		},
 		"@xtuc/ieee754": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -6284,51 +6266,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"jest-css-modules-transform": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/jest-css-modules-transform/-/jest-css-modules-transform-4.0.1.tgz",
-			"integrity": "sha512-V5MmT3ylrUamYNLWigAO7bVhD4A/Q2dvaD+ZzO1H/rmBHZvlIu9sXk379siAVJ4p7iBsHWoAq2cAy8vjXsKkRQ==",
-			"dev": true,
-			"requires": {
-				"camelcase": "^6.0.0",
-				"postcss": "^7.0.30",
-				"postcss-nested": "^4.2.1"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
-					"dev": true
-				},
-				"postcss": {
-					"version": "7.0.32",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-					"integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
-			}
-		},
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8012,61 +7949,6 @@
 			"requires": {
 				"icss-replace-symbols": "^1.1.0",
 				"postcss": "^6.0.1"
-			}
-		},
-		"postcss-nested": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.3.tgz",
-			"integrity": "sha512-rOv0W1HquRCamWy2kFl3QazJMMe1ku6rCFoAAH+9AcxdbpDeBr6k968MLWuLjvjMcGEip01ak09hKOEgpK9hvw==",
-			"dev": true,
-			"requires": {
-				"postcss": "^7.0.32",
-				"postcss-selector-parser": "^6.0.2"
-			},
-			"dependencies": {
-				"cssesc": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-					"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-					"dev": true
-				},
-				"postcss": {
-					"version": "7.0.32",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-					"integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.2",
-						"source-map": "^0.6.1",
-						"supports-color": "^6.1.0"
-					}
-				},
-				"postcss-selector-parser": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
-					"integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
-					"dev": true,
-					"requires": {
-						"cssesc": "^3.0.0",
-						"indexes-of": "^1.0.1",
-						"uniq": "^1.0.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "6.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^3.0.0"
-					}
-				}
 			}
 		},
 		"postcss-normalize-charset": {

--- a/packages/mathtype-ckeditor4/plugin.src.js
+++ b/packages/mathtype-ckeditor4/plugin.src.js
@@ -190,6 +190,8 @@ export class CKEditor4Integration extends IntegrationModel {
             if (dataContainer) {
                 newElement = document.getElementById(dataContainer + '_contents');
                 _wrs_int_divIframe = true;
+                // The events have to be added again
+                newElement.wirisActive = false;
             }
         }
 


### PR DESCRIPTION
### **Description**
This pull request fixes issue #114, which when having the source button with mathtype, it breaks the second time the button is cliked.

### **How to reproduce**

1. open https://ckeditor.com/docs/ckeditor4/latest/examples/mathtype.html
2. click on source button, to show code view
3. click on source again, to show WYSIWYG view.
4. click on source button, to show code view
5. click on source again, to show WYSIWYG view.

Expected: show WYSIWYG view and able to launch mathtype.
Actual: script error.

For more details see #114 .

The problem was solved in the mathtype from CKEditor 4 plugin,
that this did not take into account the source feature.
