### PR TITLE
Fix Froala v3 & v4 + Angular treating formulas as images

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,9 @@ Last release of this project is was 30th of September 2021.
   Latex formulas have a semantics tag that requires its inside mathml to be inside a `mrow` tag.
   Added this tag on the Latex formula generation.
 
+- Fix Angular + Froala (v3 & v4) treting Wiris formulas as images.
+  - Update Webpack to V5 and remove jQuery, on mathtype-froala3 and its demos.
+
 ## 7.27.2 - 2021-11-26
 
 ## CKEditor5 filtering mechanism

--- a/demos/angular/froala/package.json
+++ b/demos/angular/froala/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wiris/mathtype-froala3": "^7.27.0",
     "@wiris/mathtype-html-integration-devkit": "*",
-    "angular-froala-wysiwyg": "^4.0.4"
+    "angular-froala-wysiwyg": "^4.0.7"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^12.2.5",

--- a/demos/html5/froala/index.html
+++ b/demos/html5/froala/index.html
@@ -5,7 +5,6 @@
         <title> Demo Froala </title>
         <meta http-equiv="content-type" content="text/html; charset=UTF-8">
         <script src="node_modules/froala-editor/js/froala_editor.pkgd.min.js"></script>
-        <script src="node_modules/jquery/dist/jquery.min.js"></script>
     </head>
     <body>
         <script src="./dist/demo.js"></script>

--- a/demos/html5/froala/package.json
+++ b/demos/html5/froala/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "@wiris/mathtype-froala3": "^7.27.0",
     "@wiris/mathtype-html-integration-devkit": "*",
-    "froala-editor": "^4.0.4",
-    "jquery": "^3.6.0"
+    "froala-editor": "^4.0.7"
   },
   "devDependencies": {
     "css-loader": "^3.0.0",

--- a/packages/mathtype-froala3/package.json
+++ b/packages/mathtype-froala3/package.json
@@ -46,7 +46,7 @@
     "style-loader": "^3.3.0",
     "terser-webpack-plugin": "^5.2.3",
     "url-loader": "^4.1.1",
-    "webpack": "^5.50.0",
-    "webpack-cli": "^4.8.0"
+    "webpack": "^5.64.4",
+    "webpack-cli": "^4.9.1"
   }
 }

--- a/packages/mathtype-froala3/webpack.config.js
+++ b/packages/mathtype-froala3/webpack.config.js
@@ -45,23 +45,17 @@ module.exports = {
                 // The following expresion, looks for all the svg files inside the devkit folder and subfolders
                 // /mathtype-html-integration-devkit\/?(?:[^\/]+\/?)*.svg$/
                 test: /mathtype-html-integration-devkit\/styles\/icons\/[^\/]+\/[^\/]+\.svg$/,
-                use: [ 'raw-loader' ]
+                type: 'asset/source'
             },
             {
                 test: /\.(png|ttf|otf|eot|svg|woff(2)?)(.*)?$/,
                 exclude: /mathtype-html-integration-devkit\/styles\/icons\/[^\/]+\/[^\/]+\.svg$/,
-                use: [
-                  {
-                    loader: 'url-loader',
-                    options: {
-                      limit: 8192
-                    }
-                  }
-                ]
+                type: 'asset'
             }
         ]
     },
     stats: {
         colors: true
-    }
+    },
+    mode: 'none'
 };

--- a/packages/mathtype-froala3/wiris.src.js
+++ b/packages/mathtype-froala3/wiris.src.js
@@ -1,5 +1,3 @@
-/* globals $ */
-
 import IntegrationModel from '@wiris/mathtype-html-integration-devkit/src/integrationmodel';
 import Configuration from '@wiris/mathtype-html-integration-devkit/src/configuration';
 import Parser from '@wiris/mathtype-html-integration-devkit/src/parser';
