### PR TITLE
fix: add dompurify dependency and sanitize mathml to prevent XSS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Last release of this project is was 30th of September 2021.
 
 ## 7.30.0 2022-07-20
 
+  - fix: add dompurify dependenci and sanitize mathml to prevent XSS
   - fix: stop setting data parameter on text nodes
   - feat: create plugin for TinyMCE 6
 

--- a/packages/mathtype-ckeditor5/src/plugin.js
+++ b/packages/mathtype-ckeditor5/src/plugin.js
@@ -256,6 +256,11 @@ export default class MathType extends Plugin {
       // And obtain the complete formula
       formula = `<math${mathAttributes}>${formula}</math>`;
 
+      // Skip if mathml contains a XSS injection
+      if (Util.containsXSS(formula)) {
+        return;
+      }
+
       /* Model node that contains what's going to actually be inserted. This can be either:
             - A <mathml> element with a formula attribute set to the given formula, or
             - If the original <math> had a LaTeX annotation, then the annotation surrounded by "$$...$$" */
@@ -324,7 +329,9 @@ export default class MathType extends Plugin {
 
       const mathUIElement = createViewImage(modelItem, { writer: viewWriter }); // eslint-disable-line no-use-before-define
 
-      viewWriter.insert(viewWriter.createPositionAt(widgetElement, 0), mathUIElement);
+      if (mathUIElement) {
+        viewWriter.insert(viewWriter.createPositionAt(widgetElement, 0), mathUIElement);
+      }
 
       return toWidget(widgetElement, viewWriter);
     }
@@ -339,9 +346,13 @@ export default class MathType extends Plugin {
       /* Although we use the HtmlDataProcessor to obtain the attributes,
             we must create a new EmptyElement which is independent of the
             DataProcessor being used by this editor instance */
-      return viewWriter.createEmptyElement('img', imgElement.getAttributes(), {
-        renderUnsafeAttributes: ['src'],
-      });
+      if (imgElement) {
+        return viewWriter.createEmptyElement('img', imgElement.getAttributes(), {
+          renderUnsafeAttributes: ['src'],
+        });
+      }
+
+      return null;
     }
 
     // Model -> Editing view

--- a/packages/mathtype-html-integration-devkit/package.json
+++ b/packages/mathtype-html-integration-devkit/package.json
@@ -46,6 +46,7 @@
     "webpack-cli": "^4.8.0"
   },
   "dependencies": {
+    "dompurify": "^2.3.9",
     "raw-loader": "^4.0.2",
     "uuid": "^8.3.2"
   }

--- a/packages/mathtype-html-integration-devkit/src/latex.js
+++ b/packages/mathtype-html-integration-devkit/src/latex.js
@@ -144,7 +144,7 @@ export default class Latex {
         end += mathTagEnd.length;
       }
 
