### PR TITLE
Added missing 'www' on documentation wiris.net links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ Last release of this project is was 30th of September 2021.
   - Remove `jest` completely from the project.
   - Fix the `demo-html5-generic` dependencies.
   - Update third-party libraries to fix vulnerabilites.
+  - Added missing 'www' on wiris.net documentation links.
+
 ## 7.27.2 - 2021-11-26
 
 ## CKEditor5 filtering mechanism

--- a/packages/mathtype-ckeditor4/README.md
+++ b/packages/mathtype-ckeditor4/README.md
@@ -68,7 +68,7 @@ In order to install the plugin along with the correspondent services, please fol
 
 In order to display mathematical formulas on the target page, i.e. the page where content produced by the HTML editor will be visible, the target page needs to include the [MathType script](https://docs.wiris.com/en/mathtype/mathtype_web/integrations/mathml-mode#add_a_script_to_head). For example for the default setting this would be:
 ```html
-<script src="https://wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
+<script src="https://www.wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
 ```
 
 ## Documentation

--- a/packages/mathtype-ckeditor5/README.md
+++ b/packages/mathtype-ckeditor5/README.md
@@ -53,7 +53,7 @@ This npm module uses remotely hosted services to render MathML data. In case of 
 
 In order to display mathematical formulas on the target page, i.e. the page where content produced by the HTML editor will be visible, the target page needs to include the [MathType script](https://docs.wiris.com/en/mathtype/mathtype_web/integrations/mathml-mode#add_a_script_to_head). For example for the default setting this would be:
 ```html
-<script src="https://wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
+<script src="https://www.wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
 ```
 
 ## Documentation

--- a/packages/mathtype-froala/README.md
+++ b/packages/mathtype-froala/README.md
@@ -82,7 +82,7 @@ In order to install the plugin along with the correspondent services, please fol
 
 In order to display mathematical formulas on the target page, i.e. the page where content produced by the HTML editor will be visible, the target page needs to include the [MathType script](https://docs.wiris.com/en/mathtype/mathtype_web/integrations/mathml-mode#add_a_script_to_head). For example for the default setting this would be:
 ```html
-<script src="https://wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
+<script src="https://www.wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
 ```
 
 ## Documentation

--- a/packages/mathtype-froala3/README.md
+++ b/packages/mathtype-froala3/README.md
@@ -69,7 +69,7 @@ In order to install the plugin along with the correspondent services, please fol
 
 In order to display mathematical formulas on the target page, i.e. the page where content produced by the HTML editor will be visible, the target page needs to include the [MathType script](https://docs.wiris.com/en/mathtype/mathtype_web/integrations/mathml-mode#add_a_script_to_head). For example for the default setting this would be:
 ```html
-<script src="https://wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
+<script src="https://www.wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
 ```
 
 ## Documentation

--- a/packages/mathtype-generic/README.md
+++ b/packages/mathtype-generic/README.md
@@ -305,7 +305,7 @@ To install the Ruby on Rails services, please, follow the steps below:
 
 In order to display mathematical formulas on the target page, i.e. the page where content produced by the HTML editor will be visible, the target page needs to include the [MathType script](https://docs.wiris.com/en/mathtype/mathtype_web/integrations/mathml-mode#add_a_script_to_head). For example for the default setting this would be:
 ```html
-<script src="https://wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
+<script src="https://www.wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
 ```
 
 ## Documentation

--- a/packages/mathtype-tinymce4/README.md
+++ b/packages/mathtype-tinymce4/README.md
@@ -63,7 +63,7 @@ In order to install the plugin along with the correspondent services, please fol
 
 In order to display mathematical formulas on the target page, i.e. the page where content produced by the HTML editor will be visible, the target page needs to include the [MathType script](https://docs.wiris.com/en/mathtype/mathtype_web/integrations/mathml-mode#add_a_script_to_head). For example for the default setting this would be:
 ```html
-<script src="https://wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
+<script src="https://www.wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
 ```
 
 ## Documentation

--- a/packages/mathtype-tinymce5/README.md
+++ b/packages/mathtype-tinymce5/README.md
@@ -74,7 +74,7 @@ In order to install the plugin along with the correspondent services, please fol
 
 In order to display mathematical formulas on the target page, i.e. the page where content produced by the HTML editor will be visible, the target page needs to include the [MathType script](https://docs.wiris.com/en/mathtype/mathtype_web/integrations/mathml-mode#add_a_script_to_head). For example for the default setting this would be:
 ```html
-<script src="https://wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
+<script src="https://www.wiris.net/demo/plugins/app/WIRISplugins.js?viewer=image"></script>
 ```
 
 ## Documentation


### PR DESCRIPTION
## Description

wiris.net services access has changed and is not allowed to use a service without www in the hostname. Added missing 'www' on documentation wiris.net links.

---

[#taskid 34](https://wiris.kanbanize.com/ctrl_board/2/cards/34/details/) 
