### PR TITLE
[KB-30453] Add telemer class for devkit

### DIFF
--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -47,6 +47,7 @@
     "webpack-cli": "^5.0.0"
   },
   "dependencies": {
+    "@wiris/telemeter-wasm": "^1.0.2",
     "dompurify": "^2.3.9",
     "raw-loader": "^4.0.2",
     "uuid": "^8.3.2"

--- a/packages/devkit/src/telemeter.js
+++ b/packages/devkit/src/telemeter.js
@@ -1,0 +1,50 @@
+import init, { Telemeter as TelemeterWASM } from "@wiris/telemeter-wasm";
+
+/**
+ * @classdesc
+ * This class implements the @wiris/telemeter-wasm. A utility that helps our Solutions to send the data
+ * to Telemetry in a more comfortable and homogeneous way.
+ */
+export default class Telemeter {
+
+  /**
+   * Inits Telemeter class.
+   * The parameters structures are defiended on {@link [Telemeter API](https://github.com/wiris/telemeter/blob/main/docs/USAGE.md#telemeter-api)}
+   * @param {Object} telemeterAttributes.solution - The product that send data to Telemetry.
+   * @param {Object} telemeterAttributes.hosts - Data about the environment where solution is integrated.
+   * @param {Object} telemeterAttributes.config - Configuration parameters.
+   */
+  static init(telemeterAttributes) {
+    init()
+      .then(() => {
+        if (this.telemeter) {
+          let local_telemeter = this.telemeter;
+          this.telemeter = undefined;
+          local_telemeter.finish();
+        }
+
+        this.telemeter = new TelemeterWASM(
+          telemeterAttributes.solution,
+          telemeterAttributes.hosts,
+          telemeterAttributes.config);
+      })
+      .catch((error) => {
+        console.log(error);
+      })
+  }
+
+  /**
+   * Closes the Telemetry Session. After calling this method no data will be added to the Telemetry Session.
+   */
+  static async finish() {
+    if (!this.telemeter) return;
+
+    try {
+      let local_telemeter = this.telemeter;
+      this.telemeter = undefined;
+      await local_telemeter.finish();
+    } catch (e) {
+      console.error(e);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Added the new Telemetry Class in the Devkit package. This class could be used to start and close sessions with the wiris telemeter.

Telemeter class have two static funtions:

- **static init(telemeterAttributes):** Start a session with the Telemeter. The `telemeterAttributes` expects three params, a **host**, a **solution** and a **config**. (Check example on Quick Start).
- **static async finish():** Close the session with the Telemeter

## Telemeter Configuration
### Solution

A solution is defined by:

 * **name**: Use the right name from the [Solutions list](https://docs.google.com/document/d/11J17P82BtAX74YZY8BzuFYYO611IfoZNNo19qpPCAR8)
 * **version**: The version of the solution.

### Hosts

The host is defined by:

* **nam**: Some data about the environment.
* **fam**: The family of the data written in **nam**.
* **ver** (optional): The version of the data written in **nam**.

Host data can be more than one, for example, we can set data about the Operating System and about the Browser. Please read all [Hosts families and Hosts documentation](https://docs.google.com/document/d/1USosDwSsxvN_PjyAUf8cYvIRp9A6SCRqHohuuH1YJFQ) to knows how the hosts works and what values can be send.

> **Information**: Telemeter send information about itself and set some host information by default under the _telemeter_ host family. You, as Telemeter user, don't have to do anything.

### Config

Configuration parameters are:

* **test**: True to use the staging Telemetry endpoint instead of the production one.
* **debug**: True to show more information about Telemeter's execution and use dev-tools.
* **dry_run**: True to skip sending data to the Telemetry endpoint (for example for unit tests).
* **api_key**: String to auth against Telemetry. Data team is the responsible of providing it.


## Quick Start

**Start a session with the telemeter:**

```js
import Telemeter from '../devkit/src/telemeter';      

// Object to store all the attributes needed to start a session with the telemeter
let telemeterAttributes = {};

// The product that send data to Telemetry.
telemeterAttributes.solution = {
    name: "MathType for CKeditor5",
    version: "8.0.0"
};

// Data about the environment where solution is integrated.
telemeterAttributes.hosts = [
    {
        nam: "Chrome",
        fam: "editor",
        ver: "2022",
    }
];

// Configuration parameters.
telemeterAttributes.config = {
    api_key: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
    test: true,
    debug: true
};

// Starts session with telemeter
Telemeter.init(telemeterAttributes);
```
**Send logs and tracks:**

```js
// Send log to the telemeter
Telemeter.telemeter.log("debug", "test log", {});

// Send track to the telemeter
Telemeter.telemeter.track("EVENT_TYPE", { sample: "value" });
```
**Close the session:**

```js
// Finish session with telemeter
Telemeter.finish();
```

**Complete Script:**

```js
import Telemeter from '../devkit/src/telemeter';      

// Object to store all the attributes needed to start a session with the telemeter
let telemeterAttributes = {};

// The product that send data to Telemetry.
telemeterAttributes.solution = {
    name: "MathType for CKeditor5",
    version: "8.0.0"
};

// Data about the environment where solution is integrated.
telemeterAttributes.hosts = [
    {
        nam: "Chrome",
        fam: "editor",
        ver: "2022",
    }
];

// Configuration parameters.
telemeterAttributes.config = {
    api_key: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
    test: true,
    debug: true
};

// Starts session with telemeter
Telemeter.init(telemeterAttributes);

// Send log to the telemeter
Telemeter.telemeter.log("debug", "test log", {});

// Send track to the telemeter
Telemeter.telemeter.track("EVENT_TYPE", { sample: "value" });

// Finish session with telemeter
Telemeter.finish();
```

---

[#taskid 30453](https://wiris.kanbanize.com/ctrl_board/2/cards/30453/details/)