### PR TITLE
Improve dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+
 version: 2
 updates:
 
@@ -15,15 +16,14 @@ updates:
           include: "scope" # It'll include all the reviews and changes proposal
     labels:
           - "type:dependencies"
-
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: "stable"
-    labels:
-          - "type:dependencies"
-    commit-message:
-          prefix: "st:npm prod"
-          prefix-development: "st:npm dev"
-          include: "scope"
+    ignore:
+      - dependency-name: "@ckeditor/ckeditor5-core"
+      - dependency-name: "@ckeditor/ckeditor5-engine"
+      - dependency-name: "@ckeditor/ckeditor5-widget"
+      - dependency-name: "@ckeditor/ckeditor5-ui"
+      - dependency-name: "@ckeditor/ckeditor5-alignment"
+      - dependency-name: "@ckeditor/ckeditor5-basic-styles"
+      - dependency-name: "@ckeditor/ckeditor5-editor-classic"
+      - dependency-name: "@ckeditor/ckeditor5-essentials"
+      - dependency-name: "@ckeditor/ckeditor5-paragraph"
+      - dependency-name: "@ckeditor/ckeditor5-theme-lark"


### PR DESCRIPTION
## **New Changes on the dependabot file**
Delete stable branch ecosystem
Add he ignore label to ignore CK5 dependencies

[#taskid 14140](https://wiris.kanbanize.com/ctrl_board/2/cards/14140/details/)