-      mathml = content.substring(start, end);
+      mathml = Util.htmlSanitize(content.substring(start, end));
 
       startAnnotation = mathml.indexOf(openTarget);
       if (startAnnotation !== -1) {

--- a/packages/mathtype-html-integration-devkit/src/parser.js
+++ b/packages/mathtype-html-integration-devkit/src/parser.js
@@ -31,7 +31,7 @@ export default class Parser {
     imgObject.style.maxWidth = 'none';
     const data = wirisProperties || {};
 
-    data.mml = mathml;
+    data.mml = Util.htmlSanitize(mathml);
     data.lang = language;
     // Request metrics of the generated image.
     data.metrics = 'true';
@@ -200,7 +200,7 @@ export default class Parser {
           if (mathmlStart !== -1) {
             mathmlStart += mathmlStartToken.length;
             const mathmlEnd = imgCode.indexOf('"', mathmlStart);
-            const mathml = MathML.safeXmlDecode(imgCode.substring(mathmlStart, mathmlEnd));
+            const mathml = Util.htmlSanitize(MathML.safeXmlDecode(imgCode.substring(mathmlStart, mathmlEnd)));
             let latexStartPosition = mathml.indexOf(token);
 
             if (latexStartPosition !== -1) {
@@ -261,7 +261,7 @@ export default class Parser {
           // latex formulas that contains '<'.
           const latex = code.substring(startPosition + 2, endPosition);
           const decodedLatex = Util.htmlEntitiesDecode(latex);
-          let mathml = Latex.getMathMLFromLatex(decodedLatex, true);
+          let mathml = Util.htmlSanitize(Latex.getMathMLFromLatex(decodedLatex, true));
           if (!Configuration.get('saveHandTraces')) {
             // Remove hand traces.
             mathml = MathML.removeAnnotation(mathml, 'application/json');
@@ -421,7 +421,7 @@ export default class Parser {
         output += Util.createObjectCode(imgCode);
       }
     }
-    output += code.substring(endPosition, code.length)
+    output += code.substring(endPosition, code.length);
     return output;
   }
 
@@ -460,7 +460,7 @@ export default class Parser {
       }
 
       if (!MathML.isMathmlInAttribute(content, start) && imageMathmlAtrribute === -1) {
-        let mathml = content.substring(start, end);
+        let mathml = Util.htmlSanitize(content.substring(start, end));
         mathml = (characters.id === Constants.safeXmlCharacters.id)
           ? MathML.safeXmlDecode(mathml)
           : MathML.mathMLEntities(mathml);

--- a/packages/mathtype-html-integration-devkit/src/util.js
+++ b/packages/mathtype-html-integration-devkit/src/util.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-bitwise */
+import DOMPurify from 'dompurify';
 import MathML from './mathml';
 import Configuration from './configuration';
 import Latex from './latex';
@@ -390,6 +391,26 @@ export default class Util {
       .join('&gt;')
       .split('"')
       .join('&quot;');
+  }
+
+  /**
+   * Sanitize HTML to prevent XSS injections.
+   * @param {string} html - html to be sanitize.
+   * @returns {string} html sanitized.
+   * @static
+   */
+  static htmlSanitize(html) {
+    return DOMPurify.sanitize(html);
+  }
+
+  /**
+   * Check if HTML contains XSS injections.
+   * @param {string} html - html to be sanitize.
+   * @returns {string} html sanitized.
+   * @static
+   */
+  static containsXSS(html) {
+    return !(DOMPurify.sanitize(html) === html);
   }
 
   /**


### PR DESCRIPTION
## Description

When an `<img>` or malicious HTML code is encapsulated inside a <math> tag, can bypass the CKEditor security filters, causing a vulnerability.

Browser engines are parsing HTML differently based on the given content namespace which is figured out e.g. by recognizing specific unique elements. Overall, the whole HTML page is recognized as HTML namespace by default and parsed by a browser engine in a well-known pattern. So the HTML like:
 

```
<div>
  <style>
    <img src onerror="alert(1)" />
  </style>
</div>
```

will be parsed as:

```
<HTML div>
  <HTML style>
    #text: <img src onerror="alert(1)">
```


However, in the case of these both namespaces:
 

MathML, recognized by using math element
SVG, recognized by using svg element


The style element content will be parsed as a normal HTML, not a text. So, as an example replacing div element with math, we will get:
 

```
<math>
  <style>
    <img src onerror="alert(1)" />
  </style
</math>
```

to:

```
<MathML math>
  <MathML style>
    <MathML img src onerror="alert(1)" />
```


Once the above HTML will be written to document, img element will be unwrapped from style element as style in HTML “mode” can only include text:
 

```
<math>
  <img src onerror="alert(1)" />
  <style></style
</math>
```


The above HTML will cause XSS even when it’s not directly attached to DOM. It’s enough it’s parsed by a browser engine when setting it via innerHTML property.

## Steps to reproduce 

1. Run the demo of **CKEditor5** or **CKEditor4**.
> On ckeditor 5 add `"file:../../../packages/mathtype-html-integration-devkit"` on the `"@wiris/mathtype-html-integration-devkit"` dependency from demo package.json before using npm run `compile-package`.
3. Open the inspector.
4. Add next code on the inspector console.

CK5:
```
window.editor.setData('<math><mi><table><mglyph><style><img src="x" onerror="alert(1)"/></style></mglyph></table></mi></math>');
```

CK4:
```
CKEDITOR.instances.editor.setData('<math><mi><table><mglyph><style><img src="x" onerror="alert(1)"/></style></mglyph></table></mi></math>')
```

5. Click Update button

The `<img src="x" onerror="alert(1)"/>` is removed from the inserted formula and the alert dialog is not displayed. 

---

[#taskid 17724](https://wiris.kanbanize.com/ctrl_board/2/cards/17724/details/)