### PR TITLE
Changing from MT to CT while editing a formula causes a loss of information

### DIFF
--- a/packages/mathtype-froala/wiris.src.js
+++ b/packages/mathtype-froala/wiris.src.js
@@ -149,6 +149,10 @@ export class FroalaIntegration extends IntegrationModel {
      * @param {HTMLElement} element - DOM object target.
      */
     doubleClickHandler(element) {
+        // Save a image to a temporal register to detect when we want to
+        // change between MT and CT.
+        // Will be deleted when inserting the formula or canceling it
+        this.core.editionProperties.temporalImage = element;
         this.simulateClick(document);
         super.doubleClickHandler(element);
     }
@@ -161,8 +165,14 @@ export class FroalaIntegration extends IntegrationModel {
 
     /**@inheritdoc */
     openNewFormulaEditor() {
-        this.simulateClick(document);
-        super.openNewFormulaEditor();
+        // If it exists a temporal image saved, open the existing formula editor
+        const image = this.core.editionProperties.temporalImage;
+        if (image !== null && typeof image !== 'undefined' && image.classList.contains( WirisPlugin.Configuration.get( 'imageClassName' ) ) ) {
+            this.openExistingFormulaEditor(); 
+        } else {
+            this.simulateClick(document);
+            super.openNewFormulaEditor();
+        }
     }
 
     /**
@@ -199,6 +209,8 @@ export class FroalaIntegration extends IntegrationModel {
         // has to be updated.
         this.editorObject.events.trigger('contentChanged');
         const obj = super.insertFormula(focusElement, windowTarget, mathml, wirisProperties);
+        // Delete temporal image when inserting a formula
+        this.core.editionProperties.temporalImage = null; 
         this.editorObject.placeholder.refresh();
         return obj;
     }

--- a/packages/mathtype-froala3/wiris.src.js
+++ b/packages/mathtype-froala3/wiris.src.js
@@ -149,6 +149,10 @@ export class FroalaIntegration extends IntegrationModel {
      * @param {HTMLElement} element - DOM object target.
      */
     doubleClickHandler(element) {
+        // Save a image to a temporal register to detect when we want to
+        // change between MT and CT.
+        // Will be deleted when inserting the formula or canceling it
+        this.core.editionProperties.temporalImage = element;
         this.simulateClick(document);
         super.doubleClickHandler(element);
     }
@@ -161,8 +165,14 @@ export class FroalaIntegration extends IntegrationModel {
 
     /**@inheritdoc */
     openNewFormulaEditor() {
-        this.simulateClick(document);
-        super.openNewFormulaEditor();
+        // If it exists a temporal image saved, open the existing formula editor
+        const image = this.core.editionProperties.temporalImage;
+        if (image !== null && typeof image !== 'undefined' && image.classList.contains( WirisPlugin.Configuration.get( 'imageClassName' ) ) ) {
+            this.openExistingFormulaEditor(); 
+        } else {
+            this.simulateClick(document);
+            super.openNewFormulaEditor();
+        }
     }
 
     /**
@@ -199,6 +209,8 @@ export class FroalaIntegration extends IntegrationModel {
         // has to be updated.
         this.editorObject.events.trigger('contentChanged');
         const obj = super.insertFormula(focusElement, windowTarget, mathml, wirisProperties);
+        // Delete temporal image when inserting a formula
+        this.core.editionProperties.temporalImage = null;
         this.editorObject.placeholder.refresh();
         return obj;
     }

--- a/packages/mathtype-generic/wirisplugin-generic.src.js
+++ b/packages/mathtype-generic/wirisplugin-generic.src.js
@@ -140,4 +140,32 @@ export default class GenericIntegration extends IntegrationModel {
             }
         }
     }
+
+        /**
+     * @inheritdoc
+     * @param {HTMLElement} element - DOM object target.
+     */
+    doubleClickHandler(element) {
+        this.core.editionProperties.temporalImage = element;
+        super.doubleClickHandler(element);
+    }
+
+    /**@inheritdoc */
+    openNewFormulaEditor() {
+        // If it exists a temporal image saved, open the existing formula editor
+        const image = this.core.editionProperties.temporalImage;
+        if (image !== null && typeof image !== 'undefined') {
+            super.openExistingFormulaEditor(); 
+        } else {
+            super.openNewFormulaEditor();
+        }
+    }
+
+    insertFormula(focusElement, windowTarget, mathml, wirisProperties) {
+        const obj = super.insertFormula(focusElement, windowTarget, mathml, wirisProperties);
+
+        // Delete temporal image when inserting a formula
+        this.core.editionProperties.temporalImage = null;
+        return obj;
+      }
 }

--- a/packages/mathtype-html-integration-devkit/src/integrationmodel.js
+++ b/packages/mathtype-html-integration-devkit/src/integrationmodel.js
@@ -232,7 +232,7 @@ export default class IntegrationModel {
 
   /**
    * Returns integration model plugin version
-   * @param {string} - Plugin version 
+   * @param {string} - Plugin version
    */
   getVersion() {
     return this.version;
@@ -513,6 +513,13 @@ export default class IntegrationModel {
    */
   // eslint-disable-next-line class-methods-use-this, no-unused-vars
   getSelectedItem(target, isIframe) {}
+
+  static setTemporalImageToNull() {
+    // eslint-disable-next-line no-undef
+    if (WirisPlugin.currentInstance) {
+      WirisPlugin.currentInstance.core.editionProperties.temporalImage = null; // eslint-disable-line
+    }
+  }
 }
 
 // To know if the integration that extends this class implements

--- a/packages/mathtype-html-integration-devkit/src/modal.js
+++ b/packages/mathtype-html-integration-devkit/src/modal.js
@@ -5,6 +5,7 @@ import Listeners from './listeners';
 import StringManager from './stringmanager';
 import ContentManager from './contentmanager';
 import TelemetryService from './telemetry';
+import IntegrationModel from './integrationmodel';
 
 import closeIcon from '!!raw-loader!../styles/icons/general/close_icon.svg';  //eslint-disable-line
 import closeHoverIcon from '!!raw-loader!../styles/icons/hover/close_icon_h.svg';  //eslint-disable-line
@@ -543,6 +544,9 @@ export default class ModalDialog {
    * Closes modal window and restores viewport header.
    */
   close() {
+    // Set temporal image to null to avoid
+    // opening a existing formula editor when trying to open a new one
+    IntegrationModel.setTemporalImageToNull();
     this.removeClass('wrs_maximized');
     this.removeClass('wrs_minimized');
     this.removeClass('wrs_stack');


### PR DESCRIPTION
This pull request fixes KB-10222, which states that there's a loss of information when changing from MT to CT and from CT to MT when editing an existing formula in Froala2 and 3, and Generic editors.

### Context
A user opens an existing formula to start editing it and changes the editor from MT to CT, this action generates the loss of the formula the user was working on in the editor

### Why this happens
This is because the froala editor and the generic editor does not keep the existing formula to edit selected while we are in the MT or CT editor.

### Proposed solution
The proposed solution, included in this PR, consist in assign to a temporal register on the current instance, the image of the existing formula that is going to be opened to be edited. Then, every time a new formula is going to be opened, it has to be checked if exists or not the temporal image, in the case that it exists, it's going to be called the openExistingFormula method, if not, the openNewFormula method will be launched. The register is cleared every time the cancer or the insert button are clicked.