### PR TITLE
fix: chemEnabled & editorEnabled config

### DIFF
--- a/packages/mathtype-ckeditor4/plugin.src.js
+++ b/packages/mathtype-ckeditor4/plugin.src.js
@@ -49,6 +49,16 @@ export class CKEditor4Integration extends IntegrationModel {
     if ('wiriseditorparameters' in editor.config) {
       Configuration.update('editorParameters', editor.config.wiriseditorparameters);
     }
+
+    // Hide MathType toolbar button if is disabled by config.
+    if (!Configuration.get('editorEnabled')) {
+      document.getElementsByClassName('cke_button__ckeditor_wiris_formulaeditor')[0].style.display = 'none';
+    }
+  
+    // Hide ChemType toolbar button if is disabled by config.
+    if (!Configuration.get('chemEnabled')) {
+      document.getElementsByClassName('cke_button__ckeditor_wiris_formulaeditorchemistry')[0].style.display = 'none';
+    }
   }
 
   /**

--- a/packages/mathtype-ckeditor5/src/plugin.js
+++ b/packages/mathtype-ckeditor5/src/plugin.js
@@ -133,51 +133,57 @@ export default class MathType extends Plugin {
   _addViews(integration) {
     const { editor } = this;
 
-    // Add button for the formula editor
-    editor.ui.componentFactory.add('MathType', (locale) => {
-      const view = new ButtonView(locale);
+    // Check if MathType editor is enabled
+    if (Configuration.get('editorEnabled')) {
+      // Add button for the formula editor
+      editor.ui.componentFactory.add('MathType', (locale) => {
+        const view = new ButtonView(locale);
 
-      // View is enabled iff command is enabled
-      view.bind('isEnabled').to(editor.commands.get('MathType'), 'isEnabled');
+        // View is enabled iff command is enabled
+        view.bind('isEnabled').to(editor.commands.get('MathType'), 'isEnabled');
 
-      view.set({
-        label: StringManager.get('insert_math'),
-        icon: mathIcon,
-        tooltip: true,
-      });
-
-      // Callback executed once the image is clicked.
-      view.on('execute', () => {
-        editor.execute('MathType', {
-          integration, // Pass integration as parameter
+        view.set({
+          label: StringManager.get('insert_math'),
+          icon: mathIcon,
+          tooltip: true,
         });
-      });
 
-      return view;
-    });
-
-    // Add button for the chemistry formula editor
-    editor.ui.componentFactory.add('ChemType', (locale) => {
-      const view = new ButtonView(locale);
-
-      // View is enabled iff command is enabled
-      view.bind('isEnabled').to(editor.commands.get('ChemType'), 'isEnabled');
-
-      view.set({
-        label: StringManager.get('insert_chem'),
-        icon: chemIcon,
-        tooltip: true,
-      });
-
-      // Callback executed once the image is clicked.
-      view.on('execute', () => {
-        editor.execute('ChemType', {
-          integration, // Pass integration as parameter
+        // Callback executed once the image is clicked.
+        view.on('execute', () => {
+          editor.execute('MathType', {
+            integration, // Pass integration as parameter
+          });
         });
-      });
 
-      return view;
-    });
+        return view;
+      });
+    }
+
+    // Check if ChemType editor is enabled
+    if (Configuration.get('chemEnabled')) {
+      // Add button for the chemistry formula editor
+      editor.ui.componentFactory.add('ChemType', (locale) => {
+        const view = new ButtonView(locale);
+
+        // View is enabled iff command is enabled
+        view.bind('isEnabled').to(editor.commands.get('ChemType'), 'isEnabled');
+
+        view.set({
+          label: StringManager.get('insert_chem'),
+          icon: chemIcon,
+          tooltip: true,
+        });
+
+        // Callback executed once the image is clicked.
+        view.on('execute', () => {
+          editor.execute('ChemType', {
+            integration, // Pass integration as parameter
+          });
+        });
+
+        return view;
+      });
+    }
 
     // Observer for the double click event
     editor.editing.view.addObserver(ClickObserver);
@@ -335,8 +341,8 @@ export default class MathType extends Plugin {
             we must create a new EmptyElement which is independent of the
             DataProcessor being used by this editor instance */
       return viewWriter.createEmptyElement('img', imgElement.getAttributes(), {
-        renderUnsafeAttributes: [ 'src' ]
-      } );
+        renderUnsafeAttributes: ['src'],
+      });
     }
 
     // Model -> Editing view

--- a/packages/mathtype-froala/wiris.src.js
+++ b/packages/mathtype-froala/wiris.src.js
@@ -85,6 +85,24 @@ export class FroalaIntegration extends IntegrationModel {
     });
 
     super.init();
