### PR TITLE
fix(mobile): MT CT Editor responsiveness

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Last release of this project is was 30th of September 2021.
     - React
   - Add a dummy TinyMCE6 package.
   - Update related documentation and files to include the new TinyMCE V6 demos and package.
+  - Fix MT/CT Editor mobile responsiveness
 
 ## 7.28.0 2022-03-24
 

--- a/packages/mathtype-html-integration-devkit/styles/styles.css
+++ b/packages/mathtype-html-integration-devkit/styles/styles.css
@@ -193,6 +193,7 @@
 
 .wrs_content_container.wrs_modal_android {
   width: 100%;
+  height: 0%;
   flex-grow: 1;
   display: flex;
   flex-direction: column;
@@ -227,6 +228,7 @@
 
 .wrs_content_container.wrs_modal_ios {
   width: 100%;
+  height: 0%;
   flex-grow: 1;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Description

This PR fix the next issue on **mobile devices**: 

- When MT/CT Editor is open some elements are moved out of the screen, this causes that the buttons to `Insert` formula or `Cancel` the insertion are unclickable for the user, making the editor unusable.
- When switching the view mode from Landscape to Portrait and vice verse the editor is not reorganized correctly.
- In some screen size, the toolbar buttons from the MT/CT Editor doesn't appear.

### How is this solved

HTML elements inside the div with the class `wrs_content_container` force this element to grow and displacing the other adjacent elements. Setting `height:0%` to the class `wrs_content_container` fix the issue as the container will fill the flexbox area but will not grow more.

### Also in this PR

* Updated the Changes.md

## Steps to reproduce

1. Open a demo from html-integrations
2. Open the DevTools (CTRL+SHIFT+I)
3. Click on the Mobile icon from top left bar from inspector (CTRL+SHIFT+M) to activate the mobile view
4. Reload the page
5. Click on the MT Icon from the HTML Editor
6. Try to switch between Landscape and Portrait modes using the Rotate button from the top bar of the Inspector view area

---
[#taskid 23502](https://wiris.kanbanize.com/ctrl_board/2/cards/23502/details/)
