### PR TITLE
fix: caret after the formula on first insertion

### DIFF
--- a/packages/mathtype-ckeditor5/src/integration.js
+++ b/packages/mathtype-ckeditor5/src/integration.js
@@ -162,6 +162,10 @@ export default class CKEditor5Integration extends IntegrationModel {
             writer.remove(this.editorObject.editing.mapper.toModelRange(range));
           }
         }
+
+        // Set carret after the formula
+        const position = this.editorObject.model.createPositionAfter(modelElementNew);
+        writer.setSelection(position);
       } else {
         const img = core.editionProperties.temporalImage;
         const viewElement = this.editorObject.editing.view.domConverter.domToView(img).parent;


### PR DESCRIPTION
## Description

When opening the CK Editor 5 demo and directly inserting a formula in the HTML Editor by clicking the MT/CT icon, the caret is placed before the fomula.

## Steps to reproduce

1. Open the CK Editor 5 demo
2. Click on the MT icon on the HTML Editor (it opens the MT modal window)
3. Insert any equation on the MT modal window and click on Insert (the formula is inserted in the HTML Editor)

---

[#taskid 21516](https://wiris.kanbanize.com/ctrl_board/2/cards/21516/details/)