+
+    // Hide MathType toolbar button if is disabled by config.
+    if (!Configuration.get('editorEnabled')) {
+      // eslint-disable-next-line no-undef
+      $.FroalaEditor.ICONS.wirisEditor = null;
+      // eslint-disable-next-line no-undef
+      $.FroalaEditor.COMMANDS.wirisEditor = null;
+      document.getElementById('wirisEditor-1').classList.add('fr-hidden');
+    }
+
+    // Hide ChemType toolbar button if is disabled by config.
+    if (!Configuration.get('chemEnabled')) {
+      // eslint-disable-next-line no-undef
+      $.FroalaEditor.ICONS.wirisChemistry = null;
+      // eslint-disable-next-line no-undef
+      $.FroalaEditor.COMMANDS.wirisChemistry = null;
+      document.getElementById('wirisChemistry-1').classList.add('fr-hidden');
+    }
   }
 
   /**

--- a/packages/mathtype-froala3/wiris.src.js
+++ b/packages/mathtype-froala3/wiris.src.js
@@ -88,6 +88,20 @@ export class FroalaIntegration extends IntegrationModel {
     });
 
     super.init();
+
+    // Hide MathType toolbar button if is disabled by config.
+    if (!Configuration.get('editorEnabled')) {
+      FroalaEditor.ICONS.wirisEditor = null;
+      FroalaEditor.COMMANDS.wirisEditor = null;
+      document.getElementById('wirisEditor-1').classList.add('fr-hidden');
+    }
+
+    // Hide ChemType toolbar button if is disabled by config.
+    if (!Configuration.get('chemEnabled')) {
+      FroalaEditor.ICONS.wirisChemistry = null;
+      FroalaEditor.COMMANDS.wirisChemistry = null;
+      document.getElementById('wirisChemistry-1').classList.add('fr-hidden');
+    }
   }
 
   /**

--- a/packages/mathtype-generic/wirisplugin-generic.src.js
+++ b/packages/mathtype-generic/wirisplugin-generic.src.js
@@ -1,4 +1,5 @@
 import IntegrationModel from '@wiris/mathtype-html-integration-devkit/src/integrationmodel';
+import Configuration from '@wiris/mathtype-html-integration-devkit/src/configuration';
 import Parser from '@wiris/mathtype-html-integration-devkit/src/parser';
 import Util from '@wiris/mathtype-html-integration-devkit/src/util';
 import formulaIcon from './icons/formula.png';
@@ -110,24 +111,28 @@ export default class GenericIntegration extends IntegrationModel {
       this.target.innerHTML = Parser.initParse(this.target.innerHTML);
     }
 
-    /* Creating toolbar buttons */
-    const formulaButton = document.createElement('img');
-    formulaButton.id = 'editorIcon';
-    formulaButton.src = formulaIcon;
-    formulaButton.style.cursor = 'pointer';
+    // Check if MathType is enabled
+    if (Configuration.get('editorEnabled')) {
+      /* Creating toolbar buttons */
+      const formulaButton = document.createElement('img');
+      formulaButton.id = 'editorIcon';
+      formulaButton.src = formulaIcon;
+      formulaButton.style.cursor = 'pointer';
 
-    Util.addEvent(formulaButton, 'click', () => {
-      this.core.getCustomEditors().disable();
-      this.openNewFormulaEditor();
-    });
+      Util.addEvent(formulaButton, 'click', () => {
+        this.core.getCustomEditors().disable();
+        this.openNewFormulaEditor();
+      });
 
-    this.toolbar.appendChild(formulaButton);
+      this.toolbar.appendChild(formulaButton);
+    }
 
     // Dynamic customEditors buttons.
     const customEditors = this.getCore().getCustomEditors();
     // Iterate from all custom editors.
     for (const customEditor in customEditors.editors) {
-      if (customEditors.editors[customEditor].confVariable) {
+      // Check if CustomEditor is enabled
+      if (Configuration.get(customEditors.editors[customEditor].confVariable)) {
         const customEditorButton = document.createElement('img');
         // TODO make this work and add promises polyfill
         // import('./icons/' + customEditors.editors[customEditor].icon).then(({default: customEditorIcon}) => {

--- a/packages/mathtype-tinymce/editor_plugin.src.js
+++ b/packages/mathtype-tinymce/editor_plugin.src.js
@@ -407,18 +407,22 @@ export const currentInstance = null;
         commonEditor.addIcon(mathTypeIcon, mathTypeIconSvg);
         commonEditor.addIcon(chemTypeIcon, chemTypeIconSvg);
 
-        // The next two blocks create menu items to give the possibility
-        // of add MathType in the menubar.
-        commonEditor.addMenuItem('tiny_mce_wiris_formulaEditor', {
-          text: 'MathType',
-          icon: mathTypeIcon,
-          onAction: openFormulaEditorFunction,
-        });
+        // Check if MathType editor is enabled
+        if (Configuration.get('editorEnabled')) {
+          // The next two blocks create menu items to give the possibility
+          // of add MathType in the menubar.
+          commonEditor.addMenuItem('tiny_mce_wiris_formulaEditor', {
+            text: 'MathType',
+            icon: mathTypeIcon,
+            onAction: openFormulaEditorFunction,
+          });
+        }
 
         // Dynamic customEditors buttons.
         const customEditors = WirisPlugin.instances[editor.id].getCore().getCustomEditors();
         Object.keys(customEditors.editors).forEach((customEditor) => {
-          if (customEditors.editors[customEditor].confVariable) {
+          // Check if CustomEditor editor is enabled
+          if (Configuration.get(customEditors.editors[customEditor].confVariable)) {
             commonEditor.addMenuItem(`tiny_mce_wiris_formulaEditor${customEditors.editors[customEditor].name}`, {
               text: customEditors.editors[customEditor].title,
               icon: chemTypeIcon, // Parametrize when other custom editors are added.
@@ -434,22 +438,26 @@ export const currentInstance = null;
         commonEditor.addCommand('tiny_mce_wiris_openFormulaEditor', openFormulaEditorFunction);
       }
 
-      // MathType button.
-      // Cmd Parameter is needed in TinyMCE4 and onAction parameter is needed in TinyMCE5.
-      // For more details see TinyMCE migration page: https://www.tiny.cloud/docs-preview/migration-from-4.x/
-      commonEditor.addButton('tiny_mce_wiris_formulaEditor', {
-        tooltip: 'Insert a math equation - MathType', // TinyMCE3
-        title: 'Insert a math equation - MathType',
-        cmd: 'tiny_mce_wiris_openFormulaEditor',
-        image: `${WirisPlugin.instances[editor.id].getIconsPath()}formula.png`,
-        onAction: openFormulaEditorFunction,
-        icon: mathTypeIcon,
-      });
+      // Check if MathType editor is enabled
+      if (Configuration.get('editorEnabled')) {
+        // MathType button.
+        // Cmd Parameter is needed in TinyMCE4 and onAction parameter is needed in TinyMCE5.
+        // For more details see TinyMCE migration page: https://www.tiny.cloud/docs-preview/migration-from-4.x/
+        commonEditor.addButton('tiny_mce_wiris_formulaEditor', {
+          tooltip: 'Insert a math equation - MathType', // TinyMCE3
+          title: 'Insert a math equation - MathType',
+          cmd: 'tiny_mce_wiris_openFormulaEditor',
+          image: `${WirisPlugin.instances[editor.id].getIconsPath()}formula.png`,
+          onAction: openFormulaEditorFunction,
+          icon: mathTypeIcon,
+        });
+      }
 
       // Dynamic customEditors buttons.
       const customEditors = WirisPlugin.instances[editor.id].getCore().getCustomEditors();
       for (const customEditor in customEditors.editors) {
-        if (customEditors.editors[customEditor].confVariable) {
+        // Check if CustomEditor editor is enabled
+        if (Configuration.get(customEditors.editors[customEditor].confVariable)) {
           const cmd = `tiny_mce_wiris_openFormulaEditor${customEditors.editors[customEditor].name}`;
           // eslint-disable-next-line no-inner-declarations, no-loop-func
           function commandFunction() {


### PR DESCRIPTION
## Description

This PR fix the configuration issue: `chemEnabled` and `editorEnabled` configuration parameters are being ignored.

`chemEnabled` remove the ChemType toolbar button and `editorEnabled` remove the MathType toolbar button.

This bug is fixed in each editor package individualy. In `CKEditor4`, `Froala` and `Froala3` the buttons are hidden after being created because the configuration is not already loaded when the buttons and commands are added on the editor.

## Steps to reproduce

This PR will be reproduced on `plugins` project.

1. Add `html-integration` and `plugins` projects on the same folder.
2. Change the branch from `html-integrations` to `KB-16434-B`.
3. Open a demo on `plugins` project using `php` backend.
4. Navigate to `plugins/output/php/`.
5. Find the folder with the `configuration.ini.dist` file and rename it to `configuration.ini`. This file will be in a diferent folder for each editor e.g. When using generic the route is `plugins/output/php/generic_wiris/generic_wiris/`.
6. On file `configuration.ini` uncomment `wirischemeditorenabled` and `wiriseditorenabled` parameters. Set both to `false`.
7. Open the demo with the browser.

The MathType and ChemType buttons should not appear. 

8. On file `configuration.ini` set `wirischemeditorenabled` and `wiriseditorenabled` parameters to `true`.
9. Reload the page

The MathType and ChemType buttons should appear. 

---

[#taskid 16434](https://wiris.kanbanize.com/ctrl_board/2/cards/16434/details/)
