### PR TITLE
Solve parser functions not working on Generic Integrations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,11 @@ Last release of this project is was 30th of September 2021.
   - Added missing 'www' on wiris.net documentation links.
   - Destroy events from CKEditor5Integration when CK5 is destroyed.
 
+- Solve Parser not working on Generic Integrations (Issue - #450)
+
+  - Modify the generic package to use properly the parser functions.
+  - Modify the demo to initialyze the editor exposing it to the window, so it can have the necessary configurations to use the Parser class.
+
 ## 7.27.2 - 2021-11-26
 
 ## CKEditor5 filtering mechanism

--- a/demos/angular/generic/src/app/app.component.ts
+++ b/demos/angular/generic/src/app/app.component.ts
@@ -28,7 +28,7 @@ export class AppComponent implements OnInit {
     const toolbarDiv = document.getElementById('toolbar');
 
     // Initialyze the editor.
-    wrsInitEditor(editableDiv, toolbarDiv);
+    (window as any).wrs_int_init(editableDiv, toolbarDiv);
 
     // Add listener on click button to launch updateContent function.
     document.getElementById('btn_update').addEventListener('click', (e) => {

--- a/demos/html5/generic/src/app.js
+++ b/demos/html5/generic/src/app.js
@@ -1,5 +1,5 @@
 // Load scripts.
-import { wrsInitEditor, wrsGetTargetHtml } from '@wiris/mathtype-generic/wirisplugin-generic.src';
+import { wrsGetTargetHtml } from '@wiris/mathtype-generic/wirisplugin-generic.src';
 import '@wiris/mathtype-generic/wirisplugin-generic';
 import * as Generic from '../../../../resources/demos/common';
 
@@ -25,7 +25,7 @@ const mathTypeParameters = {
 };
 
 // Initialyze the editor.
-wrsInitEditor(editableDiv, toolbarDiv, mathTypeParameters);
+window.wrs_int_init(editableDiv, toolbarDiv, mathTypeParameters);
 
 document.onreadystatechange = function () {
   if (document.readyState === 'interactive') {

--- a/demos/react/generic/src/index.js
+++ b/demos/react/generic/src/index.js
@@ -51,7 +51,7 @@ class Editor extends React.Component {
     const toolbarDiv = document.getElementById('toolbar');
 
     // Initialyze the editor.
-    wrsInitEditor(editableDiv, toolbarDiv);
+    window.wrs_int_init(editableDiv, toolbarDiv);
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/packages/mathtype-generic/global.js
+++ b/packages/mathtype-generic/global.js
@@ -12,6 +12,8 @@ import '@wiris/mathtype-html-integration-devkit/src/backwardslib';
 import '@wiris/mathtype-html-integration-devkit/src/polyfills';
 import GenericIntegration, { currentInstance } from './wirisplugin-generic.src';
 
+Configuration.set('parseModes', 'latex');
+
 // Expose WirisPlugin variable to the window.
 window.WirisPlugin = {
   Core,
@@ -26,5 +28,3 @@ window.WirisPlugin = {
   GenericIntegration,
   Test,
 };
-
-Configuration.set('parseModes', 'latex');

--- a/packages/mathtype-generic/wirisplugin-generic.src.js
+++ b/packages/mathtype-generic/wirisplugin-generic.src.js
@@ -46,7 +46,7 @@ export function wrsInitEditor(target, toolbar, mathtypeProperties) {
  */
 export function wrsGetTargetHtml(target) {
   const html = target.innerHTML;
-  return Parser.endParse(html);
+  return WirisPlugin.Parser.endParse(html);
 }
 
 /**


### PR DESCRIPTION
## Description

This PR solves a bug with the Parser functions and the Generic Integration. The bug turned off the Parser functions, so they returned the exact same parameter they received, instead of transforming it. For example, executing the following function:
```js
WirisPlugin.Parser.initParse('<math><mo>x</mo></math>');
```
should return the mathml transformed into an image, but instead returns the same mathml.

This behavior is caused due to a bad configuration variable on the `global.js` mathtype-generic package file, and a wrong way to initialize the generic editor instance on the HTML5, Angular and React demos.


## Steps to reproduce

1. Open the Generic demo.
2. With F12, open the web inspector.
3. On the console tab, write the following code: `WirisPlugin.Parser.initParse('<math><mo>x</mo></math>');`
4. See that the returned object is the same mathml instead of a formula image.

---

[#taskid 16836](https://wiris.kanbanize.com/ctrl_board/2/cards/16836/details/)
