### PR TITLE
fix(ckeditor5): chemtype formulas Drag & Drop

### DIFF
--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -254,12 +254,7 @@ export default class MathType extends Plugin {
       let formula = processor.toData(viewDocumentFragment) || '';
 
       // And obtain the complete formula
-      formula = `<math${mathAttributes}>${formula}</math>`;
-
-      // Skip if mathml contains a XSS injection
-      if (Util.containsXSS(formula)) {
-        return;
-      }
+      formula = Util.htmlSanitize(`<math${mathAttributes}>${formula}</math>`);
 
       /* Model node that contains what's going to actually be inserted. This can be either:
             - A <mathml> element with a formula attribute set to the given formula, or

--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -404,16 +404,6 @@ export default class Util {
   }
 
   /**
-   * Check if HTML contains XSS injections.
-   * @param {string} html - html to be sanitize.
-   * @returns {string} html sanitized.
-   * @static
-   */
-  static containsXSS(html) {
-    return !(DOMPurify.sanitize(html) === html);
-  }
-
-  /**
    * Parses a text and replaces all the HTML entities by their characters.
    * @param {string} input - text to be parsed
    * @returns {string} the input text with all their entities replaced by characters.


### PR DESCRIPTION
## Description

Chem equations disappear when you drag them into another position inside the CKEditor. This only happens with the 8.0.0 version of our plugin.

Due an incorrect DOMPurify implamentation on CKEditor5 the ChemType formulas were detected as XSS attacks when dropped.

## Steps to reproduce

1. Open CKEditor5 demo.
2. Insert a ChemType formula and text.
3. Drag the ChemType formula to another position.
4. 

---

[#taskid 30339](https://wiris.kanbanize.com/ctrl_board/2/cards/30339/details/)
