### PR TITLE
fix: change webpack demo host to localhost

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project is was 30th of September 2021.
 
+### [Unrelease]
+
+  - fix: change webpack demo host to localhost
+
 ## 7.31.1 2022-08-18
 
   - docs: add deprecation warning message on froala and tinymce4 package

--- a/demos/angular/generic/package.json
+++ b/demos/angular/generic/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.3",
   "description": "A simple Angular App integrating WIRIS MathType in a Generic integration.",
   "scripts": {
-    "start": "ng serve --host 0.0.0.0 --open",
+    "start": "ng serve --host localhost --open",
     "compile-package": "cd ../../../packages/mathtype-generic/ && npm run compile -- npm --dev",
     "lint": "ng lint"
   },

--- a/demos/angular/tinymce5/package.json
+++ b/demos/angular/tinymce5/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.5",
   "description": "A simple Angular App integrating WIRIS MathType in a TinyMCE rich text editor.",
   "scripts": {
-    "start": "ng serve --host 0.0.0.0 --open",
+    "start": "ng serve --host localhost --open",
     "compile-package": "cd ../../../packages/mathtype-tinymce5/ && npm run compile -- npm --dev",
     "lint": "ng lint"
   },

--- a/demos/html5/ckeditor4/webpack.config.js
+++ b/demos/html5/ckeditor4/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8001,
-    host: '0.0.0.0'
+    host: 'localhost'
   },
   resolve: {
     modules: ['node_modules'],

--- a/demos/html5/ckeditor5/webpack.config.js
+++ b/demos/html5/ckeditor5/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8002,
-    host: '0.0.0.0'
+    host: 'localhost'
   },
 
   module: {

--- a/demos/html5/froala/webpack.config.js
+++ b/demos/html5/froala/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8004,
-    host: '0.0.0.0'
+    host: 'localhost'
   },
   resolve: {
     modules: ['node_modules'],

--- a/demos/html5/froala2/webpack.config.js
+++ b/demos/html5/froala2/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8003,
-    host: '0.0.0.0'
+    host: 'localhost'
   },
   resolve: {
     modules: ['node_modules'],

--- a/demos/html5/generic/webpack.config.js
+++ b/demos/html5/generic/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8007,
-    host: '0.0.0.0'
+    host: 'localhost'
   },
   resolve: {
     modules: ['node_modules'],

--- a/demos/html5/tinymce4/webpack.config.js
+++ b/demos/html5/tinymce4/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8005,
-    host: '0.0.0.0'
+    host: 'localhost'
   },
   resolve: {
     modules: ['node_modules'],

--- a/demos/html5/tinymce5/webpack.config.js
+++ b/demos/html5/tinymce5/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8006,
-    host: '0.0.0.0'
+    host: 'localhost'
   },
   resolve: {
     modules: ['node_modules'],

--- a/demos/html5/tinymce6/webpack.config.js
+++ b/demos/html5/tinymce6/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
     writeToDisk: true,
     contentBase: path.join(__dirname, ''),
     port: 8008,
-    host: '0.0.0.0'
+    host: 'localhost'
   },
   resolve: {
     modules: ['node_modules'],


### PR DESCRIPTION
## Description

Chage webpack demo host to localhost. Windows doesn't display the demos when using the IP 0.0.0.0. Using `localhost` will work on Linux and Windows.

In IPv4 the address 0.0.0.0 is a non-routable meta-address used to designate an invalid, unknown or non applicable target. However, for practical reason, many client software treat 0.0.0.0 as localhost. For this reason we have decided to use `localhost` directly.

## Steps to reproduce

1. Run a demo.
2. Check if the url use localhost

---

[#taskid 21894](https://wiris.kanbanize.com/ctrl_board/2/cards/21894/details/)
