### PR TITLE
Focus is not coming back to TinyMCE when Cancel button is pressed on MathType editor

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -11,3 +11,4 @@ packages/mathtype-froala3/wiris.js
 packages/mathtype-froala/wiris.js
 packages/mathtype-ckeditor4/plugin.js
 packages/mathtype-tinymce/editor_plugin.src.js
+packages/mathtype-html-integration-devkit/doc/templates/**

--- a/packages/mathtype-html-integration-devkit/src/integrationmodel.js
+++ b/packages/mathtype-html-integration-devkit/src/integrationmodel.js
@@ -519,6 +519,17 @@ export default class IntegrationModel {
     if (WirisPlugin.currentInstance) {
       WirisPlugin.currentInstance.core.editionProperties.temporalImage = null; // eslint-disable-line
     }
+
+    // Make focus come back on the previous place it was when click cancel button
+    const currentInstance = WirisPlugin.currentInstance;
+    const editorSelection = currentInstance.getSelection();
+    editorSelection.removeAllRanges();
+
+    if (currentInstance.core.editionProperties.range) {
+      const { range } = currentInstance.core.editionProperties;
+      currentInstance.core.editionProperties.range = null;
+      editorSelection.addRange(range);
+    }
   }
 }
 

--- a/packages/mathtype-html-integration-devkit/src/modal.js
+++ b/packages/mathtype-html-integration-devkit/src/modal.js
@@ -279,6 +279,9 @@ export default class ModalDialog {
    * will be shown if hasChanges returns true.
    */
   cancelAction() {
+    // Set temporal image to null to avoid
+    // opening a existing formula editor when trying to open a new one
+    IntegrationModel.setTemporalImageToNull();
     if (typeof this.contentManager.hasChanges === 'undefined') {
       this.close();
     } else if (!this.contentManager.hasChanges()) {
@@ -543,9 +546,6 @@ export default class ModalDialog {
    * Closes modal window and restores viewport header.
    */
   close() {
-    // Set temporal image to null to avoid
-    // opening a existing formula editor when trying to open a new one
-    IntegrationModel.setTemporalImageToNull();
     this.removeClass('wrs_maximized');
     this.removeClass('wrs_minimized');
     this.removeClass('wrs_stack');


### PR DESCRIPTION
## Description

Focus is not coming back to any editor when user does not type anything in the MathType editor and clicks cancel button.

## Steps to reproduce

Open any demo
Insert or modify a formula
Click on cancel button or escape
The focus is lost

## How is it solved

The solution added on this PR uses the same logic applied on the insert button to gt back the focus.
It is added in a function that gets called every time the modal is closed by a cancel action on every editor.

---

Closes #133

[#taskid 6837](https://wiris.kanbanize.com/ctrl_board/2/cards/6837/details/)