### PR TITLE
Use GET request for configurationjs

### DIFF
--- a/packages/mathtype-html-integration-devkit/src/core.src.js
+++ b/packages/mathtype-html-integration-devkit/src/core.src.js
@@ -255,7 +255,7 @@ export default class Core {
   init() {
     if (!Core.initialized) {
       const serviceProviderListener = Listeners.newListener('onInit', () => {
-        const jsConfiguration = ServiceProvider.getService('configurationjs', '', 'get');
+        const jsConfiguration = ServiceProvider.getService('configurationjs', '', true);
         const jsonConfiguration = JSON.parse(jsConfiguration);
         Configuration.addConfiguration(jsonConfiguration);
         // Adding JavaScript (not backend) configuration variables.

--- a/packages/mathtype-html-integration-devkit/src/test.js
+++ b/packages/mathtype-html-integration-devkit/src/test.js
@@ -10,7 +10,7 @@ export default class Test {
   static testServices() {
     let data;
     console.log('Testing configuration service...');
-    console.log(ServiceProvider.getService('configurationjs', '', 'get'));
+    console.log(ServiceProvider.getService('configurationjs', '', true));
     console.log('Testing showimage service...');
     data = [];
     data.mml = '<math xmlns="http://www.w3.org/1998/Math/MathML"><msup><mi>x</mi><mn>2</mn></msup></math>';
@@ -18,7 +18,7 @@ export default class Test {
     console.log('Testing createimage service...');
     data = [];
     data.mml = '<math xmlns="http://www.w3.org/1998/Math/MathML"><msup><mi>x</mi><mn>2</mn></msup></math>';
-    console.log(ServiceProvider.getService('createimage', data, 'post'));
+    console.log(ServiceProvider.getService('createimage', data));
     console.log('Testing MathML2Latex service...');
     data = [];
     data.service = 'mathml2latex';


### PR DESCRIPTION
The third argument in `getService` must be a Boolean value and must be `true` to send a GET request:

https://github.com/wiris/html-integrations/blob/fa065dabaf3487b13ee00d67d4364c316b19dcb7/packages/mathtype-html-integration-devkit/src/serviceprovider.js#L200-L217