### PR TITLE
[KB-29970] Remove !!raw-loader! prefix for Vite compatibility

### DIFF
--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars, import/named
-import Core, { ReturnObject } from './core.src';
+import Core from './core.src';
 import Image from './image';
 import Listeners from './listeners';
 import Util from './util';

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -8,16 +8,16 @@ import ContentManager from './contentmanager';
 import TelemetryService from './telemetry';
 import IntegrationModel from './integrationmodel';
 
-import closeIcon from '!!raw-loader!../styles/icons/general/close_icon.svg';  //eslint-disable-line
-import closeHoverIcon from '!!raw-loader!../styles/icons/hover/close_icon_h.svg';  //eslint-disable-line
-import fullsIcon from '!!raw-loader!../styles/icons/general/fulls_icon.svg';  //eslint-disable-line
-import fullsHoverIcon from '!!raw-loader!../styles/icons/hover/fulls_icon_h.svg';  //eslint-disable-line
-import minIcon from '!!raw-loader!../styles/icons/general/min_icon.svg';  //eslint-disable-line
-import minHoverIcon from '!!raw-loader!../styles/icons/hover/min_icon_h.svg';  //eslint-disable-line
-import minsIcon from '!!raw-loader!../styles/icons/general/mins_icon.svg';  //eslint-disable-line
-import minsHoverIcon from '!!raw-loader!../styles/icons/hover/mins_icon_h.svg';  //eslint-disable-line
-import maxIcon from '!!raw-loader!../styles/icons/general/max_icon.svg';  //eslint-disable-line
-import maxHoverIcon from '!!raw-loader!../styles/icons/hover/max_icon_h.svg';  //eslint-disable-line
+import closeIcon from '../styles/icons/general/close_icon.svg';  //eslint-disable-line
+import closeHoverIcon from '../styles/icons/hover/close_icon_h.svg';  //eslint-disable-line
+import fullsIcon from '../styles/icons/general/fulls_icon.svg';  //eslint-disable-line
+import fullsHoverIcon from '../styles/icons/hover/fulls_icon_h.svg';  //eslint-disable-line
+import minIcon from '../styles/icons/general/min_icon.svg';  //eslint-disable-line
+import minHoverIcon from '../styles/icons/hover/min_icon_h.svg';  //eslint-disable-line
+import minsIcon from '../styles/icons/general/mins_icon.svg';  //eslint-disable-line
+import minsHoverIcon from '../styles/icons/hover/mins_icon_h.svg';  //eslint-disable-line
+import maxIcon from '../styles/icons/general/max_icon.svg';  //eslint-disable-line
+import maxHoverIcon from '../styles/icons/hover/max_icon_h.svg';  //eslint-disable-line
 
 /**
  * @typedef {Object} DeviceProperties


### PR DESCRIPTION
## Description

Vite is unable to resolve the routes starting by `!!raw-loader!`

We use the `!!raw-loader!` prefix to import the close, minimize and maximize `svg` for the MathType editor on the devkit package. However, this prefix is not necessary.

Remove the `!!raw-loader!` on the imports from `devkit/modal.js` file will fix the issue.

## Steps to reproduce

- Open a demo:
  - Build package using `nx build <editor>`
  - Start package using `nx start <framework-editor>`
- Open MathType Editor.
- Validate that the close, minimize and maximize buttons from MathType Editor appears correctly.

---

[#taskid 29970](https://wiris.kanbanize.com/ctrl_board/2/cards/29970/details/)
