### PR TITLE
Solve the sintax error with the currentInstance CKEditor5

### DIFF
--- a/packages/mathtype-ckeditor5/src/plugin.js
+++ b/packages/mathtype-ckeditor5/src/plugin.js
@@ -434,7 +434,7 @@ export default class MathType extends Plugin {
             Configuration: Configuration,
             Listeners: Listeners,
             IntegrationModel: IntegrationModel,
-            CurrentInstance: currentInstance,
+            currentInstance: currentInstance,
             Latex: Latex
         }
 


### PR DESCRIPTION
This pull request fixes KB-10332, which states that there's a sintax mistake with the currentInstance component in the CKEditor5.

### Context
Although the current instance component is not really used in the CKEditor5 plugin, it exists and sould be consistent with the current instances of the other wiris plugins. In this case there's a sintax error: it actually is "CurrentInstance" when it  should be "currentInstance".

### Proposed solution
Change the syntax error in all the places where the bad currentInstance of the CKEditor5 plugin appears.

This fix should not break anything, but just to be cautious you can check that the CK5 demo works propertly with the change