### PR TITLE
fix: focus when cancel insertion mt editor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Last release of this project is was 30th of September 2021.
   - Add a dummy TinyMCE6 package.
   - Update related documentation and files to include the new TinyMCE V6 demos and package.
   - Fix MT/CT Editor mobile responsiveness
+  - Fix focus when cancel insertion mt editor
 
 ## 7.28.0 2022-03-24
 

--- a/packages/mathtype-html-integration-devkit/src/popupmessage.js
+++ b/packages/mathtype-html-integration-devkit/src/popupmessage.js
@@ -131,6 +131,9 @@ export default class PopUpMessage {
     this.overlayWrapper.style.display = 'none';
     if (typeof this.callbacks.cancelCallback !== 'undefined') {
       this.callbacks.cancelCallback();
+      // Set temporal image to null to prevent loading
+      // an existent formula when strarting one from scrath. Make focus come back too.
+      IntegrationModel.setActionsOnCancelButtons();
     }
   }
 
@@ -139,9 +142,6 @@ export default class PopUpMessage {
    * For example to close the overlaid element.
    */
   closeAction() {
-    // Set temporal image to null to prevent loading
-    // an existent formula when strarting one from scrath. Make focus come back too.
-    IntegrationModel.setActionsOnCancelButtons();
     this.cancelAction();
     if (typeof this.callbacks.closeCallback !== 'undefined') {
       this.callbacks.closeCallback();


### PR DESCRIPTION
## Description
This PR fix the issue: when user opens the MathType Editor and starts writing a formula and cancels the process by clicking on Cancel, the HTML Editor is not focused, i.e., the user doesn't see the caret is placed where it was before opening MathType.
### How is this solved
Now the function `setActionsOnCancelButtons()` is called after `cancelCallback()`.
### Also in this PR
* Updated the Changes.md
## Steps to reproduce
1. Open the demo
2. Click on the MT icon
3. Type anything inside the MT Editor
4. Click on the Cancel button (it triggers the "Are you sure you want to leave?" dialog)
5. Click on the Close button
---
[#taskid 21616](https://wiris.kanbanize.com/ctrl_board/2/cards/21616/details/)
