### PR TITLE
Add the 'repository' key on all editor packages and set dev-kit dependency version

### DIFF
--- a/packages/mathtype-ckeditor4/package.json
+++ b/packages/mathtype-ckeditor4/package.json
@@ -17,12 +17,13 @@
     "mathtype",
     "wiris"
   ],
-  "homepage": "http://www.wiris.com/",
+  "repository": "https://github.com/wiris/html-integrations/tree/stable/packages/mathtype-ckeditor4",
+  "homepage": "https://www.wiris.com/",
   "bugs": {
     "email": "support@wiris.com"
   },
   "license": "MIT",
-  "author": "WIRIS Team (http://www.wiris.com)",
+  "author": "WIRIS Team (https://www.wiris.com)",
   "main": "plugin.js",
   "scripts": {
     "build": "webpack --mode production",

--- a/packages/mathtype-ckeditor5/package.json
+++ b/packages/mathtype-ckeditor5/package.json
@@ -18,7 +18,7 @@
     "wiris"
   ],
   "repository": "https://github.com/wiris/html-integrations/tree/stable/packages/mathtype-ckeditor5",
-  "homepage": "http://www.wiris.com/",
+  "homepage": "https://www.wiris.com/",
   "bugs": {
     "email": "support@wiris.com"
   },
@@ -40,7 +40,7 @@
     "@ckeditor/ckeditor5-engine": ">=23.0.0",
     "@ckeditor/ckeditor5-ui": ">=23.0.0",
     "@ckeditor/ckeditor5-widget": ">=23.0.0",
-    "@wiris/mathtype-html-integration-devkit": "^1.5.0"
+    "@wiris/mathtype-html-integration-devkit": "^1.5.1"
   },
   "devDependencies": {
     "babel-jest": "^26.1.0",

--- a/packages/mathtype-froala/package.json
+++ b/packages/mathtype-froala/package.json
@@ -16,7 +16,8 @@
     "mathtype",
     "wiris"
   ],
-  "homepage": "http://www.wiris.com/",
+  "repository": "https://github.com/wiris/html-integrations/tree/stable/packages/mathtype-froala",
+  "homepage": "https://www.wiris.com/",
   "bugs": {
     "email": "support@wiris.com"
   },
@@ -31,7 +32,7 @@
     "prepack": "npm install && npm run build"
   },
   "dependencies": {
-    "@wiris/mathtype-html-integration-devkit": "1.5.1"
+    "@wiris/mathtype-html-integration-devkit": "^1.5.1"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",

--- a/packages/mathtype-froala3/package.json
+++ b/packages/mathtype-froala3/package.json
@@ -17,7 +17,8 @@
     "mathtype",
     "wiris"
   ],
-  "homepage": "http://www.wiris.com/",
+  "repository": "https://github.com/wiris/html-integrations/tree/stable/packages/mathtype-froala3",
+  "homepage": "https://www.wiris.com/",
   "bugs": {
     "email": "support@wiris.com"
   },
@@ -32,7 +33,7 @@
     "prepack": "npm install && npm run build"
   },
   "dependencies": {
-    "@wiris/mathtype-html-integration-devkit": "1.5.1"
+    "@wiris/mathtype-html-integration-devkit": "^1.5.1"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",

--- a/packages/mathtype-generic/package.json
+++ b/packages/mathtype-generic/package.json
@@ -15,7 +15,8 @@
     "mathtype",
     "wiris"
   ],
-  "homepage": "http://www.wiris.com/",
+  "repository": "https://github.com/wiris/html-integrations/tree/stable/packages/mathtype-generic",
+  "homepage": "https://www.wiris.com/",
   "bugs": {
     "email": "support@wiris.com"
   },
@@ -30,7 +31,7 @@
     "prepack": "npm install && npm run build"
   },
   "dependencies": {
-    "@wiris/mathtype-html-integration-devkit": "1.5.1"
+    "@wiris/mathtype-html-integration-devkit": "^1.5.1"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",
@@ -44,77 +45,5 @@
     "url-loader": "^4.1.1",
     "webpack": "^5.36.2",
     "webpack-cli": "^4.6.0"
-  },
-  "esdoc": {
-    "source": ".",
-    "destination": "./docs",
-    "includes": [
-      "\\.js$",
-      "/core/src"
-    ],
-    "excludes": [
-      "backwardslib.js",
-      "cas.js",
-      "core.js",
-      "display.js",
-      "generic_demo.js",
-      "global.js",
-      "jsvariables.js",
-      "md5.js",
-      "polyfills.js",
-      "node_modules",
-      "lang",
-      "integration/",
-      "docs",
-      "out",
-      "wirisplugin-generic.js",
-      "webpack.config.js"
-    ],
-    "plugins": [
-      {
-        "name": "esdoc-standard-plugin",
-        "option": {
-          "lint": {
-            "enable": true
-          },
-          "coverage": {
-            "enable": true
-          },
-          "accessor": {
-            "access": [
-              "public",
-              "protected",
-              "private"
-            ],
-            "autoPrivate": true
-          },
-          "undocumentIdentifier": {
-            "enable": true
-          },
-          "unexportedIdentifier": {
-            "enable": false
-          },
-          "typeInference": {
-            "enable": true
-          },
-          "brand": {
-            "title": "My Library",
-            "description": "this is awesome library",
-            "site": "http://my-library.org",
-            "author": "https://twitter.com/foo",
-            "image": "http://my-library.org/logo.png"
-          }
-        }
-      },
-      {
-        "name": "esdoc-inject-style-plugin",
-        "option": {
-          "enable": true,
-          "styles": [
-            "./src-doc/styles.css"
-          ]
-        }
-      }
-    ]
   }
 }

--- a/packages/mathtype-tinymce4/package.json
+++ b/packages/mathtype-tinymce4/package.json
@@ -17,7 +17,8 @@
     "tinymce4",
     "wiris"
   ],
-  "homepage": "http://www.wiris.com/",
+  "repository": "https://github.com/wiris/html-integrations/tree/stable/packages/mathtype-tinymce4",
+  "homepage": "https://www.wiris.com/",
   "bugs": {
     "email": "support@wiris.com"
   },
@@ -32,7 +33,7 @@
     "prepack": "npm install && npm run compile -- npm"
   },
   "dependencies": {
-    "@wiris/mathtype-html-integration-devkit": "^1.5.0"
+    "@wiris/mathtype-html-integration-devkit": "^1.5.1"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",

--- a/packages/mathtype-tinymce5/package.json
+++ b/packages/mathtype-tinymce5/package.json
@@ -17,7 +17,8 @@
     "tinymce5",
     "wiris"
   ],
-  "homepage": "http://www.wiris.com/",
+  "repository": "https://github.com/wiris/html-integrations/tree/stable/packages/mathtype-tinymce5",
+  "homepage": "https://www.wiris.com/",
   "bugs": {
     "email": "support@wiris.com"
   },
@@ -32,7 +33,7 @@
     "prepack": "npm install && npm run compile -- npm"
   },
   "dependencies": {
-    "@wiris/mathtype-html-integration-devkit": "^1.5.0"
+    "@wiris/mathtype-html-integration-devkit": "^1.5.1"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",


### PR DESCRIPTION
### Use '^' for mathtype-html-integration-devkit dependency version

`"@wiris/mathtype-html-integration-devkit": "^1.5.1"
`

### Add the 'repository' key on all editor packages 

The MathType published packages are not properly linked
to GitHub so it's not possible to manage the
third-party dependency graph.

Adding the 'repository' key on all editor packages should
fix this.

Also on this commit:

- Remove unused 'esdoc' settings on generic.
- Set https on homepage setting.