### PR TITLE
fix(froala3): Solve top right buttons not showing

### DIFF
--- a/packages/mathtype-froala3/webpack.config.js
+++ b/packages/mathtype-froala3/webpack.config.js
@@ -45,17 +45,23 @@ module.exports = {
                 // The following expresion, looks for all the svg files inside the devkit folder and subfolders
                 // /mathtype-html-integration-devkit\/?(?:[^\/]+\/?)*.svg$/
                 test: /mathtype-html-integration-devkit\/styles\/icons\/[^\/]+\/[^\/]+\.svg$/,
-                type: 'asset/source'
+                use: [ 'raw-loader' ]
             },
             {
                 test: /\.(png|ttf|otf|eot|svg|woff(2)?)(.*)?$/,
                 exclude: /mathtype-html-integration-devkit\/styles\/icons\/[^\/]+\/[^\/]+\.svg$/,
-                type: 'asset'
+                use: [
+                  {
+                    loader: 'url-loader',
+                    options: {
+                      limit: 8192
+                    }
+                  }
+                ]
             }
         ]
     },
     stats: {
         colors: true
-    },
-    mode: 'none'
+    }
 };


### PR DESCRIPTION
## Description

The BUGSPRINT branch contains adds a new bug when updating the mathtype-froala3 package webpack to v5. The top right MathType buttons are functional but not visible. See the image below for clarification.
![image](https://user-images.githubusercontent.com/60604864/156750137-397ac6b8-9966-4acc-95fc-99cae45d3860.png)

### Why does the bug happens?

On webpack v4, the icons are loaded through raw-loader with the following pre-fix: `!!raw-loader!`, which is not supported on v5.

### The solution

Downgrade mathtype-froala3 to **webpack** v4 and destinate a single task to upgrade all the webpack versions.

## Steps to reproduce

1. Copy the content from the lerna.demos.json to the lerna.json file.
2. Run the follwing commands on the root project:
  ```shell
   npm install
   npm run start
  ```
3. Go to the **demos/html5/froala** folder
4. Run `npm run` start
5. Open the MathType modal.

---

[#taskid 21424](https://wiris.kanbanize.com/ctrl_board/2/cards/21424/details/)
