### PR TITLE
Copy for dataMd5 in Parser.createShowImageSrc is wrong

### DIFF
--- a/packages/mathtype-html-integration-devkit/src/parser.js
+++ b/packages/mathtype-html-integration-devkit/src/parser.js
@@ -320,8 +320,7 @@ export default class Parser {
   static createShowImageSrc(data, language) {
     const dataMd5 = [];
     const renderParams = ['mml', 'color', 'centerbaseline', 'zoom', 'dpi', 'fontSize', 'fontFamily', 'defaultStretchy', 'backgroundColor', 'format'];
-    renderParams.forEach((key) => {
-      const param = renderParams[key];
+    renderParams.forEach((param) => {
       if (typeof data[param] !== 'undefined') {
         dataMd5[param] = data[param];
       }

--- a/packages/mathtype-html-integration-devkit/src/parser.js
+++ b/packages/mathtype-html-integration-devkit/src/parser.js
@@ -318,7 +318,7 @@ export default class Parser {
    * @returns {Object} JSON object containing showimage response.
    */
   static createShowImageSrc(data, language) {
-    const dataMd5 = [];
+    const dataMd5 = {};
     const renderParams = ['mml', 'color', 'centerbaseline', 'zoom', 'dpi', 'fontSize', 'fontFamily', 'defaultStretchy', 'backgroundColor', 'format'];
     renderParams.forEach((param) => {
       if (typeof data[param] !== 'undefined') {

--- a/packages/mathtype-html-integration-devkit/src/parser.js
+++ b/packages/mathtype-html-integration-devkit/src/parser.js
@@ -318,7 +318,7 @@ export default class Parser {
    * @returns {Object} JSON object containing showimage response.
    */
   static createShowImageSrc(data, language) {
-    const dataMd5 = {};
+    let dataMd5 = {};
     const renderParams = ['mml', 'color', 'centerbaseline', 'zoom', 'dpi', 'fontSize', 'fontFamily', 'defaultStretchy', 'backgroundColor', 'format'];
     renderParams.forEach((param) => {
       if (typeof data[param] !== 'undefined') {


### PR DESCRIPTION
The problem is that the dataMd5 always returns [] so the function does not assign the properties to the formula.

It has to be checked that the issue is solved and the formulas are still correctly rendered and have assigned the properties correctly. It can be checked by debugging the code running a Froala demo, for example, in a development mode.

This pull request solves the github issue https://github.com/wiris/html-integrations/issues/19.

