### PR TITLE
Solve Latex rendering issues

### DIFF
--- a/demos/html5/generic/src/app.js
+++ b/demos/html5/generic/src/app.js
@@ -1,5 +1,5 @@
 // Load scripts.
-import { wrsInitEditor } from '@wiris/mathtype-generic/wirisplugin-generic.src';
+import { wrsInitEditor, wrsGetTargetHtml } from '@wiris/mathtype-generic/wirisplugin-generic.src';
 import '@wiris/mathtype-generic/wirisplugin-generic';
 import * as Generic from '../../../../resources/demos/common';
 
@@ -38,5 +38,6 @@ document.onreadystatechange = function () {
 // Add listener on click button to launch updateContent function.
 document.getElementById('btn_update').addEventListener('click', (e) => {
   e.preventDefault();
-  Generic.updateContent(WirisPlugin.Parser.initParse(editableDiv.innerHTML), 'transform_content');      //eslint-disable-line
+  const innerHTMLEditor = wrsGetTargetHtml(editableDiv);
+  Generic.updateContent(innerHTMLEditor, 'transform_content');      //eslint-disable-line
 });

--- a/packages/mathtype-generic/wirisplugin-generic.src.js
+++ b/packages/mathtype-generic/wirisplugin-generic.src.js
@@ -39,6 +39,18 @@ export function wrsInitEditor(target,toolbar, mathtypeProperties) {
 }
 
 /**
+ * Gets the html content of the Generic editor and parses it to transform the latex
+ * $$$$ into a mathml image
+ * @param {HTMLElement} target - DOM target, in this integration the editable iframe
+ * @returns {HTMLElement} The html content of the target parsed with the wiris funcions
+ */
+export function wrsGetTargetHtml(target) {
+    const html = target.innerHTML;
+    return Parser.endParse(html);
+ }
+ 
+
+/**
  * Backwards compatibility init method.
  */
 window.wrs_int_init = wrsInitEditor;


### PR DESCRIPTION
This pull request fixes KB-10710, which states that the latex formulas introduced as $$formula$$ are not rendered when clicking the update button in the Generic integration.

### Context
A user creates a formula using latex in the Generic editor, clicks the update button and it should be rendered as a mathml formula, but it stays as a plain text with the latex structure.

### Why this happens
This happens because latex formulas can not automatically be rendered. They need a intermedium process to render them as a mathml formula.

### Proposed solution
The proposed solution, included in this PR, consist in create a get function in the generic plugin that gets the inner html of the editable block area, parses it with a intermedium procces that renders the latex formulas, and returns it. This get function will be used in the update process.