### PR TITLE
KB-11600: Add 'import' support to linting strategy

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,9 +7,11 @@ module.exports = {
   },
   plugins: [
     'jest', // We use the plugin jest so we can lint test files
+    'import',
   ],
   extends: [
     'airbnb-base', // We extend our linting to follow the airbnb rules
+    'plugin:import/recommended',
   ],
   parser: 'babel-eslint', // Parser that'll help linting react demos
 
@@ -29,7 +31,9 @@ module.exports = {
     sourceType: 'module', // This project's code is in ECMAScript modules.
   },
   rules: {
-    // First 5 rules, specific for testing purposes
+    // Change 'no-unresolved' to warn to avoid raising errors on node_modules imports.
+    'import/no-unresolved': 'warn',
+    // First 5 rules, specific for testing purposes.
     'jest/no-disabled-tests': 'warn',
     'jest/no-focused-tests': 'error',
     'jest/no-identical-title': 'error',

--- a/docs/development/linting/README.md
+++ b/docs/development/linting/README.md
@@ -2,9 +2,7 @@
 
 <small>[MathType Web Integrations](../../../README.md) → [Documentation](../../README.md) → [Development guide](../README.md) → Linting</small>
 
-There are configuration files at the root of the project to help. They statically analyze and fix code errors in files with extensions .js, .css and .html. The analysis shows the error and where it is, then it can be fixed. The commands are:
-
-> Before running the lint commands, make sure that the dependenceis fo the folder/folders where you're trying to lint file/files are installed.
+We've implemented a complete lint strategy for the JavaScript, HTML and CSS files include on this project.
 
 ## Table of contents
 
@@ -14,13 +12,13 @@ There are configuration files at the root of the project to help. They staticall
 
 ## JavaScript files
 
-To check all the .js files of the project, run:
+To validate all the `.js` files of the project, run:
 
 ```sh
   $ npm run lint-js
 ```
 
-To check specific .js files or folders of the project, add the --route option to the previous commands:
+To validate specific `.js` files or folders of the project, add the `--route` option to the previous commands:
 
 ```sh
   $ npm run lint-js --route=path
@@ -32,13 +30,13 @@ To check specific .js files or folders of the project, add the --route option to
 
 ## CSS files
 
-To check all the .css files of the project, run:
+To validate all the `.css` files of the project, run:
 
 ```sh
     $ npm run lint-css
 ```
 
-To check specific .css files or folders of the project, add the --route option to the previous commands:
+To validate specific `.css` files or folders of the project, add the `--route` option to the previous commands:
 
 ```sh
   $ npm run lint-css --route=path
@@ -55,7 +53,7 @@ To check specific .css files or folders of the project, add the --route option t
     $ npm run lint-html
 ```
 
-To check specific .html files or folders of the project, add the --route option to the previous commands:
+To validate specific `.html` files or folders of the project, add the `--route` option to the previous commands:
 
 ```sh
   $ npm run lint-html --route=path

--- a/resources/demos/angular-imports.js
+++ b/resources/demos/angular-imports.js
@@ -1,4 +1,5 @@
 // Export generic functions.
+// eslint-disable-next-line import/extensions
 export * from './common.js';
 
 // Generate scripts.

--- a/resources/demos/imports.js
+++ b/resources/demos/imports.js
@@ -5,6 +5,7 @@ import './design.css';
 import * as htmlContent from './index.html';
 
 // Export generic functions.
+// eslint-disable-next-line import/extensions
 export * from './common.js';
 
 // Display html content.

--- a/resources/demos/react-imports.js
+++ b/resources/demos/react-imports.js
@@ -2,6 +2,7 @@
 import './design.css';
 
 // Export generic functions.
+// eslint-disable-next-line import/extensions
 export * from './common.js';
 
 // Generate scripts.


### PR DESCRIPTION
### Add 'import' support to linting strategy

The 'import' clausules were not included on our linting strategy.
This was causing that there were still a lot of uncontrolled Javascript errors in our codebase with exports and imports statements.

- The js linting configuration file has been updated to include the 'import' eslint module configuration.

- The export sentences on the common resources used by React and Angular demos have been commented.

- The import statements have been changed from 'error' to 'warn' to avoid stopping the build procedure.

#taskid: 11600