### PR TITLE
fix: Include backend config when rendering formulas

### DIFF
--- a/packages/mathtype-html-integration-devkit/src/parser.js
+++ b/packages/mathtype-html-integration-devkit/src/parser.js
@@ -29,7 +29,11 @@ export default class Parser {
     const imgObject = creator.createElement('img');
     imgObject.align = 'middle';
     imgObject.style.maxWidth = 'none';
-    const data = wirisProperties || {};
+    let data = wirisProperties || {};
+
+    // Take into account the backend config
+    const wirisEditorProperties = Configuration.get("editorParameters");
+    data = { ...wirisEditorProperties, ...data };
 
     data.mml = Util.htmlSanitize(mathml);
     data.lang = language;


### PR DESCRIPTION
## Description

This PR fixes the formula cache ignoring the global color configuration. For more details check the associated card.

## Steps to reproduce

Set `plugins` to branch `master` and `html-integrations` to this branch.

1. Open a demo from plugins project (e.g. PHP with generic). See `plugins/docker/README.md` for instructions on how to do this.

2. Add this parameter on configuration.ini file (`plugins/output/php/generic-demo/generic_wiris/configuration.ini` in the case of a PHP demo) to change the formulas color to red

```ini
wiriseditorparameters = {"color":"#FF0000"}
```

3. Open the MathType Editor and paste this mathml:

```html
<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi><mo>=</mo><mfrac><mrow><mo>-</mo><mi>b</mi><mo>&#xB1;</mo><msqrt><msup><mi>b</mi><mn>2</mn></msup><mo>-</mo><mn>4</mn><mi>a</mi><mi>c</mi></msqrt></mrow><mrow><mn>2</mn><mi>a</mi></mrow></mfrac></math>
```

4. Click the insert button from the MathType editor

## Expected result

The inserted formula have to be inserted with the configured color (in this case red).

## Actual result

As we are inserting a formula that is already cached, the color will be black.

---

[#taskid 26403](https://wiris.kanbanize.com/ctrl_board/2/cards/26403/details/)