### PR TITLE
Don't allow editing formulas in Froala 3 readonly mode

### DIFF
--- a/packages/mathtype-froala3/wiris.src.js
+++ b/packages/mathtype-froala3/wiris.src.js
@@ -149,6 +149,11 @@ export class FroalaIntegration extends IntegrationModel {
      * @param {HTMLElement} element - DOM object target.
      */
     doubleClickHandler(element) {
+        // If the editor is in readOnly mode, don't add the handler
+        if (this.editorObject.edit.isDisabled()) {
+            return;
+        }
+
         // Save a image to a temporal register to detect when we want to
         // change between MT and CT.
         // Will be deleted when inserting the formula or canceling it


### PR DESCRIPTION
This PR solves bug KB-9825.

## Description

Formulas shouldn't be able to be edited in Froala 3 readonly mode.

## Steps

1. Use Froala is in readonly mode, with some predefined text that contains a formula.

## Expected

Formulas cannot be edited.

## Actual

By double-clicking the formulas, they can still be edited.

## Notes

To test this, you can enable readonly mode in the demos by adding in `demos/html5/froala3/src/app.js` the following line:

```js
this.edit.off()
```

Inside the `initialized` method.