### PR TITLE
Destroy events from CKEditor5Integration when CK5 is destroyed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Last release of this project is was 30th of September 2021.
   - Fix the `demo-html5-generic` dependencies.
   - Update third-party libraries to fix vulnerabilites.
   - Added missing 'www' on wiris.net documentation links.
+  - Destroy events from CKEditor5Integration when CK5 is destroyed.
 
 ## 7.27.2 - 2021-11-26
 

--- a/packages/mathtype-ckeditor5/src/plugin.js
+++ b/packages/mathtype-ckeditor5/src/plugin.js
@@ -59,6 +59,13 @@ export default class MathType extends Plugin {
   }
 
   /**
+   * Inherited from Plugin class: Executed when CKEditor5 is destroyed
+   */
+  destroy() { // eslint-disable-line class-methods-use-this
+    currentInstance.removeEvents();
+  }
+
+  /**
      * Create the MathType API Integration object
      * @returns {CKEditor5Integration} the integration object
      */

--- a/packages/mathtype-html-integration-devkit/src/integrationmodel.js
+++ b/packages/mathtype-html-integration-devkit/src/integrationmodel.js
@@ -388,6 +388,14 @@ export default class IntegrationModel {
   }
 
   /**
+   * Remove events to formulas in the DOM target.
+   */
+  removeEvents() {
+    const eventTarget = this.isIframe ? this.target.contentWindow.document : this.target;
+    Util.removeElementEvents(eventTarget);
+  }
+
+  /**
    * Handles a double click on the target element. Opens an editor
    * to re-edit the double-clicked formula.
    * @param {HTMLElement} element - DOM object target.

--- a/packages/mathtype-html-integration-devkit/src/util.js
+++ b/packages/mathtype-html-integration-devkit/src/util.js
@@ -69,23 +69,27 @@ export default class Util {
    */
   static addElementEvents(eventTarget, doubleClickHandler, mousedownHandler, mouseupHandler) {
     if (doubleClickHandler) {
-      Util.addEvent(eventTarget, 'dblclick', (event) => {
+      this.callbackDblclick = (event) => {
         const realEvent = (event) || window.event;
         const element = realEvent.srcElement ? realEvent.srcElement : realEvent.target;
         doubleClickHandler(element, realEvent);
-      });
+      };
+
+      Util.addEvent(eventTarget, 'dblclick', this.callbackDblclick);
     }
 
     if (mousedownHandler) {
-      Util.addEvent(eventTarget, 'mousedown', (event) => {
+      this.callbackMousedown = (event) => {
         const realEvent = (event) || window.event;
         const element = realEvent.srcElement ? realEvent.srcElement : realEvent.target;
         mousedownHandler(element, realEvent);
-      });
+      };
+
+      Util.addEvent(eventTarget, 'mousedown', this.callbackMousedown);
     }
 
     if (mouseupHandler) {
-      const callback = (event) => {
+      this.callbackMouseup = (event) => {
         const realEvent = (event) || window.event;
         const element = realEvent.srcElement ? realEvent.srcElement : realEvent.target;
         mouseupHandler(element, realEvent);
@@ -94,9 +98,24 @@ export default class Util {
       // while the mouse is outside the editor text field.
       // This is a workaround: we trigger the event independently of where the mouse
       // is when we release its button.
-      Util.addEvent(document, 'mouseup', callback);
-      Util.addEvent(eventTarget, 'mouseup', callback);
+      Util.addEvent(document, 'mouseup', this.callbackMouseup);
+      Util.addEvent(eventTarget, 'mouseup', this.callbackMouseup);
     }
+  }
+
+  /**
+   * Remove all callback function, for a certain event target, to the following event types:
+   * - dblclick
+   * - mousedown
+   * - mouseup
+   * @param {EventTarget} eventTarget - event target.
+   * @static
+   */
+  static removeElementEvents(eventTarget) {
+    Util.removeEvent(eventTarget, 'dblclick', this.callbackDblclick);
+    Util.removeEvent(eventTarget, 'mousedown', this.callbackMousedown);
+    Util.removeEvent(document, 'mouseup', this.callbackMouseup);
+    Util.removeEvent(eventTarget, 'mouseup', this.callbackMouseup);
   }
 
   /**


### PR DESCRIPTION
## Description

Implemented the inherited `destroy?(): void` function on `plugin.js` file from `packages/mathtype-ckeditor5`, in order to remove all event listeners from the CKEditor5Integration object when CKEditor5 is destroyed. Remove the event listeners allow the garbatge collector free up the memory of the CKEditor5Integrations object.

## Steps to reproduce

1. Close all Chrome windows.
2. Run html5 CKEditor5 demo with a guest profile.
3. Initialize the editor, then destroy it a couple of times. Click the Garbage Collector button after each destruction. Make sure no references are left behind (such as window.editor).
4. Take a memory snapshot.
5. Repeat 3.-4. a couple of times.

## Expected result

There should be no dramatic difference in snapshot size and retained memory.

---

Closes #459 
[#taskid 17299](https://wiris.kanbanize.com/ctrl_board/2/cards/17299/details/)
