### PR TITLE
docs: add support for conventional commits (KB-18015)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The [MathType Privacy Policy](http://www.wiris.com/mathtype/privacy-policy) cove
 
 ## License
 
-Copyright © 2010-2021 [Wiris](http://www.wiris.com). Released under the [MIT License](LICENSE).
+Copyright © 2010-2022 [Wiris](http://www.wiris.com). Released under the [MIT License](LICENSE).
 
 [MathType by Wiris]: https://www.wiris.com/en/mathtype/
 [CKEditor]: https://ckeditor.com/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For the MathType integration for Moodle and other LMS see [here](https://www.wir
 
 In order to manually try out each plugin, there's a set of developer demos on the [`demos`](demos) folder.
 
-Refer to the [documentation](docs/demos/README.md) for more information.
+Refer to the [documentation](docs/demos/) for more information.
 
 ## Releases
 
@@ -67,12 +67,12 @@ Visit the [MathType integrations release notes](https://docs.wiris.com/en/mathty
 
 ## Documentation and important links
 
-- [Documentation](docs/README.md)
-- [Trying out the demos](docs/demos/README.md)
-- [Integrating MathType in your website](docs/integration/README.md)
-- [Development guide](docs/development/README.md)
-- [Contributing guidelines](docs/contributing/README.md)
-- [Code of conduct](docs/code-of-conduct/README.md)
+- [Documentation](docs/)
+- [Trying out the demos](docs/demos/)
+- [Integrating MathType in your website](docs/integration/)
+- [Development guide](docs/development/)
+- [Contributing guidelines](docs/contributing/)
+- [Code of conduct](docs/code-of-conduct/)
 
 ## Technical support
 

--- a/demos/angular/ckeditor5/README.md
+++ b/demos/angular/ckeditor5/README.md
@@ -123,4 +123,4 @@ To get more information about wiris MathType you can check on the [official docu
 
 ## License
 
-Copyright © 2010-2021 [WIRIS](http://www.wiris.com). Released under the [MIT License](../../../LICENSE).
+Copyright © 2010-2022 [WIRIS](http://www.wiris.com). Released under the [MIT License](../../../LICENSE).

--- a/demos/angular/froala/README.md
+++ b/demos/angular/froala/README.md
@@ -178,4 +178,4 @@ To get more information about wiris MathType you can check on the [official docu
 
 ## License
 
-Copyright © 2010-2021 [WIRIS](http://www.wiris.com). Released under the [MIT License](../../../LICENSE).
+Copyright © 2010-2022 [WIRIS](http://www.wiris.com). Released under the [MIT License](../../../LICENSE).

--- a/demos/angular/generic/README.md
+++ b/demos/angular/generic/README.md
@@ -110,4 +110,4 @@ To get more information about wiris MathType you can check on the [official docu
 
 ## License
 
-Copyright © 2010-2021 [WIRIS](http://www.wiris.com). Released under the [MIT License](../../../LICENSE).
+Copyright © 2010-2022 [WIRIS](http://www.wiris.com). Released under the [MIT License](../../../LICENSE).

--- a/demos/angular/tinymce5/README.md
+++ b/demos/angular/tinymce5/README.md
@@ -167,4 +167,4 @@ To get more information about wiris MathType you can check on the [official docu
 
 ## License
 
-Copyright © 2010-2021 [WIRIS](http://www.wiris.com). Released under the [MIT License](../../../LICENSE).
+Copyright © 2010-2022 [WIRIS](http://www.wiris.com). Released under the [MIT License](../../../LICENSE).

--- a/demos/react/froala/README.md
+++ b/demos/react/froala/README.md
@@ -146,4 +146,4 @@ To get more information about wiris MathType you can check on the [official docu
 
 ## License
 
-Copyright © 2010-2021 [WIRIS](http://www.wiris.com). Released under the [MIT License](../../../LICENSE).
+Copyright © 2010-2022 [WIRIS](http://www.wiris.com). Released under the [MIT License](../../../LICENSE).

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,42 +1,207 @@
-# Contributing guidelines
+# Contributing to MathType Web Integrations
 
 <small>[MathType Web Integrations](../../README.md) → [Documentation](../README.md) → Contributing guidelines</small>
 
-You can contribute in this project in different ways.
+We would love for you to contribute to this project and help make it better.
 
-## Table of contents
+As a contributor, here are the guidelines we would like you to follow:
 
-- [Code contributing](#code-contributing)
+- [Code of Conduct](#code-of-conduct)
+- [Questions or problems?](#questions-or-problems)
 - [Reporting issues](#reporting-issues)
-- [Questions and others](#questions-and-others)
+- [Coding Rules](#coding-rules)
+- [Commit Message Guidelines](#commit-message-guidelines)
 
-## Code contributing
+## Code of Conduct
 
-Make sure to read the [Development guide](../development/README.md) before proposing any changes.
+Please read and follow our [Code of Conduct](/docs/code-of-conduct/).
 
-First, clone this repository, create a branch from master, code and submit it for a PR. Then, we'll review, discuss, and merge changes as needed. You can contribute by:
+## Questions or problems
 
-- Adding a missing or new feature.
-- Solving an existing bug.
-- Submitting any code you think that may improve this project.
+Do not open issues for general support questions as we want to keep GitHub issues for bug reports and feature requests.
+
+Instead, we recommend you sending an e-mail to [support@wiris.com](mailto:support@wiris.com) to ask support-related questions.
 
 ## Reporting issues
 
-You can report an error by:
+If you find a bug in the source code, you can help us by [submitting an issue](#submitting-an-issue) to our [GitHub Repository][github]. Even better, you can submit a Pull Request with a fix.
 
-- Sending an email to support@wiris.com, or
-- Opening a GitHub issue on this repository.
+### Submitting an Issue
 
-To give you a good and fast support we need the following information: 
+Before you submit an issue, please search the issue tracker. An issue for your problem might already exist and the discussion might inform you of workarounds readily available.
 
-- A description of the error you have/found.
-- Explanation of how to reproduce the bug.
-- (Optional) A demo with the code that causes the issue.
+We want to fix all the issues as soon as possible, but before fixing a bug, we need to reproduce and confirm it.
 
-We will review the submission and support you by solving the issue, or providing you the right code to use MathType.
+In order to reproduce bugs, we require that you provide a minimal reproduction.
+Having a minimal reproducible scenario gives us a wealth of important information without going back and forth to you with additional questions.
 
-## Questions and others
+A minimal reproduction allows us to quickly confirm a bug (or point out a coding problem) as well as confirm that we are fixing the right problem.
 
-If you have any questions or another thing that doesn't fit the previous ones, you can both send a mail to [support@wiris.com](mailto:support@wiris.com) or open a GitHub issue on this repository. We will answer you as soon as possible. 
+We require a minimal reproduction to save maintainers' time and ultimately be able to fix more bugs.
+Often, developers find coding problems themselves while preparing a minimal reproduction.
+We understand that sometimes it might be hard to extract essential bits of code from a larger codebase but we really need to isolate the problem before we can fix it.
 
-We encourage you to collaborate as you want! 
+Unfortunately, we are not able to investigate / fix bugs without a minimal reproduction, so if we don't hear back from you, we are going to close an issue that doesn't have enough info to be reproduced.
+
+You can file new issues by selecting from our [new issue templates](https://github.com/wiris/html-integrations/issues/new/choose) and filling out the issue template.
+
+## Coding Rules
+
+To ensure consistency throughout the source code, keep these rules in mind as you are working:
+
+- Follow the [Commit Message Format guidelines](#commit-message-format).
+- Lint all code.
+- Once forked the project, create a new branch from `master` branch.
+- Make sure to read the [Development guide](/docs/development/) before proposing any changes.
+
+## Commit Message Guidelines
+
+We have very precise rules over how our Git commit messages must be formatted.
+This format leads to **easier to read commit history**.
+
+> **Note**: You don't need to use this specification to contribute to this project, but we encourage you to do, so.
+
+- Wrap message lines to about 72 characters or so.
+
+- Each commit message consists of a **header**, a **body**, and a **footer**.
+
+```
+<header>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+- The `header` is mandatory and must conform to the [Commit Message Header](#commit-message-header) format.
+
+- The `body` is mandatory for all commits except for those of type "docs".
+  When the body is present it must be at least 20 characters long and must conform to the [Commit Message Body](#commit-message-body) format.
+
+- The `footer` is optional. The [Commit Message Footer](#commit-message-footer) format describes what the footer is used for and the structure it must have.
+
+### Commit Message Header
+
+The commit message `header` should be structured as follows:
+
+```
+<type>(<scope>): <summary>
+  │       │             │
+  │       │             └─> Summary in present tense. Not capitalized. No period at the end.
+  │       │
+  │       └─> Commit Scope: ckeditor4|ckeditor5|froala|froala3||generic|
+  │                         devkit|tinymce|tinymce4|tinymce5|
+  │                         demo|packaging|changelog|dev-infra|none
+  │
+  └─> Commit Type: build|ci|docs|feat|fix|perf|refactor|test
+```
+
+- The `<type>` and `<summary>` fields are mandatory.
+- The `(<scope>)` field is optional.
+
+#### Type
+
+The recommended default values for `<type>` are the following:
+
+- `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm).
+- `ci`: Changes to our CI configuration files and scripts (examples: GitHub, Jenkins).
+- `docs`: Documentation only changes.
+- `feat`: A new feature.
+- `fix`: A bug fix.
+- `perf`: A code change that improves performance.
+- `refactor`: A code change that neither fixes a bug nor adds a feature.
+- `test`: Adding missing tests or correcting existing tests.
+
+#### Scope
+
+We use the "package name rule" as follows.
+
+For brevity, `<scope>` will take one of these next values depending on the affected package:
+
+| Scope value | Affected package                   |
+| ----------- | ---------------------------------- |
+| `devkit`    | `mathtype-html-integration-devkit` |
+| `ckeditor4` | `mathtype-ckeditor4`               |
+| `ckeditor5` | `mathtype-ckeditor5`               |
+| `froala`    | `mathtype-froala`                  |
+| `froala3`   | `mathtype-froala3`                 |
+| `generic`   | `mathtype-generic`                 |
+| `tinymce`   | `mathtype-tinymce`                 |
+| `tinymce4`  | `mathtype-tinymce4`                |
+| `tinymce5`  | `mathtype-tinymce5`                |
+
+
+There are usually a few exceptions to the above rules:
+
+- `demo`: used when updating the integrations examples on the `/demos` folder.
+
+- `packaging`: used for changes that change the npm package layout in all of our packages, e.g. public path changes, package.json changes done to all packages, d.ts file/format changes, changes to bundles, etc.
+
+- `changelog`: used for updating the release notes in CHANGELOG.md
+
+- `dev-infra`: used for dev-infra related changes within the directories /scripts and /tools
+
+- `none` or empty string: useful for `test` and `refactor` changes that are done across all packages (e.g. `test: add missing unit tests`) and for docs changes that are not related to a specific package (e.g. `docs: fix typo in tutorial`).
+
+#### Summary
+
+Use the `<summary>` field to provide a succinct description of the change:
+
+- use the imperative, present tense: "change" not "changed" nor "changes".
+- don't capitalize the first letter.
+- no dot (.) at the end.
+
+### Commit Message Body
+
+Explain the motivation for the change in the commit message `body`.
+
+Just as in the `<summary>`, use the imperative, present tense: "fix" not "fixed" nor "fixes".
+
+This commit message should explain _why_ you are making the change.
+You can include a comparison of the previous behavior with the new behavior in order to illustrate the impact of the change.
+
+### Commit Message Footer
+
+The `footer` can contain information about breaking changes and deprecations and is also the place to reference GitHub issues, Kanbanize card, Jira tickets, and other PRs that this commit closes or is related to.
+
+In the case of Kanbanize, it is compulsory to add `#taskid {card_number}` to allow kanbanize to track commits.
+
+For example:
+
+```
+BREAKING CHANGE: <breaking change summary>
+<BLANK LINE>
+<breaking change description + migration instructions>
+<BLANK LINE>
+<BLANK LINE>
+Fixes #{issue_number}
+#taskid {card_number}
+```
+
+or
+
+```
+DEPRECATED: <what is deprecated>
+<BLANK LINE>
+<deprecation description + recommended update path>
+<BLANK LINE>
+<BLANK LINE>
+Closes #{pull_number}
+#taskid {card_number}
+```
+
+Breaking Change section should start with the phrase `"BREAKING CHANGE: "` followed by a summary of the breaking change, a blank line, and a detailed description of the breaking change that also includes migration instructions.
+
+Similarly, a Deprecation section should start with `"DEPRECATED: "` followed by a short description of what is deprecated, a blank line, and a detailed description of the deprecation that also mentions the recommended update path.
+
+## Revert commits
+
+If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit.
+
+The content of the commit message body should contain:
+
+- information about the SHA of the commit being reverted in the following format: `This reverts commit <SHA>`,
+- a clear description of the reason for reverting the commit message.
+
+[conv-commits]: https://www.conventionalcommits.org/en/v1.0.0/
+[github]: https://github.com/wiris/html-integrations


### PR DESCRIPTION
## Add support for conventional commits

On our last Engineering teams lead meeting, we decided to adopt the Conventional Commits specification to commit messages to all our source code projects.

Therefore, we need to update our Contributing guidelines section to adhere to this new standard and allow others to do, so.

### Why use a conventional commits strategy 

The main benefits of this initiative are:

- Provide better information when browsing the history.
- Allow generating `CHANGELOG` by script.
- Allow ignoring commits by `git bisect`.
- Automatically determining a semantic version bump (based on the types of commits landed).
- Communicating the nature of changes to teammates, the public, and other stakeholders.
- Be able to trigger build and publish processes.
- Make it easier for people to contribute to your projects, by allowing them to explore a more structured commit history.

### Scope name strategy

Regarding the conventional commit strategy the most relevant decision is about the `<scope>` name strategy proposed, which is:

1. Use package name, if the affected package is not the `mathtype-html-integration-devkit`
2. Use the ES6 module name, if the affected package is the `mathtype-html-integration-devkit`.
3. Use 'demos' if the changes affect the demo "packages".
4. If no affected package or demo, use a reserved list of values from our default strategy as defined on our guides.

> The rest of thi commit message format proposal is copied from our blueprint specification from our Team guides.

### Disclaimer

- This decision will affect our current Contributing and Semantic Versioning strategy, and its best practices.
- This decision will affect our current Lerna implementation settings.
- This PR include some changes to the above mentioned sections in order to keep this guide consistent.
- A further examination of those matters may need to be done, and **it is out of the scope of this PR**.
- This PR doesn't enforce the mandatory use of this strategy on any project's repository. This decision will be done on a different context than this one.

## Also on this commit:

- Improve the Contribution guidelines section of this project.
  I have adapt them to this conventional commit strategy while making it consistent. 
  [AngularJS Git Commit Message Conventions document](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#heading=h.uyo6cb12dt6w) has been a great deal of inspiration.
- Bump year to 2022 on all copyright footers.
  Since the end of the year is near, we've decided to include this change on the source code. It allowed me to test the conventional commits a bit more. ;)

#taskid: [18015](https://wiris.kanbanize.com/ctrl_board/2/cards/18015/details/)