### PR TITLE
[Fix] Latex not rendering on Moodle

### DIFF
--- a/packages/tinymce5/editor_plugin.src.js
+++ b/packages/tinymce5/editor_plugin.src.js
@@ -357,7 +357,11 @@ export const currentInstance = null;
       }
 
       const onSave = function (editor, params) { // eslint-disable-line no-shadow
-        params.content = Parser.endParse(params.content, editor.getParam('language'));
+        if (integrationModelProperties.isMoodle) {
+          params.content = Parser.endParseSaveMode(params.content, editor.getParam('language'));
+        } else {
+          params.content = Parser.endParse(params.content, editor.getParam('language'));
+        }
       };
 
       if ('onSaveContent' in editor) {


### PR DESCRIPTION
## Description

The MathType filter for Moodle doesn't render LaTex formulas to MathType if they are written in student text fields. Insted, they get corrupted.

This PR solves the mentioned issue with the same behaviour as the Moodle default parser, MathJax, for TinyMCE.

## Steps to reproduce

1. Open a new Moodle instance with the changes on this PR.
2. Change to student role.
3. Set TinyMCE as the default editor.
4. In a student field (for example, a forum), write a latex formula.
5. Validate that is rendered properly.

---
[#taskid 4878](https://wiris.kanbanize.com/ctrl_board/2/cards/4878/details/)