### PR TITLE
Solve CK5+windows+build-dev issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Mono-repository for the [MathType](http://www.wiris.com/en/mathtype) Web plugins
 - [Examples for developers](#examples-for-developers)
 - [More information](#more-information)
 - [Privacy policy](#privacy-policy)
-- [Contact information](#contact-information)
+- [Technical support](#technical-support)
 - [License](#license)
 
 ## Requirements
@@ -312,9 +312,9 @@ the ['demos/'](./demos/) folder on this project.
 
 Refer to the [README](demos/README.md) file for more information.
 
-## Contact information
+### Technical Support
 
-support@wiris.com
+If you have questions or need help integrating MathType, please contact us (support@wiris.com) instead of opening an issue.
 
 
 ## Privacy policy
@@ -323,4 +323,4 @@ The [MathType Privacy Policy](http://www.wiris.com/mathtype/privacy-policy) cove
 
 ## License
 
-Copyright © 2010-2020 [WIRIS](http://www.wiris.com). Released under the [MIT License](LICENSE).
+Copyright © 2010-2021 [WIRIS](http://www.wiris.com). Released under the [MIT License](LICENSE).

--- a/demos/README.md
+++ b/demos/README.md
@@ -13,8 +13,8 @@
     - [How to run a demo with the local package](#how-to-run-a-demo-with-the-local-package)
     - [Linting files](#linting-files)
 - [Testing](#testing)
-- [Updates](#updates)
-- [Contact information](#contact-information)
+- [Troubleshooting](#troubleshooting)
+- [Technical support](#technical-support)
 - [License](#license)
 - [Privacy Policity](#privacy-policity)
 
@@ -118,8 +118,6 @@ html-integrations/demos/angular/ckeditor5$ npm run build-dev
 
 You can find a list of which technologies and which frameworks you can work with on this project in the [Supported editors & technologies](#supported-editors-&-technologies) section.
 
->There is a special case, with the html5+CKEditor5 demo, where the command `npm run build-dev` doesn't work in Windows. For this case, there's a special command to be used: `npm run build-dev-windows`.
-
 ### Linting files
 
 For more detailed information, take a look at this same section found in the README at the root of the project.
@@ -170,17 +168,19 @@ This command executes all the tests of the desired demo. If you want to run the 
 
 Remember to close the demo so you can free the used port when you are done with the tests.
 
-## Updates
+## Troubleshooting
 
-- :tada: Examples for developers for ReactJS and Angular are now available.
+### 01. Build command not working on Windows for the HTML5+CKEditor5
 
-## Contact information
+On windows, run the `npm run build-dev-windows` instead of `npm run build-dev`.
 
-support@wiris.com
+### Technical Support
+
+If you have questions or need help integrating MathType, please contact us (support@wiris.com) instead of opening an issue.
 
 ## License
 
-Copyright © 2010-2020 [WIRIS](http://www.wiris.com). Released under the [MIT License](../LICENSE).
+Copyright © 2010-2021 [WIRIS](http://www.wiris.com). Released under the [MIT License](../LICENSE).
 
 ## Privacy policy
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -118,6 +118,8 @@ html-integrations/demos/angular/ckeditor5$ npm run build-dev
 
 You can find a list of which technologies and which frameworks you can work with on this project in the [Supported editors & technologies](#supported-editors-&-technologies) section.
 
+>There is a special case, with the html5+CKEditor5 demo, where the command `npm run build-dev` doesn't work in Windows. For this case, there's a special command to be used: `npm run build-dev-windows`.
+
 ### Linting files
 
 For more detailed information, take a look at this same section found in the README at the root of the project.

--- a/demos/html5/ckeditor5/package.json
+++ b/demos/html5/ckeditor5/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest",
     "compile-package": "",
+    "build-dev-windows": "lerna bootstrap && cd ../../../packages/mathtype-ckeditor5/ && npm run compile -- npm --dev && cd ../../ && node scripts/installCK5Windows.js && cd demos/html5/ckeditor5/ && webpack-dev-server -d --open",
     "build-dev": " lerna bootstrap && cd ../../../packages/mathtype-ckeditor5/ && npm run compile -- npm --dev && filename=$( npm pack --quiet ) && cd ../../demos/html5/ckeditor5 && npm install ../../../packages/mathtype-ckeditor5/$filename && webpack-dev-server -d --open",
     "start": "npm uninstall --save @wiris/mathtype-ckeditor5 && npm install --save @wiris/mathtype-ckeditor5 && webpack-dev-server --open",
     "serve": "npm uninstall --save @wiris/mathtype-ckeditor5 && npm install --save @wiris/mathtype-ckeditor5 && webpack-dev-server",

--- a/scripts/installCK5windows.js
+++ b/scripts/installCK5windows.js
@@ -1,44 +1,43 @@
 const { exec } = require('child_process');
 
 const pack = () => new Promise((resolve, reject) => {
-    exec(`cd packages/mathtype-ckeditor5/ && npm pack --quiet `, (err, stdout, stderr) => {
-        if (err) {
-          reject(err);
-        }
-        console.log({ dout: stdout, derr: stderr })
-        resolve({ dout: stdout, derr: stderr });
-    });
+  exec('cd packages/mathtype-ckeditor5/ && npm pack --quiet ', (err, stdout, stderr) => {
+    if (err) {
+      reject(err);
+    }
+    console.log({ dout: stdout, derr: stderr });
+    resolve({ dout: stdout, derr: stderr });
+  });
 });
 
-const  install_mathtype = (path) => new Promise((resolve, reject) => {
-    exec(`cd demos/html5/ckeditor5 && npm install ../../../packages/mathtype-ckeditor5/${path}`, (err, stdout, stderr) => {
-        if (err) {
-          reject(err);
-        }
-        console.log({ dout: stdout, derr: stderr })
-        resolve({ dout: stdout, derr: stderr });
-    });
+const install_mathtype = (path) => new Promise((resolve, reject) => {
+  exec(`cd demos/html5/ckeditor5 && npm install ../../../packages/mathtype-ckeditor5/${path}`, (err, stdout, stderr) => {
+    if (err) {
+      reject(err);
+    }
+    console.log({ dout: stdout, derr: stderr });
+    resolve({ dout: stdout, derr: stderr });
+  });
 });
 
 const sequenceExecution = () => Promise.resolve(
-    pack().then((packOut) => {
-      install_mathtype(packOut.dout);
-    }),
-  );
+  pack().then((packOut) => {
+    install_mathtype(packOut.dout);
+  }),
+);
 
 // This file is being executed as a script.
 if (!module.parent) {
-    // Process args
-    const args = process.argv.slice(2);
-  
-    // Log a warning if there are more than 0 arguments
-    if (args.length > 0) {
-      emitWarning('No parameters needed, all the additional parameters will be ignored.');
-    }
-  
-    // Execute all the tests and resolve when finished
-    sequenceExecution();
-  } else { // This file is being imported as a module.
-    module.exports = sequenceExecution;
+  // Process args
+  const args = process.argv.slice(2);
+
+  // Log a warning if there are more than 0 arguments
+  if (args.length > 0) {
+    emitWarning('No parameters needed, all the additional parameters will be ignored.');
   }
-  
+
+  // Execute all the tests and resolve when finished
+  sequenceExecution();
+} else { // This file is being imported as a module.
+  module.exports = sequenceExecution;
+}

--- a/scripts/installCK5windows.js
+++ b/scripts/installCK5windows.js
@@ -1,0 +1,44 @@
+const { exec } = require('child_process');
+
+const pack = () => new Promise((resolve, reject) => {
+    exec(`cd packages/mathtype-ckeditor5/ && npm pack --quiet `, (err, stdout, stderr) => {
+        if (err) {
+          reject(err);
+        }
+        console.log({ dout: stdout, derr: stderr })
+        resolve({ dout: stdout, derr: stderr });
+    });
+});
+
+const  install_mathtype = (path) => new Promise((resolve, reject) => {
+    exec(`cd demos/html5/ckeditor5 && npm install ../../../packages/mathtype-ckeditor5/${path}`, (err, stdout, stderr) => {
+        if (err) {
+          reject(err);
+        }
+        console.log({ dout: stdout, derr: stderr })
+        resolve({ dout: stdout, derr: stderr });
+    });
+});
+
+const sequenceExecution = () => Promise.resolve(
+    pack().then((packOut) => {
+      install_mathtype(packOut.dout);
+    }),
+  );
+
+// This file is being executed as a script.
+if (!module.parent) {
+    // Process args
+    const args = process.argv.slice(2);
+  
+    // Log a warning if there are more than 0 arguments
+    if (args.length > 0) {
+      emitWarning('No parameters needed, all the additional parameters will be ignored.');
+    }
+  
+    // Execute all the tests and resolve when finished
+    sequenceExecution();
+  } else { // This file is being imported as a module.
+    module.exports = sequenceExecution;
+  }
+  

--- a/scripts/installCK5windows.js
+++ b/scripts/installCK5windows.js
@@ -1,20 +1,23 @@
 const { exec } = require('child_process');
+const { emitWarning } = require('process');
 
 const pack = () => new Promise((resolve, reject) => {
   exec('cd packages/mathtype-ckeditor5/ && npm pack --quiet ', (err, stdout, stderr) => {
     if (err) {
       reject(err);
     }
+    // eslint-disable-next-line no-console
     console.log({ dout: stdout, derr: stderr });
     resolve({ dout: stdout, derr: stderr });
   });
 });
 
-const install_mathtype = (path) => new Promise((resolve, reject) => {
+const installMathtype = (path) => new Promise((resolve, reject) => {
   exec(`cd demos/html5/ckeditor5 && npm install ../../../packages/mathtype-ckeditor5/${path}`, (err, stdout, stderr) => {
     if (err) {
       reject(err);
     }
+    // eslint-disable-next-line no-console
     console.log({ dout: stdout, derr: stderr });
     resolve({ dout: stdout, derr: stderr });
   });
@@ -22,7 +25,7 @@ const install_mathtype = (path) => new Promise((resolve, reject) => {
 
 const sequenceExecution = () => Promise.resolve(
   pack().then((packOut) => {
-    install_mathtype(packOut.dout);
+    installMathtype(packOut.dout);
   }),
 );
 


### PR DESCRIPTION
Solved by adding a script in the package.json CK5 file
that can be executed in all the SO but it's slower than
the regular one.

Issue reproducable just in the CKEditor5 + html5 demo with the npm run build-dev command.
Now, on windows, instead of using npm run build-dev, it has to be used npm run build-dev-windows.
It has to be tested that this command works as expected and that the script created for that is correct.

Issue found by QA team.