@@ -279,7 +277,7 @@ export class FroalaIntegration extends IntegrationModel {
       currentFroalaIntegrationInstance.hidePopups();
       currentFroalaIntegrationInstance.core.getCustomEditors().disable();
       const imageObject = currentFroalaIntegrationInstance.editorObject.image.get();
-      if (typeof imageObject !== 'undefined' && imageObject !== null && imageObject.hasClass(WirisPlugin.Configuration.get('imageClassName'))) {
+      if (typeof imageObject !== 'undefined' && imageObject !== null && imageObject[0].classList.contains(WirisPlugin.Configuration.get('imageClassName'))) {
         currentFroalaIntegrationInstance.core.editionProperties.temporalImage = imageObject[0];
         currentFroalaIntegrationInstance.openExistingFormulaEditor();
       } else {
@@ -294,19 +292,19 @@ export class FroalaIntegration extends IntegrationModel {
     // Value can be undefined.
     if (selectedImage) {
       if (($btn.parent()[0].hasAttribute('class') && $btn.parent()[0].getAttribute('class').indexOf('fr-buttons') === -1) || (selectedImage[0]
-                && ($(selectedImage[0]).hasClass(Configuration.get('imageClassName')) || $(selectedImage[0]).contents().hasClass(Configuration.get('imageClassName'))))) { // Is a MathType image.
-        // Show MathType icons if previously were hiden.
+                && (selectedImage[0].classList.contains(Configuration.get('imageClassName')) || selectedImage[0].contents().classList.contains(Configuration.get('imageClassName'))))) { // Is a MathType image.
+        // Show MathType icons if previously were hidden.
         $btn.removeClass('fr-hidden');
         // Disable resize box.
-        if (!$('#wrs_style').get(0)) { // eslint-disable-line no-undef
-          $('head').append('<style id="wrs_style">.fr-image-resizer {pointer-events: none;}</style>');
+        if (!document.getElementById('wrs_style')) { // eslint-disable-line no-undef
+          document.getElementsByTagName('head')[0].append('<style id="wrs_style">.fr-image-resizer {pointer-events: none;}</style>');
         }
       } else { // Is a non-MathType image.
         // Hide MathType icons.
         $btn.addClass('fr-hidden');
         // Enable resize box (if it was configured).
-        if ($('#wrs_style').get(0)) {
-          $('#wrs_style').get(0).remove();
+        if (document.getElementById('wrs_style')) {
+          document.getElementById('wrs_style').remove();
         }
       }
     }
@@ -326,7 +324,7 @@ export class FroalaIntegration extends IntegrationModel {
       currentFroalaIntegrationInstance.hidePopups();
       currentFroalaIntegrationInstance.core.getCustomEditors().enable('chemistry');
       const imageObject = currentFroalaIntegrationInstance.editorObject.image.get();
-      if (typeof imageObject !== 'undefined' && imageObject !== null && imageObject.hasClass(WirisPlugin.Configuration.get('imageClassName'))) {
+      if (typeof imageObject !== 'undefined' && imageObject !== null && imageObject[0].classList.contains(WirisPlugin.Configuration.get('imageClassName'))) {
         currentFroalaIntegrationInstance.core.editionProperties.temporalImage = imageObject[0];
         currentFroalaIntegrationInstance.openExistingFormulaEditor();
       } else {


### PR DESCRIPTION
## Description

The Wiris formulas images should have a different behavior than regular images when clicking into them, meaning that the image toolbar for formulas should include the mathtype buttons when specified. With angular framework and Froala v3 or v4 editor, this behavior was not working, instead, the formulas were treated as regular images even when the image toolbar had specified the mathtype buttons.

The bug was solved by:
- Deleting jQuery residual code on mathtype-froala3 package, since Froala3 and above works with pure JavaScript.
- Migrating webpack v4 to v5.

This PR also includes:
- Removing jQuery dependency from html5+froala demo.
- Updating Froala version on angular and html5 + froala demos.

## Steps to reproduce

1. Open the angular + froala demo.
2. Click on any formula on the editor.
3. Check that the image toolbar doesn't even open the image toolbar and an error appears on the console.

---

[#taskid 14726](https://wiris.kanbanize.com/ctrl_board/2/cards/14726/details/)
