### PR TITLE
KB-17724: Add an ADR document for XSS vulnerability when browser engines parsing HTML

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Last release of this project is was 30th of September 2021.
   - Update third-party libraries to fix vulnerabilites.
   - Added missing 'www' on wiris.net documentation links.
   - Destroy events from CKEditor5Integration when CK5 is destroyed.
+  - Added ADR 005. Use HTML sanitizer to avoid XSS attacks.
 
 - Solve Parser not working on Generic Integrations (Issue - #450)
 

--- a/docs/adr/005-Use-HTML-sanitizer-to-avoid-XSS-attacks.md
+++ b/docs/adr/005-Use-HTML-sanitizer-to-avoid-XSS-attacks.md
@@ -1,0 +1,82 @@
+# 005. Use DOMPurify as HTML sanitizer to avoid XSS attacks
+
+Date: 29-no-2021
+
+## Status
+
+ACCEPTED
+
+## Summary
+
+_An XSS vulnerability has been detected on the MathType devkit package._
+_A user could inject malicious code using the editor by encapsulating them inside a `<math>` tag._
+_In order to prevent XSS attacks, we will use the DOMPurify third-party library. An open-source XSS sanitizer for HTML, MathML and SVG code._
+
+## Context
+
+All browser engines, during _parsing_ step, they turn the data received over the network into the DOM. Given the following block, which uses the `<math>` tag:
+
+```html
+<math>
+  <style>
+    <img src onerror="alert(1)" />
+  </style
+</math>
+```
+
+The browser engine will generate it to:
+
+```html
+<MathML math>
+  <MathML style> <MathML img src onerror="alert(1)" /></MathML
+></MathML>
+```
+
+Normally, an `<img>` inside an `<style>` will be parsed as a `#text` inside the `<MathML style>` tag. Nevertheless, this behavior changes when it's encapsulated inside a `<math>` tag, and interprets the `img` as a `<MathML>` independent block. 
+
+As a result, the HTML will be unwrapped and written on the DOM following this format:
+
+```html
+<math>
+  <img src onerror="alert(1)" />
+  <style></style>
+</math>
+```
+
+This parsing behavior can be used to inject malicious JavaScript on a website. In order to avoid this vulnerability, is needed to filter all the HTML added from the editor.
+
+Implementing a sanitize system can be laborious, and it will be difficult to maintenance in order to detect as much XSS vulnerabilities as possible.
+
+## Decision
+
+DOMPurify sanitize HTML and prevents XSS attacks. You can feed DOMPurify with strings full of dirty HTML, and it will return a string without ant dangerous HTML.
+
+DOMPurify will be added to `@wiris/mathtype-html-integration-devkit` and, therefore, this dependency will affect to all the packages and demos on this project.
+
+### Pros and Cons of the Options
+
+#### Implement our own JavaScript library for that
+
+- Bad, because it is a huge task to detect all possible XSS injections.
+- Bad, because we'll need to maintain it.
+- Good, we will have full control on the library.
+
+#### Using a third party library like github.com/cure53/DOMPurify
+
+- Good, because it's well maintained, no issues and widely used; (1,612,881 downloads/week).
+- Good, because it solves our problem immediately.
+- Good, because it's secure, small and cross-platform.
+- Bad, because we're adding a new dependency to our core library, and therefore, to all the packages on the project.
+
+## Consequences
+
+Adding a dependency to our main library means that all the packages on this project will include it, too.
+
+No specific changes need to be done to our current GitHub's Dependabot strategy as a result of this decision.
+
+## Links
+
+- [Populating the page: how browsers work](https://developer.mozilla.org/en-US/docs/Web/Performance/How_browsers_work)
+- [The process of browser parsing and rendering HTML documents](https://developpaper.com/the-process-of-browser-parsing-and-rendering-html-documents/)
+- [npm DOMPurify](https://www.npmjs.com/package/dompurify)
+- [GitHub DOMPurify](https://github.com/cure53/DOMPurify)

--- a/packages/mathtype-html-integration-devkit/README.md
+++ b/packages/mathtype-html-integration-devkit/README.md
@@ -49,6 +49,10 @@ The following packages are dependencies of the project:
 
     **Note**: As a consequence of this dependency, if you want to integrate `mathtype-html-integration-devkit` in your own project, you will have to apply `raw-loader` to the MathType source files in your own `webpack.config.js`.
 
+- [`DOMPurify`](https://www.npmjs.com/package/dompurify)
+
+    Used to sanitize HTML and prevents XSS attacks. When HTML code is sent by the user, DOMPurify receive the input and delete the malicious code.
+
 
 ## Generate the package documentation site
 

--- a/packages/mathtype-html-integration-devkit/package.json
+++ b/packages/mathtype-html-integration-devkit/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "raw-loader": "^4.0.2",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "dompurify": "^2.3.3"
   }
 }

--- a/packages/mathtype-html-integration-devkit/src/parser.js
+++ b/packages/mathtype-html-integration-devkit/src/parser.js
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 import Util from './util';
 import Latex from './latex';
 import MathML from './mathml';
@@ -422,6 +423,8 @@ export default class Parser {
       }
     }
     output += code.substring(endPosition, code.length);
+    // Sanitize output HTML to remove XSS inyections
+    output = DOMPurify.sanitize(output);
     return output;
   }
 

--- a/packages/mathtype-html-integration-devkit/src/parser.js
+++ b/packages/mathtype-html-integration-devkit/src/parser.js
@@ -423,7 +423,7 @@ export default class Parser {
       }
     }
     output += code.substring(endPosition, code.length);
-    // Sanitize output HTML to remove XSS inyections
+    // Sanitize output HTML to remove XSS injections
     output = DOMPurify.sanitize(output);
     return output;
   }


### PR DESCRIPTION
## Description

Detected an XSS vulnerability on the Mathtype devkit package. A user could inject malicious to a website code encaplusating them inside a <math> tag.

In order to prevent XSS attacks it is proposed to use the DOMPurify library. An open-source XSS sanitizer for HTML, MathML and SVG.

## Decision

DOMPurify sanitize HTML and prevents XSS attacks. You can feed DOMPurify with string full of dirty HTML and it will return a string removing the dangerous HTML.

DOMPurify will be added to @wiris/mathtype-html-integration-devkit so this dependency will affect to all the html-integrations packages.

---

[#taskid 17724](https://wiris.kanbanize.com/ctrl_board/2/cards/17724/details/)
