### PR TITLE
[KB-17161] Automated release for npm packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,11 +35,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # - name: Merge master to stable
-      #   run: |
-      #     git checkout stable
-      #     git merge master
-
       - name: Install expect
         run: sudo apt-get install -y expect
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,71 @@
+# Publishes the MathType integrations front-end packages to npm
+#
+# Jobs:
+# - Publish
+#
+name: Publish
+
+# Controls when the action will run
+on:
+  # Ideally we would want this to run on every PR, but GitHub Actions doesn't offer a way to set default values for the
+  # input arguments of the execution.
+  # pull_request:
+  workflow_dispatch:
+    inputs:
+      publish_npm:
+        description: |
+          Whether to publish the frontend packages to npm.
+          Type `publish_npm` to do publish to npm, any other value otherwise.
+          WARNING: This action cannot be undone.
+        required: false
+        default: ""
+      versions:
+        description: |
+          Space-separated list of versions to publish, e.g.: "@wiris/mathtype-ckeditor5=7.27.0 @wiris/mathtype-html-integration-devkit=1.6.1"
+          Packages not mentioned in the list will stay at their current version and will not be published.
+        required: false
+        default: ""
+
+# Array of jobs to run in this workflow
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # - name: Merge master to stable
+      #   run: |
+      #     git checkout stable
+      #     git merge master
+
+      - name: Install expect
+        run: sudo apt-get install -y expect
+
+      # For safety reasons, by default all npm publishing actions in this pipeline will be done with a dummy private npm registry underneath.
+      # This will only be turned off when the publish_npm flag is set to "publish_npm".
+      - name: Set up a private npm registry and publish
+        run: |
+
+          # In case we want to just emulate the publishing, we set up Verdaccio
+          if [ ${{ github.event.inputs.publish_npm == 'publish_npm' }} ] ; then
+
+            # Add the token to publish to the npm registry
+            npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_TOKEN }}
+
+          else
+
+            # We use Verdaccio to run a local private npm server
+            npm install -g verdaccio
+
+            # Set npm to publish to local registry
+            cp resources/publish/.npmrc ~/.npmrc
+
+            # Run and block verdaccio until it is ready
+            (verdaccio --config resources/publish/config.yaml &) | grep -q "http address"
+
+          fi
+
+          # Call the Expect script that interacts with the Lerna TUI
+          ./scripts/publish.exp ${{ github.event.inputs.publish_npm == 'publish_npm' }} ${{ github.event.inputs.versions }}

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ packages/*/package-lock.json
 # Cypress
 cypress/screenshots
 cypress/videos
+
+# Verdaccio
+/storage

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,8 @@
 {
-    "recommendations": ["dbaeumer.vscode-eslint", "html-validate.vscode-html-validate", "stylelint.vscode-stylelint" ]
-  }
+  "recommendations": [
+    "bdavs.expect",
+    "dbaeumer.vscode-eslint",
+    "html-validate.vscode-html-validate",
+    "stylelint.vscode-stylelint"
+  ]
+}

--- a/docs/adr/005-use-verdaccio-for-emulating-publishing-npm-packages.md
+++ b/docs/adr/005-use-verdaccio-for-emulating-publishing-npm-packages.md
@@ -1,0 +1,75 @@
+# 005. Use Verdaccio for emulating publishing npm packages
+
+Date: 21-dec-2021
+
+## Status
+
+DRAFT
+
+## Summary
+
+*When running the build pipeline, we want to automatically publish to npm*
+*but we want to be able to simulate the publishing in a safe manner.*
+*We decided to use Verdaccio*
+*to simulate a local npm registry to safely publish to.*
+
+## Context
+
+As part of the improvement of our CI/CD infrastructure, we want to be able to publish our front-end packages to npm
+automatically. The official npm registry has very strict unpublishing rules, which means that we should be careful
+when publishing new versions of our npm packages.
+
+To make sure that the pipeline publishes the correct versions and contents, we want to add a way to simulate the whole
+process without actually publishing to the official registry.
+
+## Decision
+
+After researching the landscape of alternatives, we have finally settled for Verdaccio, as it is actively maintained
+and is the most popular choice in its market.
+
+### Pros and Cons of the Options
+
+#### Verdaccio
+
+A lightweight Node.js private proxy registry.
+
+[Website][verdaccio]
+
+- Good, because it doesn't require setting up any other software.
+- Good, because it can serve as a staging platform if we want to publish from there to npm in the future.
+- Bad, because the documentation is a bit poor.
+
+#### CNPM
+
+CNPM stands for "Company npm" and is a private npm registry software.
+
+[Website][cnpm]
+
+- Good, because it is oriented towards npm specifically.
+- Bad, because it requires setting up a local database.
+- Bad, because it is oriented to proxying in production.
+
+#### Nexus Repository
+
+Sonatype Nexus Repository 3 is a software and SaaS acting as a private binary repository for npm, among other systems.
+
+[Website][nexus]
+
+- Bad, because it is unnecessarily complex.
+- Bad, because if serves as a respository for multiple package types (not only npm).
+
+## Consequences
+
+We will use Verdaccio for emulating the public npm registry and, possibly in the future, act as a staging ground for npm packages.
+
+This makes automating publishing more robust as we can see the effects of publishing without actually doing it.
+
+## Links
+
+- [Verdaccio][verdaccio]
+- [CNPM][cnpm]
+- [Nexus Repository][nexus]
+
+[verdaccio]: https://verdaccio.org/
+[cnpm]: https://github.com/cnpm/cnpmjs.org
+[nexus]: https://help.sonatype.com/repomanager3

--- a/docs/adr/006-use-expect-for-automating-tui-interaction.md
+++ b/docs/adr/006-use-expect-for-automating-tui-interaction.md
@@ -1,0 +1,68 @@
+# 006. Use Expect for automating TUI interaction
+
+Date: 21-dec-2021
+
+## Status
+
+DRAFT
+
+## Summary
+
+*When publishing automatically to npm, we want to interact with Lerna*
+*but we don't want to require human interaction.*
+*We decided to use Expect*
+*to automatically interact with the text-based user interface.*
+
+## Context
+
+Lerna (and other terminal tools) requires interaction via a TUI (text-based user interface) when publishing packages.
+As part of our effort to automate this task, we need a way to interact with this TUI automatically (without human
+intervention).
+
+Different TUIs have different complexities: some of them only require entering text, while others have interactive menus
+controlled with the arrow keys (as is the case of Lerna).
+
+## Decision
+
+We have decided to use Expect, as it is a tool designed with this purpose in mind and is lightweight in dependencies.
+
+### Pros and Cons of the Options
+
+#### Shell scripts
+
+Shell scripting is a very powerful, but dangerous, solution.
+
+- Good, because it doesn't any dependencies.
+- Bad, because it is very hard to write robust scripts.
+- Bad, because it is complicated to interact with the output of the TUI to automate.
+
+#### Expect
+
+CNPM stands for "Company npm" and is a private npm registry software.
+
+[Website][expect]
+
+- Good, because it is built with this purpose in mind
+- Good, because the syntax is very readable and straightforward.
+- Bad, because we have to learn a new language (Tcl/Expect) to use it.
+
+#### Node scripts
+
+The html-integrations repository already contains a few Node scripts used for similar automation tasks, so it wouldn't
+be out of place to do this with JavaScript as well.
+
+- Good, because we are already familiar with the language.
+- Good, because it is very powerful.
+- Bad, because it is not well-suited for interacting with the terminal.
+
+## Consequences
+
+Expect requires a simple apt-get install, and comes with many commands and utilities for dealing with the terminal and
+TUIs in general. An implementation of the script that interacts with Lerna has already been designed and is pretty
+readable and maintainable.
+
+## Links
+
+- [Expect][expect]
+
+[expect]: https://core.tcl-lang.org/expect/index

--- a/docs/adr/006-use-expect-for-automating-tui-interaction.md
+++ b/docs/adr/006-use-expect-for-automating-tui-interaction.md
@@ -38,9 +38,7 @@ Shell scripting is a very powerful, but dangerous, solution.
 
 #### Expect
 
-CNPM stands for "Company npm" and is a private npm registry software.
-
-[Website][expect]
+[Expect][expect] is a tool for automating interactive applications such as telnet, ftp, passwd, fsck, rlogin, tip, etc...
 
 - Good, because it is built with this purpose in mind
 - Good, because the syntax is very readable and straightforward.

--- a/docs/adr/007-use-verdaccio-for-emulating-publishing-npm-packages.md
+++ b/docs/adr/007-use-verdaccio-for-emulating-publishing-npm-packages.md
@@ -1,4 +1,4 @@
-# 005. Use Verdaccio for emulating publishing npm packages
+# 007. Use Verdaccio for emulating publishing npm packages
 
 Date: 21-dec-2021
 

--- a/resources/publish/.npmrc
+++ b/resources/publish/.npmrc
@@ -1,0 +1,6 @@
+# Publish to private registry
+registry=http://localhost:4873/
+
+# It is necessary to authenticate to publish in Verdaccio
+# Token for username="username", password="password"
+//localhost:4873/:_authToken="kSwBbr9NJVcgqZ4Kl4zufXavhs0H8aVgveIW8R9SftM="

--- a/resources/publish/config.yaml
+++ b/resources/publish/config.yaml
@@ -1,0 +1,13 @@
+storage: ./storage
+auth:
+  htpasswd:
+    file: ./resources/publish/htpasswd
+packages:
+  "@*/*":
+    access: $all
+    publish: $all
+  "**":
+    access: $all
+    publish: $all
+logs:
+  - { type: stdout, format: pretty, level: http }

