### PR TITLE
Solve language changes don't apply to MT plugins integration icons

### DIFF
--- a/demos/html/froala/index.html
+++ b/demos/html/froala/index.html
@@ -4,7 +4,8 @@
     <head>
         <title> Demo Froala </title>
         <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-        <script src="./dist/froala-editor/froala_editor.pkgd.min.js"></script>
+        <script src="node_modules/froala-editor/js/froala_editor.pkgd.min.js"></script>
+        <!-- <script type="text/javascript" src="node_modules/froala-editor/js/languages/de.js"></script> -->
     </head>
     <body>
         <script src="./dist/demo.js"></script>

--- a/packages/ckeditor4/plugin.src.js
+++ b/packages/ckeditor4/plugin.src.js
@@ -2,6 +2,7 @@ import IntegrationModel from '@wiris/mathtype-html-integration-devkit/src/integr
 import Parser from '@wiris/mathtype-html-integration-devkit/src/parser';
 import Util from '@wiris/mathtype-html-integration-devkit/src/util';
 import Configuration from '@wiris/mathtype-html-integration-devkit/src/configuration';
+import StringManager from '@wiris/mathtype-html-integration-devkit/src/stringmanager';
 
 import packageInfo from './package.json';
 
@@ -276,7 +277,7 @@ export class CKEditor4Integration extends IntegrationModel {
     init(editor) {
       editor.ui.addButton('ckeditor_wiris_formulaEditor', {
 
-        label: 'Insert a math equation - MathType',
+        label: StringManager.get('insert_math', editor.langCode),
         command: 'ckeditor_wiris_openFormulaEditor',
         icon: `${CKEDITOR.plugins.getPath('ckeditor_wiris')}./icons/formula.png`,
 
@@ -284,7 +285,7 @@ export class CKEditor4Integration extends IntegrationModel {
 
       editor.ui.addButton('ckeditor_wiris_formulaEditorChemistry', {
 
-        label: 'Insert a chemistry formula - ChemType',
+        label: StringManager.get('insert_chem', editor.langCode),
         command: 'ckeditor_wiris_openFormulaEditorChemistry',
         icon: `${CKEDITOR.plugins.getPath('ckeditor_wiris')}./icons/chem.png`,
 

--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -143,7 +143,7 @@ export default class MathType extends Plugin {
         view.bind('isEnabled').to(editor.commands.get('MathType'), 'isEnabled');
 
         view.set({
-          label: StringManager.get('insert_math'),
+          label: StringManager.get('insert_math', editor.config.get('language')),
           icon: mathIcon,
           tooltip: true,
         });
@@ -169,7 +169,7 @@ export default class MathType extends Plugin {
         view.bind('isEnabled').to(editor.commands.get('ChemType'), 'isEnabled');
 
         view.set({
-          label: StringManager.get('insert_chem'),
+          label: StringManager.get('insert_chem', editor.config.get('language')),
           icon: chemIcon,
           tooltip: true,
         });

--- a/packages/devkit/src/stringmanager.js
+++ b/packages/devkit/src/stringmanager.js
@@ -11,10 +11,18 @@ export default class StringManager {
    * Returns the associated value of certain string key. If the associated value
    * doesn't exits returns the original key.
    * @param {string} key - string key
+   * @param {string} lang - DEFAULT = null. Specify the language to translate the string
    * @returns {string} correspondent value. If doesn't exists original key.
    */
-  static get(key) {
-    let { language } = this;
+  static get(key, lang) {
+
+    // Default language definition
+    let {language} = this;
+
+    // If parameter language, use it
+    if (lang) {
+      language = lang;
+    }
 
     // Cut down on strings. e.g. en_US -> en
     if (language && language.length > 2) {

--- a/packages/froala/wiris.src.js
+++ b/packages/froala/wiris.src.js
@@ -3,6 +3,7 @@ import Configuration from '@wiris/mathtype-html-integration-devkit/src/configura
 import Parser from '@wiris/mathtype-html-integration-devkit/src/parser';
 import Constants from '@wiris/mathtype-html-integration-devkit/src/constants';
 import MathML from '@wiris/mathtype-html-integration-devkit/src/mathml';
+import StringManager from '@wiris/mathtype-html-integration-devkit/src/stringmanager';
 
 import packageInfo from './package.json';
 
@@ -94,6 +95,9 @@ export class FroalaIntegration extends IntegrationModel {
       FroalaEditor.ICONS.wirisEditor = null;
       FroalaEditor.COMMANDS.wirisEditor = null;
       document.getElementById('wirisEditor-1').classList.add('fr-hidden');
+    } else {
+      // Translate the button title
+      document.getElementById('wirisEditor-1').title = StringManager.get('insert_math', editor.opts.language);
     }
 
     // Hide ChemType toolbar button if is disabled by config.
@@ -101,6 +105,9 @@ export class FroalaIntegration extends IntegrationModel {
       FroalaEditor.ICONS.wirisChemistry = null;
       FroalaEditor.COMMANDS.wirisChemistry = null;
       document.getElementById('wirisChemistry-1').classList.add('fr-hidden');
+    } else {
+      // Translate the button title
+      document.getElementById('wirisChemistry-1').title = StringManager.get('insert_chem', editor.opts.language);
     }
   }
 

--- a/packages/generic/wirisplugin-generic.src.js
+++ b/packages/generic/wirisplugin-generic.src.js
@@ -1,5 +1,6 @@
 import IntegrationModel from '@wiris/mathtype-html-integration-devkit/src/integrationmodel';
 import Configuration from '@wiris/mathtype-html-integration-devkit/src/configuration';
+import StringManager from '@wiris/mathtype-html-integration-devkit/src/stringmanager';
 import Parser from '@wiris/mathtype-html-integration-devkit/src/parser';
 import Util from '@wiris/mathtype-html-integration-devkit/src/util';
 import formulaIcon from './icons/formula.png';
@@ -118,6 +119,7 @@ export default class GenericIntegration extends IntegrationModel {
       const formulaButton = document.createElement('img');
       formulaButton.id = 'editorIcon';
       formulaButton.src = formulaIcon;
+      formulaButton.title = StringManager.get('insert_math', this.editorParameters.language);
       formulaButton.style.cursor = 'pointer';
 
       Util.addEvent(formulaButton, 'click', () => {
@@ -142,6 +144,7 @@ export default class GenericIntegration extends IntegrationModel {
         // Horrible hard-coded temporary fix
         if (customEditor === 'chemistry') {
           customEditorButton.src = chemIcon;
+          customEditorButton.title = StringManager.get('insert_chem', this.editorParameters.language);
         }
         customEditorButton.id = `${customEditor}Icon`;
         customEditorButton.style.cursor = 'pointer';

--- a/packages/tinymce5/editor_plugin.src.js
+++ b/packages/tinymce5/editor_plugin.src.js
@@ -3,6 +3,7 @@ import Configuration from '@wiris/mathtype-html-integration-devkit/src/configura
 import Parser from '@wiris/mathtype-html-integration-devkit/src/parser';
 import Util from '@wiris/mathtype-html-integration-devkit/src/util';
 import Listeners from '@wiris/mathtype-html-integration-devkit/src/listeners';
+import StringManager from '@wiris/mathtype-html-integration-devkit/src/stringmanager';
 
 import packageInfo from './package.json';
 
@@ -443,14 +444,22 @@ export const currentInstance = null;
         commonEditor.addCommand('tiny_mce_wiris_openFormulaEditor', openFormulaEditorFunction);
       }
 
+      // Get editor language code
+      let lang_code;
+      if (editor.getParam('language')) {
+        lang_code = editor.getParam('language');
+        lang_code = (lang_code.split("-")[0]).split("_")[0];
+      } else lang_code = 'en';
+      
+
       // Check if MathType editor is enabled
       if (Configuration.get('editorEnabled')) {
         // MathType button.
         // Cmd Parameter is needed in TinyMCE4 and onAction parameter is needed in TinyMCE5.
         // For more details see TinyMCE migration page: https://www.tiny.cloud/docs-preview/migration-from-4.x/
         commonEditor.addButton('tiny_mce_wiris_formulaEditor', {
-          tooltip: 'Insert a math equation - MathType', // TinyMCE3
-          title: 'Insert a math equation - MathType',
+          tooltip: StringManager.get('insert_math', lang_code), // TinyMCE3
+          title: StringManager.get('insert_math', lang_code),
           cmd: 'tiny_mce_wiris_openFormulaEditor',
           image: `${WirisPlugin.instances[editor.id].getIconsPath()}formula.png`,
           onAction: openFormulaEditorFunction,
@@ -474,8 +483,8 @@ export const currentInstance = null;
           // Cmd Parameter is needed in TinyMCE4 and onAction parameter is needed in TinyMCE5.
           // For more details see TinyMCE migration page: https://www.tiny.cloud/docs-preview/migration-from-4.x/
           commonEditor.addButton(`tiny_mce_wiris_formulaEditor${customEditors.editors[customEditor].name}`, {
-            title: customEditors.editors[customEditor].tooltip, // TinyMCE3
-            tooltip: customEditors.editors[customEditor].tooltip,
+            title: StringManager.get('insert_chem', lang_code), // TinyMCE3
+            tooltip: StringManager.get('insert_chem', lang_code),
             onAction: commandFunction,
             cmd,
             image: WirisPlugin.instances[editor.id].getIconsPath() + customEditors.editors[customEditor].icon,

--- a/packages/tinymce6/editor_plugin.src.js
+++ b/packages/tinymce6/editor_plugin.src.js
@@ -3,6 +3,7 @@ import Configuration from '@wiris/mathtype-html-integration-devkit/src/configura
 import Parser from '@wiris/mathtype-html-integration-devkit/src/parser';
 import Util from '@wiris/mathtype-html-integration-devkit/src/util';
 import Listeners from '@wiris/mathtype-html-integration-devkit/src/listeners';
+import StringManager from '@wiris/mathtype-html-integration-devkit/src/stringmanager';
 
 import packageInfo from './package.json';
 
@@ -69,12 +70,12 @@ export class TinyMceIntegration extends IntegrationModel {
   getLanguage() {
     const editorSettings = this.editorObject;
     try {
-      return editorSettings.mathTypeParameters.editorParameters.language;
+      return editorSettings.getParam('mathTypeParameters').editorParameters.language;
     } catch (e) { console.error(); }
     // Get the deprecated wirisformulaeditorlang
-    if (editorSettings.wirisformulaeditorlang) {
+    if (editorSettings.getParam('wirisformulaeditorlang')) {
       console.warn('Deprecated property wirisformulaeditorlang. Use mathTypeParameters on instead.');
-      return editorSettings.wirisformulaeditorlang;
+      return editorSettings.getParam('wirisformulaeditorlang');
     }
     const langParam = this.editorObject.getParam('language');
     return langParam || super.getLanguage();
@@ -359,9 +360,13 @@ export const currentInstance = null;
         }
       });
 
+      // Get editor language code
+      let lang_code = editor.getParam('language');
+      lang_code = (lang_code.split("-")[0]).split("_")[0];
+
       // MathType button.
       commonEditor.addButton('tiny_mce_wiris_formulaEditor', {
-        tooltip: 'Insert a math equation - MathType',
+        tooltip: StringManager.get('insert_math', lang_code),
         image: `${WirisPlugin.instances[editor.id].getIconsPath()}formula.png`,
         onAction: openFormulaEditorFunction,
         icon: mathTypeIcon,
@@ -378,7 +383,7 @@ export const currentInstance = null;
           }
           editor.addCommand(cmd, commandFunction);
           commonEditor.addButton(`tiny_mce_wiris_formulaEditor${customEditors.editors[customEditor].name}`, {
-            tooltip: customEditors.editors[customEditor].tooltip,
+            tooltip: StringManager.get('insert_chem', lang_code),
             onAction: commandFunction,
             image: WirisPlugin.instances[editor.id].getIconsPath() + customEditors.editors[customEditor].icon,
             icon: chemTypeIcon, // At the moment only chemTypeIcon because of the provisional solution for TinyMCE6.


### PR DESCRIPTION
## Description

The mathtype integration with mathtype plugin, do not update the tooltip language.
The editor and mathtype modal are both in the specified language while the toolbar buttons are shown in English.

This PR fixes the mentioned issue by:
* Changing the icon wiris translator to take into account any specified language.
* Updates the editors button definition by making the tool-tip parameter dynamic.

## Steps to reproduce

The steps have to be done on all demos, except the CKEditor5.

1. Follow the editor instructions to change its language.
2. Uncomment the language settings on the editor Wiris demo.
3. Build and open the demo in development mode.
4. Verify that the Wiris icons tool-tip is in the editor language.

---

[#taskid 15517](https://wiris.kanbanize.com/ctrl_board/2/cards/15517/details/)
