### PR TITLE
fix: open MT/CT Editor in Keybord mode when using iOS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,12 @@ Last release of this project is was 30th of September 2021.
 
 ## UNRELEASED
 
+  - fix: caret after the formula on first insertion
+  - fix: chemEnabled & editorEnabled config
+  - fix: open MT/CT Editor in Keyboard mode when using iOS
+
+## 7.28.1 2022-05-09
+
   - Fix the redo & undo buttons not working on TinyMCE when interacting with MathType formulas. (KB-14441)
   - Create TinyMCE V6 demos for:
     - HTML5

--- a/packages/mathtype-html-integration-devkit/src/contentmanager.js
+++ b/packages/mathtype-html-integration-devkit/src/contentmanager.js
@@ -447,6 +447,28 @@ export default class ContentManager {
     }
     this.updateToolbar();
     this.onFocus();
+    
+    if (this.deviceProperties.isIOS) {
+      const zoom = document.documentElement.clientWidth / window.innerWidth;
+
+      if (zoom != 1) {
+        // Open editor in Keyboard mode if user use iOS, Safari and page is zoomed.
+        this.setKeyboardMode();
+      }
+    }
+  }
+
+  /**
+   * Change Editor in keyboard mode when is loaded
+   */
+  setKeyboardMode() {
+    const wrsEditor = document.getElementsByClassName('wrs_handOpen wrs_disablePalette')[0];
+    if (wrsEditor) {
+      wrsEditor.classList.remove('wrs_handOpen');
+      wrsEditor.classList.remove('wrs_disablePalette');
+    } else {
+      setTimeout(ContentManager.prototype.setKeyboardMode.bind(this), 100);
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

When the user opens the MT/CT Editor using an iOS device with zoomed webpage. The user will not be able to zoom out on the handwrite area.

Now, the MT/CT Editor will be open on keyboard mode when using an iOS device by default.

If the user use Safari and doesn't zoom, the page will be opened in handwrite mode. This will not happen in Chrome, as I didn't found a way to detect the zoom level of the page.

## Steps to reproduce

1. Open a demo on `html-integrations`
2. With an iOS device, navigate to the opened demo using Safari
3. Zoom the web page
4. Open the MT Editor

The MT Editor will be opened in Keyboard mode

5. Close the MT Editor
6. Reset the page
7. Open the MT Editor without zooming the page

The MT Editor will be opened in Handwrite mode

---

[#taskid 24192](https://wiris.kanbanize.com/ctrl_board/2/cards/24192/details/)
