### PR TITLE
fix: Autofocus not working

### DIFF
--- a/demos/angular/froala/README.md
+++ b/demos/angular/froala/README.md
@@ -118,15 +118,6 @@ Open [http://localhost:4004/](http://localhost:4004/) to view it in the browser.
         'wirisChemistry',
         'insertImage'
       ],
-      // Add [MW] uttons to the image editing popup Toolbar.
-      imageEditButtons: [
-        'wirisEditor',
-        'wirisChemistry',
-        'imageDisplay',
-        'imageAlign',
-        'imageInfo',
-        'imageRemove'
-      ],
       // Allow all the tags to understand the mathml
       htmlAllowedTags:  ['.*'],
       htmlAllowedAttrs: ['.*'],

--- a/demos/react/froala/README.md
+++ b/demos/react/froala/README.md
@@ -81,8 +81,6 @@ You will also see any lint errors in the console.
     const toolbar = ['wirisEditor', 'wirisChemistry'];
     const froalaConfig = {
         toolbarButtons: toolbar,
-        // Add [MW] uttons to the image editing popup Toolbar.
-        imageEditButtons: ['wirisEditor', 'wirisChemistry', 'imageDisplay', 'imageAlign', 'imageInfo', 'imageRemove'],
         // Allow all the tags to understand the mathml
         htmlAllowedTags: ['.*'],
         htmlAllowedAttrs: ['.*'],

--- a/packages/froala/README.md
+++ b/packages/froala/README.md
@@ -32,9 +32,8 @@ Easily include quality math equations in your documents and digital content.
      ```js  
          // From Froala 'Get started' section https://froala.com/wysiwyg-editor/docs/overview/
          new FroalaEditor('.selector', {
-            // Add MathType and ChemType buttons to the toolbar and the image menu:
+            // Add MathType and ChemType buttons to the toolbar:
             toolbar: ['wirisEditor', 'wirisChemistry'], 
-            imageEditButtons: ['wirisEditor', 'wirisChemistry'],
             // Allow all tags, in order to allow MathML:
             htmlAllowedTags:  ['.*'],
             htmlAllowedAttrs: ['.*'],

--- a/packages/froala/wiris.src.js
+++ b/packages/froala/wiris.src.js
@@ -59,6 +59,16 @@ export class FroalaIntegration extends IntegrationModel {
       WirisPlugin.currentInstance = WirisPlugin.instances[this.editorObject.id];
     }.bind(this, this.editorObject));
 
+    // Prevent froala from putting the image toolbar over the formulas
+    this.editorObject.$el.on('click', 'img', () => {
+      const imgObject = this.editorObject.image.get();
+      if (imgObject[0].classList.contains('Wirisformula')) {
+        const imgHeight = imgObject[0].height;
+        const imgToolbar = document.getElementsByClassName('fr-popup fr-desktop');
+        imgToolbar[0].style.marginTop = `${imgHeight}px`;
+      }
+    });
+
     /**
      * Update editor parameters.
      * The integration could contain an object with editor parameters.
@@ -309,7 +319,7 @@ export class FroalaIntegration extends IntegrationModel {
       if (($btn.parent()[0].hasAttribute('class') && $btn.parent()[0].getAttribute('class').indexOf('fr-buttons') === -1) || (selectedImage[0]
                 && (selectedImage[0].classList.contains(Configuration.get('imageClassName')) || selectedImage[0].contents().classList.contains(Configuration.get('imageClassName'))))) { // Is a MathType image.
         // Show MathType icons if previously were hidden.
-        $btn.removeClass('fr-hidden');
+        $btn.addClass('fr-hidden');
         // Disable resize box.
         if (!document.getElementById('wrs_style')) { // eslint-disable-line no-undef
           document.getElementsByTagName('head')[0].append('<style id="wrs_style">.fr-image-resizer {pointer-events: none;}</style>');


### PR DESCRIPTION
## Description

The MT/CT Editor is not focused when it is opened by clicking in the MT/CT icon in the Contextual Toolbar in the HTML Editor.

### How is the issue fixed

The root of the issue resides in the way Froala handles the contextual toolbar. Since fixing the focus can not be done on our side, the best solution, also recommended by the Froala support team, is to disable the contextual toolbar on formulas.
This means that the existing formulas can only be edited by double click.

## Steps to reproduce

1. Open the latest Froala demo.
2. Try to open a new or existing formula in all the possible ways.
3. Validate that, once the modal is opened, you can type on it without manually focusing.

---

[#taskid 26198](https://wiris.kanbanize.com/ctrl_board/2/cards/26198/details/)
