### PR TITLE
DOMPurify is removing semantics and annotation Tags.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Last release of this project is was 30th of September 2021.
 
   - Fix: Generic demos on staging are now in english. #KB-31349
   - Fix: tinymce folder names confuse nx. #KB-31663
+  - Fix: exclude semantics and annotation tags from dompurify. #KB-31876
 
 ### 8.0.1 2022-12-14
 

--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -400,7 +400,13 @@ export default class Util {
    * @static
    */
   static htmlSanitize(html) {
-    return DOMPurify.sanitize(html);
+    let annotationRegex = /\<annotation.+\<\/annotation\>/
+    // Get all the annotation content including the tags.
+    let annotation = html.match(annotationRegex);
+    // Sanitize html code without removing the <semantics> and <annotation> tags.
+    html = DOMPurify.sanitize(html, { ADD_TAGS: ['semantics', 'annotation']});
+    // Readd old annotation content.
+    return html.replace(annotationRegex, annotation);
   }
 
   /**


### PR DESCRIPTION
## Description

MathType for CKEditor5 use DOMPurify to remove XSS Injections using Mathml.

DOMPurify is removing the `semantics` and `annotation` tags from our formulas and the value `toolbar` added to the `annotation` tag. We need to configure DOMPurify to accept these elements.

## Steps to reproduce

1. Open CKeditor5 demo
2. Open the inspector and execute the next code on the console.

```
window.editor.setData('<math xmlns="http://www.w3.org/1998/Math/MathML"><semantics><mrow><msqrt><mi>a</mi><mi>a</mi></msqrt><mi>h</mi><mi>e</mi><mi>l</mi><mi>l</mi><mi>o</mi><mfenced><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr><mtr><mtd><mi>c</mi></mtd><mtd><mi>d</mi></mtd></mtr></mtable></mfenced></mrow><annotation encoding="application/vnd.wiris.mtweb-params+json">{"language":"en","toolbar":"<toolbar ref="general"></toolbar>"}</annotation></semantics></math>');
```

3. A formula will be inserted on CKEditor5. Check If data-mathml from the formula is the same as the data from step 2.
---

[#taskid 31875](https://wiris.kanbanize.com/ctrl_board/2/cards/31876/details/)