--- a/resources/publish/htpasswd
+++ b/resources/publish/htpasswd
@@ -1,0 +1,1 @@
+username:$apr1$gwQzvrYX$hLkvErWORju3C1RS2.QrW0

--- a/resources/publish/htpasswd
+++ b/resources/publish/htpasswd
@@ -1,1 +1,3 @@
+# username:password pair.
+# Generated with `htpasswd -c htpasswd username`
 username:$apr1$gwQzvrYX$hLkvErWORju3C1RS2.QrW0

--- a/scripts/publish.exp
+++ b/scripts/publish.exp
@@ -1,0 +1,64 @@
+#!/usr/bin/expect -f
+
+# Empty dictionary
+set versions [dict create]
+
+# The first argument is a boolean
+# false - do not actually publish or commit anything
+# true - do publish to npm and generate the corresponding commit and tags in git
+set publish [lindex $argv 0]
+set argv [lrange $argv 1 end]
+
+# For each argument provided to this script, of the form packageName=version, split into [packageName, version]
+# and then add an entry version[packageName] = version to the $version dictionary
+foreach {arg} $argv {
+    set tokens [split $arg "="]
+    dict append versions [lindex $tokens 0] [lindex $tokens 1]
+}
+
+# Start the process by calling lerna version
+if { $publish } {
+    # If actually publishing, only allow the permitted branches
+    spawn npx lerna version
+} else {
+    # Fake publishing allowed on any branch, and doesn't change the upstream repo
+    spawn npx lerna version --no-push --allow-branch *
+}
+
+# Are there packages to version?
+expect {
+
+    # Next package to version
+    "Select a new version for " {
+
+        # Read package name, e.g. "@wiris/mathtype-generic"
+        expect -re {@wiris/\S+}
+        set package "$expect_out(0,string)"
+
+        # Read the current version of the package, e.g. "7.20.0"
+        expect -re {\(currently [^\)]+}
+        set current_version [lindex [split "$expect_out(0,string)" " "] 1]
+
+        # Send arrow key up + return to select "Custom Version"
+        send -- "\033\[A\r"
+
+        # Set the version to the one defined in the dictionary $versions, or to the current one if none is given
+        expect "Enter a custom version"
+        send [expr {[dict exists $versions $package] ? "[dict get $versions $package]\r" : "$current_version\r"}]
+
+        # Keep looking for packages to version, or finish otherwise
+        exp_continue
+
+    }
+
+    # No more packages to version
+    "Are you sure you want to create these versions?" {
+        # Send "yes" to go ahead
+        # If we are actually publishing, this finishes the job
+        # If we are fake publishing, this is okay as we set --no-push and the npm registry is local
+        send "y\r"
+    }
+
+}
+
+expect eof


### PR DESCRIPTION
## Description

This PR adds a new GitHub Actions workflow capable of automatically publishing the front-end npm packages.

It has two main additions:

- ADRs, justifying the technical decisions taken. Please read those and comment if there is any disagreements.
- Code changes, including:
  - A new workflow (`.github/workflows/publish.yml`).
  - A new Expect script (`scripts/publish.exp`) in charge of managing Lerna, used by the previous workflow.

---

[#taskid 17161](https://wiris.kanbanize.com/ctrl_board/2/cards/17161/details/)