### PR TITLE
NPM MathType Generic integration instructions lead to errors with close buttons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,9 @@ Last release of this project is was 30th of September 2021.
   - Update Webpack to V5 and remove jQuery, on mathtype-froala3 and its demos.
 
 - Accept non standard ports for host.
+
+- doc: Update Generic integration instructions with a missing step (#KB-19571)
+  - On `mathtype-generic` and `mathtype-html-integration-devkit` pacakges
 ## Unreleased
 
 - Start sending data to Cypress Dashboard with the published packages (KB-18683)

--- a/packages/mathtype-generic/README.md
+++ b/packages/mathtype-generic/README.md
@@ -64,6 +64,8 @@ To integrate MathType, please follow the steps below. Please, note you may adjus
      var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
      genericIntegrationInstance.init();
      genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+     WirisPlugin.currentInstance = this.wiris_generic;
    </script>
    ```
 
@@ -94,6 +96,8 @@ After following these steps, you should have something like this:
       var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
       genericIntegrationInstance.init();
       genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+      WirisPlugin.currentInstance = this.wiris_generic;
     </script>
   </body>
 </html>
@@ -198,6 +202,8 @@ To install the Java services, please, follow the steps below:
       var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
       genericIntegrationInstance.init();
       genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+      WirisPlugin.currentInstance = this.wiris_generic;
     </script>
     ```
 
@@ -230,6 +236,8 @@ To install the PHP services, please, follow the steps below:
       var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
       genericIntegrationInstance.init();
       genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+      WirisPlugin.currentInstance = this.wiris_generic;
     </script>
     ```
 
@@ -262,6 +270,8 @@ To install the ASP .NET services, please, follow the steps below:
       var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
       genericIntegrationInstance.init();
       genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+      WirisPlugin.currentInstance = this.wiris_generic;
     </script>
     ```
 
@@ -298,6 +308,8 @@ To install the Ruby on Rails services, please, follow the steps below:
       var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
       genericIntegrationInstance.init();
       genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+      WirisPlugin.currentInstance = this.wiris_generic;
     </script>
     ```
 

--- a/packages/mathtype-generic/getting_started.md
+++ b/packages/mathtype-generic/getting_started.md
@@ -35,6 +35,8 @@ To integrate MathType, please follow the steps below (you may adjust the example
         var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
         genericIntegrationInstance.init();
         genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+        WirisPlugin.currentInstance = this.wiris_generic;
     </script>
     ```
     This is the main step of the integration, doing the following:
@@ -59,17 +61,19 @@ The complete HTML code of the previuos example is the following:
         </div>
     </body>
     <script>
-    /**
-     * @type {integrationModelProperties}
-     */
-    var genericIntegrationProperties = {};
-    genericIntegrationProperties.target = document.getElementById("example");
-    genericIntegrationProperties.toolbar = document.getElementById("toolbarLocation");
+        /**
+         * @type {integrationModelProperties}
+         */
+        var genericIntegrationProperties = {};
+        genericIntegrationProperties.target = document.getElementById("example");
+        genericIntegrationProperties.toolbar = document.getElementById("toolbarLocation");
 
-    // GenericIntegration instance.
-    var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
-    genericIntegrationInstance.init();
-    genericIntegrationInstance.listeners.fire('onTargetReady', {});
+        // GenericIntegration instance.
+        var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
+        genericIntegrationInstance.init();
+        genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+        WirisPlugin.currentInstance = this.wiris_generic;
     </script>
 </html>
 ```

--- a/packages/mathtype-generic/services.md
+++ b/packages/mathtype-generic/services.md
@@ -27,6 +27,8 @@ To install the Java services follow the steps below:
         var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
         genericIntegrationInstance.init();
         genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+        WirisPlugin.currentInstance = this.wiris_generic;
     </script>
     ```
 
@@ -51,6 +53,8 @@ To install the PHP services follow the steps below:
         var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
         genericIntegrationInstance.init();
         genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+        WirisPlugin.currentInstance = this.wiris_generic;
     </script>
     ```
 
@@ -75,6 +79,8 @@ To install the .NET services follow the steps below:
         var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
         genericIntegrationInstance.init();
         genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+        WirisPlugin.currentInstance = this.wiris_generic;
     </script>
     ```
 
@@ -103,4 +109,6 @@ To install the Ruby on Rails services follow the steps below:
         var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
         genericIntegrationInstance.init();
         genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+        WirisPlugin.currentInstance = this.wiris_generic;
     </script>    ```

--- a/packages/mathtype-html-integration-devkit/doc/src/getting_started.md
+++ b/packages/mathtype-html-integration-devkit/doc/src/getting_started.md
@@ -35,6 +35,8 @@ To integrate MathType, please follow the steps below (you may adjust the example
         var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
         genericIntegrationInstance.init();
         genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+        WirisPlugin.currentInstance = this.wiris_generic;
     </script>
     ```
     This is the main step of the integration, doing the following:
@@ -59,17 +61,19 @@ The complete HTML code of the previuos example is the following:
         </div>
     </body>
     <script>
-    /**
-     * @type {integrationModelProperties}
-     */
-    var genericIntegrationProperties = {};
-    genericIntegrationProperties.target = document.getElementById("example");
-    genericIntegrationProperties.toolbar = document.getElementById("toolbarLocation");
+        /**
+         * @type {integrationModelProperties}
+         */
+        var genericIntegrationProperties = {};
+        genericIntegrationProperties.target = document.getElementById("example");
+        genericIntegrationProperties.toolbar = document.getElementById("toolbarLocation");
 
-    // GenericIntegration instance.
-    var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
-    genericIntegrationInstance.init();
-    genericIntegrationInstance.listeners.fire('onTargetReady', {});
+        // GenericIntegration instance.
+        var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
+        genericIntegrationInstance.init();
+        genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+        WirisPlugin.currentInstance = this.wiris_generic;
     </script>
 </html>
 ```

--- a/packages/mathtype-html-integration-devkit/doc/src/services_generic.md
+++ b/packages/mathtype-html-integration-devkit/doc/src/services_generic.md
@@ -28,6 +28,8 @@ To install the Java services follow the steps below:
         var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
         genericIntegrationInstance.init();
         genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+        WirisPlugin.currentInstance = this.wiris_generic;
     </script>
     ```
 
@@ -57,6 +59,8 @@ To install the PHP services follow the steps below:
         var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
         genericIntegrationInstance.init();
         genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+        WirisPlugin.currentInstance = this.wiris_generic;
     </script>
     ```
 
@@ -86,6 +90,8 @@ To install the .NET services follow the steps below:
         var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
         genericIntegrationInstance.init();
         genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+        WirisPlugin.currentInstance = this.wiris_generic;
     </script>
     ```
 
@@ -118,5 +124,7 @@ To install the Ruby on Rails services follow the steps below:
         var genericIntegrationInstance = new WirisPlugin.GenericIntegration(genericIntegrationProperties);
         genericIntegrationInstance.init();
         genericIntegrationInstance.listeners.fire('onTargetReady', {});
+
+        WirisPlugin.currentInstance = this.wiris_generic;
     </script>
     ```


### PR DESCRIPTION
## Description

The NPM generic MathType package documentation, on how to integrate MathType, is missing  the following step:

```js
WirisPlugin.currentInstance = this.wiris_generic;
```

This leads to errors when interacting with the close buttons on the MathType modal.

### Implementation

The files where the documentation was missing a step had been updated:
* `mathtype-generic` markdown files
* `mathtype-html-integration-devkit` markdown files

### Also included in this PR

Updated the CHANGELOG.md


## Steps to reproduce

* Follow the instructions on the [NPM mathtype-generic](https://www.npmjs.com/package/@wiris/mathtype-generic) page to integrate MathType on your application.
* When trying to close the MathType modal, a console error will appear and the modal will not close.

---

We realised there was a missing step thanks to the, already closed, #330 issue

[#taskid 19571](https://wiris.kanbanize.com/ctrl_board/2/cards/19571/details/)
