### PR TITLE
Allowed unsafe "src" attribute on the <img> element to override CKEditor 5 filtering mechanism

### DIFF
--- a/packages/mathtype-ckeditor5/src/plugin.js
+++ b/packages/mathtype-ckeditor5/src/plugin.js
@@ -326,7 +326,9 @@ export default class MathType extends Plugin {
       /* Although we use the HtmlDataProcessor to obtain the attributes,
             we must create a new EmptyElement which is independent of the
             DataProcessor being used by this editor instance */
-      return viewWriter.createEmptyElement('img', imgElement.getAttributes());
+      return viewWriter.createEmptyElement('img', imgElement.getAttributes(), {
+        renderUnsafeAttributes: [ 'src' ]
+      } );
     }
 
     // Model -> Editing view


### PR DESCRIPTION
## Description

Hi, I'm a core developer of CKEditor 5 👋

Just wanted to let you know that in CKEditor 5 we're working on the unsafe attribute filtering in the editing layer. Currently, this feature is disabled ([behind a flag](https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_view_domconverter-DomConverter.html#member-experimentalRenderingMode)) but in the nearest future, it will be enabled by default.

We noticed that in order to comply with the new filtering mechanism, the MathType plugin has to allow the `src` attribute in the editing layer (considered unsafe because it contains `data:image/svg+xml...`).

Would you consider merging this change so your integration will smoothly align to the upcoming CKEditor 5 API?

Please let me know if something is unclear.  
Thanks!