### PR TITLE
feat(mobile): reset and lock zoom when open MT/CT Editor on mobile

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@ Last release of this project is was 30th of September 2021.
 
 ## UNRELEASED
 
+  - Fix caret after the formula on first insertion
+  - Added reset and lock zoom when open MT/CT Editor on mobile
+
+## 7.28.1 2022-05-09
+
   - Fix the redo & undo buttons not working on TinyMCE when interacting with MathType formulas. (KB-14441)
   - Create TinyMCE V6 demos for:
     - HTML5


### PR DESCRIPTION
## Description

When the MT/CT Editor is open with a zoomed page, the Insert/Cancel buttons are not visible. In order to make them visible, the user needs to zoom out but if he/she exceeds the "zoom out limit" the page refreshes and the MT/CT Editor is closed.

In iPhones it is impossible to zoom out as the pinch zoom event is not detected when the handwritte fill the whole screen.

### How is this solved

Changed the funtion `restoreWebsiteScale` from `modal.js` (now named `setEditorViewport`). When the MT/CT Editor are open using a mobile, we check if the webpage have a [meta viewport HTML element](https://www.w3schools.com/css/css_rwd_viewport.asp), If exist we update this meta element to reset and lock the zoom scale. If not exist we create the meta element.

When the MT/CT Editor is close we reset the original meta viewport HTML element from the webpage. 

### Also in this PR

* Updated the Changes.md

## Steps to reproduce

1. Open a demo from html-integrations
2. Open the DevTools (CTRL+SHIFT+I)
3. Click on the Mobile icon from top left bar from inspector (CTRL+SHIFT+M) to activate the mobile view
4. Select iPhone 6/7/8 Plus as device
5. Reload the page
6. Make zoom (Press shift then click and drag with the mouse)
7. Open the MT Icon

The Editor must be fully visible and the user cannot zoom.

8. Close the MT Editor
9. Try making zoom

The user can make zoom when the MT/CT Editor is closed.

---

[#taskid 24192](https://wiris.kanbanize.com/ctrl_board/2/cards/24192/details/)

