### PR TITLE
KB-10221: Formulas can be resized in TinyMCE 4 and 5

### DIFF
--- a/packages/mathtype-html-integration-devkit/src/util.js
+++ b/packages/mathtype-html-integration-devkit/src/util.js
@@ -85,7 +85,11 @@ export default class Util {
     }
 
     if (mouseupHandler) {
-      Util.addEvent(eventTarget, 'mouseup', (event) => {
+      // Chrome doesn't trigger this event for eventTarget if we release the mouse button
+      // while the mouse is outside the editor text field.
+      // This is a workaround: we trigger the event independently of where the mouse
+      // is when we release its button.
+      Util.addEvent(document, 'mouseup', (event) => {
         const realEvent = (event) || window.event;
         const element = realEvent.srcElement ? realEvent.srcElement : realEvent.target;
         mouseupHandler(element, realEvent);

--- a/packages/mathtype-tinymce4/package.json
+++ b/packages/mathtype-tinymce4/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    "@wiris/mathtype-html-integration-devkit": "1.4.4",
+    "@wiris/mathtype-html-integration-devkit": "^1.4.4",
     "babel-loader": "^8.0.2",
     "css-loader": "^1.0.0",
     "esdoc": "^1.1.0",

--- a/packages/mathtype-tinymce5/package.json
+++ b/packages/mathtype-tinymce5/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    "@wiris/mathtype-html-integration-devkit": "1.4.4",
+    "@wiris/mathtype-html-integration-devkit": "^1.4.4",
     "babel-loader": "^8.0.2",
     "css-loader": "^1.0.0",
     "esdoc": "^1.1.0",


### PR DESCRIPTION
This pull request fixes KB-10221, which states that formulas can be resized to be bigger in TinyMCE 4 and 5.

## Context

When resizing a formula in TinyMCE, if the mouse is dragged outside of the text editor, and the mouse button released, then the formula stays resized until the editor is clicked again. This does NOT affect the output of the editor, i.e. if we click "Update" in one of the demos, the rendered formula presents the correct sized. This is just a visual bug.

## Why this happens

The bug is caused by the fact that some browsers (Chrome and Safari for instance) do not trigger the mouseup event for the HTML element of the TinyMCE editor if the mouse is *not* on the editor when the mouse button is released. [According to MDN](https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseup_event), this is the expected behavior, so a solution should be provided considering this the correct browser behavior.

## Proposed solution

The proposed solution, included in this PR, consist of elevating the event bearer to be the whole `document`, instead of just the editor HTML element. This is a very coarse solution that might affect performance, but I couldn't think of any other solution that wasn't as inefficient or too complex.