### PR TITLE
KB-13890: CKEditor5 integration language changes the toolbar buttons language except the wiris ones

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project is was 30th of September 2021.
 
+
 ## UNRELEASED
 
   - doc: add limitation disclaimer about inline limitations on ChemType and Safari #486.
@@ -40,7 +41,7 @@ Last release of this project is was 30th of September 2021.
 ## Unreleased
 
 - Start sending data to Cypress Dashboard with the published packages (KB-18683)
-
+- Fix toolbar wiris buttons static label issue on CKEditor5 (KB-13890).
 ## 7.27.2 - 2021-11-26
 
 ## CKEditor5 filtering mechanism

--- a/demos/html5/ckeditor5/package.json
+++ b/demos/html5/ckeditor5/package.json
@@ -11,14 +11,14 @@
   "author": "WIRIS Team (http://www.wiris.com)",
   "license": "MIT",
   "dependencies": {
-    "@ckeditor/ckeditor5-alignment": ">=27.1.0",
-    "@ckeditor/ckeditor5-basic-styles": ">=27.1.0",
-    "@ckeditor/ckeditor5-dev-utils": "^12.0.9",
-    "@ckeditor/ckeditor5-editor-classic": ">=27.1.0",
-    "@ckeditor/ckeditor5-essentials": ">=27.1.0",
-    "@ckeditor/ckeditor5-paragraph": ">=27.1.0",
-    "@ckeditor/ckeditor5-theme-lark": ">=27.1.0",
-    "@wiris/mathtype-ckeditor5": "^7.26.1",
+    "@ckeditor/ckeditor5-alignment": ">=31.1.0",
+    "@ckeditor/ckeditor5-basic-styles": ">=31.1.0",
+    "@ckeditor/ckeditor5-dev-utils": "^28.0.1",
+    "@ckeditor/ckeditor5-editor-classic": ">=31.1.0",
+    "@ckeditor/ckeditor5-essentials": ">=31.1.0",
+    "@ckeditor/ckeditor5-paragraph": ">=31.1.0",
+    "@ckeditor/ckeditor5-theme-lark": ">=31.1.0",
+    "@wiris/mathtype-ckeditor5": "^7.27.2",
     "@wiris/mathtype-html-integration-devkit": "*"
   },
   "devDependencies": {

--- a/packages/mathtype-ckeditor5/src/integration.js
+++ b/packages/mathtype-ckeditor5/src/integration.js
@@ -43,7 +43,7 @@ export default class CKEditor5Integration extends IntegrationModel {
         // eslint-disable-next-line no-prototype-builtins
         if (languageObject.hasOwnProperty('ui')) {
           return languageObject.ui;
-        } return super.getLanguage();
+        } return languageObject;
       }
       return languageObject;
     }

--- a/packages/mathtype-ckeditor5/src/plugin.js
+++ b/packages/mathtype-ckeditor5/src/plugin.js
@@ -18,6 +18,7 @@ import Configuration from '@wiris/mathtype-html-integration-devkit/src/configura
 import Listeners from '@wiris/mathtype-html-integration-devkit/src/listeners';
 import MathML from '@wiris/mathtype-html-integration-devkit/src/mathml';
 import Latex from '@wiris/mathtype-html-integration-devkit/src/latex';
+import StringManager from '@wiris/mathtype-html-integration-devkit/src/stringmanager';
 
 // Local imports
 import { MathTypeCommand, ChemTypeCommand } from './commands';
@@ -140,7 +141,7 @@ export default class MathType extends Plugin {
       view.bind('isEnabled').to(editor.commands.get('MathType'), 'isEnabled');
 
       view.set({
-        label: 'Insert a math equation - MathType',
+        label: StringManager.get('insert_math'),
         icon: mathIcon,
         tooltip: true,
       });
@@ -163,7 +164,7 @@ export default class MathType extends Plugin {
       view.bind('isEnabled').to(editor.commands.get('ChemType'), 'isEnabled');
 
       view.set({
-        label: 'Insert a chemistry formula - ChemType',
+        label: StringManager.get('insert_chem'),
         icon: chemIcon,
         tooltip: true,
       });


### PR DESCRIPTION
## Description

The mathtype integration with CKEditor5, made both from CKEditor builder or npm dependencies, does not update the tooltip language. The editor and mathtype modal are both in the specified language while the toolbar Wiris buttons are shown in English. 

This issue was because the label on the Wiris toolbar buttons was static, so when the editor had a different language defined than english, the buttons were still in english.

This PR solves this issue by making the label button property dynamic instead of static.

> **Note**: this PR has been recovered from a reverted state at the KB-13890 branch.

## Steps to reproduce

1. Clone the repo
2. Edit lerna.json to compile the `demos/html5/ckeditor5` demo
3. Run `npm install`
4. Run `npm start`
2. Edit the demo and define a language following the CKEditor5 guidelines
  * Edit `demos/html5/ckeditor5/src/app.js`
  * Set `language: 'es',`
3. Validate that the Wiris buttons labels are set in the defined language


https://user-images.githubusercontent.com/85346791/151220333-bdc4b31b-50bd-42e4-8cb7-3f67bdc4e6c6.mp4

## Considerations

* This PR fixes the language bug on CKEditor5, only
* This bug occurs on this demos, too: CKEditor4, Froala2 and Froala3+.

---

[#taskid 13890](https://wiris.kanbanize.com/ctrl_board/2/cards/13890/details/)
