### PR TITLE
chore(package.json): send only 'plugin.min.js' to npm

### DIFF
--- a/packages/mathtype-tinymce5/package.json
+++ b/packages/mathtype-tinymce5/package.json
@@ -2,6 +2,9 @@
   "name": "@wiris/mathtype-tinymce5",
   "version": "7.26.0",
   "description": "MathType Web for TinyMCE5 editor",
+  "files": [
+      "plugin.min.js"
+  ],
   "keywords": [
     "chem",
     "chemistry",


### PR DESCRIPTION
Without specifying which files should be sent to npm, all files were being sent.  But the only needed file is `plugin.min.js`, since the `global.js` is referencing a package that is in devDependencies, not in dependencies.