### PR TITLE
Return focus when cancel the process on MT/CT Editor

### DIFF
--- a/packages/mathtype-html-integration-devkit/src/popupmessage.js
+++ b/packages/mathtype-html-integration-devkit/src/popupmessage.js
@@ -131,6 +131,7 @@ export default class PopUpMessage {
     this.overlayWrapper.style.display = 'none';
     if (typeof this.callbacks.cancelCallback !== 'undefined') {
       this.callbacks.cancelCallback();
+      IntegrationModel.setActionsOnCancelButtons();
     }
   }
 
@@ -141,7 +142,6 @@ export default class PopUpMessage {
   closeAction() {
     // Set temporal image to null to prevent loading
     // an existent formula when strarting one from scrath. Make focus come back too.
-    IntegrationModel.setActionsOnCancelButtons();
     this.cancelAction();
     if (typeof this.callbacks.closeCallback !== 'undefined') {
       this.callbacks.closeCallback();


### PR DESCRIPTION
## Description

This PR fix the issue: when user opens the MathType Editor and starts writing a formula and cancels the process by clicking on Cancel, the HTML Editor is not focused, i.e., the user doesn't see the caret is placed where it was before opening MathType.

### How is this solved

Now the function `setActionsOnCancelButtons()` is called after `cancelCallback()`. 

### Also in this PR

* Updated the Changes.md

## Steps to reproduce

1. Open the demo
2. Click on the MT icon
3. Type anything inside the MT Editor
4. Click on the Cancel button (it triggers the "Are you sure you want to leave?" dialog)
5. Click on the Close button

---
[#taskid 21616](https://wiris.kanbanize.com/ctrl_board/2/cards/21616/details/)
