### PR TITLE
KB-10021: Use GET request for configurationjs

### DIFF
--- a/packages/mathtype-html-integration-devkit/README.md
+++ b/packages/mathtype-html-integration-devkit/README.md
@@ -1,7 +1,4 @@
-MathType Web Integration JavaScript SDK
-==========
-## Master Build status
-![Build status](https://api.travis-ci.org/wiris/mathtype-integration-js-dev.svg?branch=master)
+# MathType Web Integration JavaScript SDK
 
 ## Install instructions
 
@@ -17,6 +14,18 @@ Compile:
 $ npm run build-dev
 ```
 
+Lint:
+
+```bash
+$ npm run lint
+```
+
+Test:
+
+```bash
+$ npm run test
+```
+
 ## Privacy policy
 
-The [MathType Privacy Policy](http://www.wiris.com/mathtype/privacy-policy) covers the data processing operations for the MathType users. It is an addendum of the company’s general Privacy Policy and the [general Privacy Policy](https://wiris.com/en/privacy-policy) still applies to MathType users.
+The [MathType Privacy Policy](https://www.wiris.com/en/mathtype-privacy-policy/) covers the data processing operations for the MathType users. It is an addendum of the company's general Privacy Policy and the [general Privacy Policy](https://www.wiris.com/en/privacy-policy) still applies to MathType users.

--- a/packages/mathtype-html-integration-devkit/package.json
+++ b/packages/mathtype-html-integration-devkit/package.json
@@ -16,12 +16,12 @@
     "wiris"
   ],
   "repository": "https://github.com/wiris/html-integrations/tree/stable/packages/mathtype-html-integration-devkit",
-  "homepage": "http://www.wiris.com/",
+  "homepage": "https://www.wiris.com/",
   "bugs": {
     "email": "support@wiris.com"
   },
   "license": "MIT",
-  "author": "WIRIS Team (http://www.wiris.com)",
+  "author": "WIRIS Team (https://www.wiris.com)",
   "main": "core.src.js",
   "scripts": {
     "build": "webpack --mode production",

--- a/packages/mathtype-html-integration-devkit/src/core.src.js
+++ b/packages/mathtype-html-integration-devkit/src/core.src.js
@@ -255,7 +255,7 @@ export default class Core {
   init() {
     if (!Core.initialized) {
       const serviceProviderListener = Listeners.newListener('onInit', () => {
-        const jsConfiguration = ServiceProvider.getService('configurationjs', '', 'get');
+        const jsConfiguration = ServiceProvider.getService('configurationjs', '', true);
         const jsonConfiguration = JSON.parse(jsConfiguration);
         Configuration.addConfiguration(jsonConfiguration);
         // Adding JavaScript (not backend) configuration variables.

--- a/packages/mathtype-html-integration-devkit/src/test.js
+++ b/packages/mathtype-html-integration-devkit/src/test.js
@@ -10,7 +10,7 @@ export default class Test {
   static testServices() {
     let data;
     console.log('Testing configuration service...');
-    console.log(ServiceProvider.getService('configurationjs', '', 'get'));
+    console.log(ServiceProvider.getService('configurationjs', '', true));
     console.log('Testing showimage service...');
     data = [];
     data.mml = '<math xmlns="http://www.w3.org/1998/Math/MathML"><msup><mi>x</mi><mn>2</mn></msup></math>';
@@ -18,7 +18,7 @@ export default class Test {
     console.log('Testing createimage service...');
     data = [];
     data.mml = '<math xmlns="http://www.w3.org/1998/Math/MathML"><msup><mi>x</mi><mn>2</mn></msup></math>';
-    console.log(ServiceProvider.getService('createimage', data, 'post'));
+    console.log(ServiceProvider.getService('createimage', data));
     console.log('Testing MathML2Latex service...');
     data = [];
     data.service = 'mathml2latex';


### PR DESCRIPTION
The third argument in `getService` must be a Boolean value and must be `true` to send a GET request:

https://github.com/wiris/html-integrations/blob/fa065dabaf3487b13ee00d67d4364c316b19dcb7/packages/mathtype-html-integration-devkit/src/serviceprovider.js#L200-L217

- Original author: @ilyasgaraev
- Pull request originak and closes #147