### PR TITLE
Fix wrapping issue when converting Latex to MathML

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,11 @@ Last release of this project is was 30th of September 2021.
   - Modify the generic package to use properly the parser functions.
   - Modify the demo to initialyze the editor exposing it to the window, so it can have the necessary configurations to use the Parser class.
 
+- Fix wrapping issue when converting Latex to MathML wothout the Wiris render script (KB-16387 - Issue #419)
+  
+  Latex formulas have a semantics tag that requires its inside mathml to be inside a `mrow` tag.
+  Added this tag on the Latex formula generation.
+
 ## 7.27.2 - 2021-11-26
 
 ## CKEditor5 filtering mechanism

--- a/packages/mathtype-html-integration-devkit/src/mathml.js
+++ b/packages/mathtype-html-integration-devkit/src/mathml.js
@@ -229,7 +229,7 @@ export default class MathML {
       const beginMathMLContent = mathml.indexOf('>') + 1;
       const endMathmlContent = mathml.lastIndexOf('</math>');
       const mathmlContent = mathml.substring(beginMathMLContent, endMathmlContent);
-      mathmlWithAnnotation = `${mathml.substring(0, beginMathMLContent)}<semantics>${mathmlContent}<annotation encoding="${annotationEncoding}">${content}</annotation></semantics></math>`;
+      mathmlWithAnnotation = `${mathml.substring(0, beginMathMLContent)}<semantics><mrow>${mathmlContent}</mrow><annotation encoding="${annotationEncoding}">${content}</annotation></semantics></math>`; // eslint-disable-line max-len
     }
 
     return mathmlWithAnnotation;


### PR DESCRIPTION
## Description

When adding latex to our MathML formulas, we include a semantics field that can make formulas render badly when the wiris plugins are not used to render them, for example, not including the plugin and trying to render the formulas with firefox browser.

This is caused due to a specification of the `semantics` field. It requires to have all the MathML associated to the Latex formula inside a `mrow` tag.

## Steps to reproduce

1. Add the following mathml to the source code:

```
<math xmlns="http://www.w3.org/1998/Math/MathML">
    <semantics>
        <mfrac>
            <mrow>
                <mn>8</mn>
                <mo>&#xB7;</mo>
                <mn>4</mn>
            </mrow>
            <mn>12</mn>
        </mfrac>
        <mo>+</mo>
        <mfrac>
            <mrow>
                <mn>1</mn>
                <mo>&#xB7;</mo>
                <mn>3</mn>
            </mrow>
            <mn>12</mn>
        </mfrac>
        <mo>=</mo>
        <mfrac>
            <mrow>
                <mn>32</mn>
                <mo>+</mo>
                <mn>1</mn>
            </mrow>
            <mn>12</mn>
        </mfrac>
        <mo>=</mo>
        <mfrac>
            <mn>33</mn>
            <mn>12</mn>
        </mfrac>

        <annotation encoding="LaTeX">\frac{8\cdot4}{12}+\frac{1\cdot3}{12}=\frac{32+1}{12}=\frac{33}{12}</annotation>

    </semantics>
</math>
```
> or add its corresponding Latex on an active demo: `$$\frac{8\cdot4}{12}+\frac{1\cdot3}{12}=\frac{32+1}{12}=\frac{33}{12}$$` and click the button update.

2. Remove the Wiris PluginJS dependency from the demos.
3. Open any demo on Firefox and see the formula rendered.

---

Closes #419 

[#taskid 16387](https://wiris.kanbanize.com/ctrl_board/2/cards/16387/details/)
