### PR TITLE
Add carret to html-integration-devkit plugins dependency

### DIFF
--- a/packages/mathtype-ckeditor4/package.json
+++ b/packages/mathtype-ckeditor4/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    "@wiris/mathtype-html-integration-devkit": "1.4.4",
+    "@wiris/mathtype-html-integration-devkit": "^1.4.4",
     "babel-loader": "^8.0.2",
     "css-loader": "^1.0.0",
     "esdoc": "^1.1.0",

--- a/packages/mathtype-ckeditor5/package.json
+++ b/packages/mathtype-ckeditor5/package.json
@@ -40,7 +40,7 @@
     "@ckeditor/ckeditor5-engine": ">=23.0.0",
     "@ckeditor/ckeditor5-ui": ">=23.0.0",
     "@ckeditor/ckeditor5-widget": ">=23.0.0",
-    "@wiris/mathtype-html-integration-devkit": "1.4.4"
+    "@wiris/mathtype-html-integration-devkit": "^1.4.4"
   },
   "devDependencies": {
     "babel-jest": "^26.1.0",

--- a/packages/mathtype-froala/package.json
+++ b/packages/mathtype-froala/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    "@wiris/mathtype-html-integration-devkit": "1.4.4",
+    "@wiris/mathtype-html-integration-devkit": "^1.4.4",
     "babel-loader": "^8.0.2",
     "css-loader": "^1.0.0",
     "esdoc": "^1.1.0",

--- a/packages/mathtype-froala3/package.json
+++ b/packages/mathtype-froala3/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    "@wiris/mathtype-html-integration-devkit": "1.4.4",
+    "@wiris/mathtype-html-integration-devkit": "^1.4.4",
     "babel-loader": "^8.0.2",
     "css-loader": "^1.0.0",
     "esdoc": "^1.1.0",

--- a/packages/mathtype-generic/package.json
+++ b/packages/mathtype-generic/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    "@wiris/mathtype-html-integration-devkit": "1.4.4",
+    "@wiris/mathtype-html-integration-devkit": "^1.4.4",
     "babel-loader": "^8.0.2",
     "css-loader": "^1.0.0",
     "mini-css-extract-plugin": "^0.4.2",


### PR DESCRIPTION
This pull request fixes KB-10335, which states that there's a missing carret in the html-integration-devkit dependency on the mathtype plugins to let lerna work the expected way.

### Context
In all the packages of the plugins of mathtype, there's a dependency, html-integration-devkit that sould have a caret (^) in the beggining. This missing caret makes the lerna arquitecture not working when trying to link the dependency to the local package.

### Proposed solution
Add the missing carret on the html-integration-devkit dependency on all the mathtype plugins (except tinymce4 and 5, it is in another PR)