### PR TITLE
Set Generic demo language to English in Staging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project is was 30th of September 2021.
 
+### UNRELEASED
+
+  - Fix: Generic demos on staging are now in english. #KB-31349
+
 ### 8.0.1 2022-12-14
 
   - Create staging environment

--- a/demos/angular/generic/src/app/app.component.ts
+++ b/demos/angular/generic/src/app/app.component.ts
@@ -33,9 +33,12 @@ export class AppComponent implements OnInit {
     // Load the toolbar and the editable area into const variables to work easy with them
     const editableDiv = document.getElementById('htmlEditor');
     const toolbarDiv = document.getElementById('toolbar');
+    const mathTypeParameters = {
+      editorParameters: { language: 'en' }, // MathType config, including language
+    };
 
     // Initialyze the editor.
-    (window as any).wrs_int_init(editableDiv, toolbarDiv);
+    (window as any).wrs_int_init(editableDiv, toolbarDiv, mathTypeParameters);
 
     // Add listener on click button to launch updateContent function.
     document.getElementById('btn_update').addEventListener('click', (e) => {

--- a/demos/html/generic/src/app.js
+++ b/demos/html/generic/src/app.js
@@ -21,7 +21,7 @@ Generic.copyContentFromxToy('editable', 'transform_content');
 const editableDiv = document.getElementById('editable');
 const toolbarDiv = document.getElementById('toolbar');
 const mathTypeParameters = {
-  editorParameters: { language: 'es' }, // MathType config, including language
+  editorParameters: { language: 'en' }, // MathType config, including language
 };
 
 // Initialyze the editor.

--- a/demos/react/generic/src/index.js
+++ b/demos/react/generic/src/index.js
@@ -59,9 +59,12 @@ class Editor extends React.Component {
     // Load the toolbar and the editable area into const variables to work easy with them.
     const editableDiv = document.getElementById('htmlEditor');
     const toolbarDiv = document.getElementById('toolbar');
+    const mathTypeParameters = {
+      editorParameters: { language: 'en' }, // MathType config, including language
+    };
 
     // Initialyze the editor.
-    window.wrs_int_init(editableDiv, toolbarDiv);
+    window.wrs_int_init(editableDiv, toolbarDiv, mathTypeParameters);
   }
 
   // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
## Description

In Staging we need all demos to be in English for the automation tests but the Generic one was in Spanish. This PR fixes the Generic language in both staging and development demo for all the frameworks.

## Steps to reproduce

Go to the following links, the staging ones, and verify that demo language is english:
* [HTML5 demo](https://integrations.wiris.kitchen/KB-31349/html/generic/)
* [Angular demo](https://integrations.wiris.kitchen/KB-31349/angular/generic/)
* [React demo](https://integrations.wiris.kitchen/KB-31349/react/generic/)

---

[#taskid 31349](https://wiris.kanbanize.com/ctrl_board/2/cards/31349/details/)
