### PR TITLE
[KB-30785] Fix typo in compilation instructions

### DIFF
--- a/docs/development/compiling/README.md
+++ b/docs/development/compiling/README.md
@@ -53,7 +53,7 @@ If your website hosts its own MathType Web services, instead of using the wiris.
 
 
 ```sh
-$ SERVICE_PROVIDER_URL=[url] SERVICE_PROVIDER_SERVER=[tech] yarn build
+$ SERVICE_PROVIDER_URI=[url] SERVICE_PROVIDER_SERVER=[tech] yarn build
 ```
 
 Where `[tech]` is one of:


### PR DESCRIPTION
## Description

`SERVICE_PROVIDER_URI` was misspelled as `SERVICE_PROVIDER_URL`.

---

[#taskid 30785](https://wiris.kanbanize.com/ctrl_board/2/cards/30785/details/)
