### PR TITLE
fix(tinymce): Redo & undo buttons broken

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project is was 30th of September 2021.
 
+## UNRELEASED
+
+* Fix the redo & undo buttons not working on TinyMCE when interacting with MathType formulas. (KB-14441)
 
 ## 7.28.0 2022-03-24
 

--- a/packages/mathtype-tinymce/editor_plugin.src.js
+++ b/packages/mathtype-tinymce/editor_plugin.src.js
@@ -80,6 +80,29 @@ export class TinyMceIntegration extends IntegrationModel {
     return langParam || super.getLanguage();
   }
 
+  /** @inheritdoc */
+  insertFormula(focusElement, windowTarget, mathml, wirisProperties) {
+    // Due to insertFormula adds an image using pure JavaScript functions,
+    // it is needed notificate to the editorObject that placeholder status
+    // has to be updated.
+    const obj = super.insertFormula(focusElement, windowTarget, mathml, wirisProperties);
+
+    // Add formula to undo & redo
+    this.editorObject.undoManager.add(obj);
+
+    // Delete temporal image when inserting a formula
+    this.core.editionProperties.temporalImage = null;
+    return obj;
+  }
+
+  updateFormula(mathml) {
+    const obj = super.updateFormula(mathml);
+
+    // Add modified formula to undo & redo
+    this.editorObject.undoManager.add(obj);
+    return obj;
+  }
+
   /**
      * Callback function called before 'onTargetLoad' is fired. All the logic here is to
      * avoid TinyMCE change MathType formulas.


### PR DESCRIPTION
The redo & undo buttons were broken when interacting
with the MathType formulas

## Description

This PR fixes the following issue: If the user inserts a formula in TinyMCE4 or TinyMCE5 and then presses the Undo button followed by the Redo button, the formula that should be recovered, will be lost.

### How is this solved

This has been solved by adding the edited and created formulas on a TinyMCE queue that stores the changes made by the Undo and Redo buttons

### Also in this PR

* Updated the Changes.md

## Steps to reproduce

1. Open TinyMCE4 or TinyMCE5 demo.
2. Create and Insert a formula using MT or CT.
3. Click the Undo button. The formula disappears.
4. Click the Redo button.

---

Closes #275 

[#taskid 14441](https://wiris.kanbanize.com/ctrl_board/2/cards/14441/details/)