### PR TITLE
KB-31663: TinyMCE 5 & 6 demos share module and confuses Nx

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Last release of this project is was 30th of September 2021.
 ### 8.1.1 2023-01-11
 
   - Fix: Generic demos on staging are now in english. #KB-31349
+  - Fix: tinymce folder names confuse nx. #KB-31663
 
 ### 8.0.1 2022-12-14
 

--- a/demos/html/tinymce5/index.html
+++ b/demos/html/tinymce5/index.html
@@ -4,7 +4,7 @@
     <head>
         <title> Demo TinyMCE</title>
         <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-        <script src="./dist/tinymce/tinymce.min.js" referrerpolicy="origin"></script>
+        <script src="./dist/tinymce5/tinymce.min.js" referrerpolicy="origin"></script>
     </head>
     <body>
         <script src="./dist/demo.js"></script>

--- a/demos/html/tinymce5/webpack.config.js
+++ b/demos/html/tinymce5/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = (config, context) => {
         patterns: [
           {
             from: `${path.dirname(require.resolve(`tinymce`))}`,
-            to: path.resolve(__dirname, "dist/tinymce"),
+            to: path.resolve(__dirname, "dist/tinymce5"),
           },
           {
             from: `${path.dirname(require.resolve(`@wiris/mathtype-tinymce5`))}/plugin.min.js`,

--- a/demos/html/tinymce6/index.html
+++ b/demos/html/tinymce6/index.html
@@ -4,7 +4,7 @@
     <head>
         <title> Demo TinyMCE </title>
         <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-        <script src="./dist/tinymce/tinymce.min.js" referrerpolicy="origin"></script>
+        <script src="./dist/tinymce6/tinymce.min.js" referrerpolicy="origin"></script>
     </head>
     <body>
         <script src="./dist/demo.js"></script>

--- a/demos/html/tinymce6/webpack.config.js
+++ b/demos/html/tinymce6/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = (config, context) => {
         patterns: [
           {
             from: `${path.dirname(require.resolve(`tinymce`))}`,
-            to: path.resolve(__dirname, "dist/tinymce"),
+            to: path.resolve(__dirname, "dist/tinymce6"),
           },
           {
             from: `${path.dirname(require.resolve(`@wiris/mathtype-tinymce6`))}/plugin.min.js`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5016,9 +5016,9 @@ axe-core@^4.6.2:
   integrity sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==
 
 axios@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.0.tgz#4cb0d72213989dec08d4b10129e42063bcb3dc78"
-  integrity sha512-oCye5nHhTypzkdLIvF9SaHfr8UAquqCn1KY3j8vsrjeol8yohAdGxIpRPbF1bOLsx33HOAatdfMX1yzsj2cHwg==
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.1.tgz#80bf6c8dbb46e6db1fa8fe9ab114c1ca7405c2ee"
+  integrity sha512-78pWJsQTceInlyaeBQeYZ/QgZeWS8hGeKiIJiDKQe3hEyBb7sEMq0K4gjx+Va6WHTYO4zI/RRl8qGRzn0YMadA==
   dependencies:
     follow-redirects "^1.15.0"
     form-data "^4.0.0"


### PR DESCRIPTION
## Description

Currently, Tinymce5 & 6 demos copy the Tinymce module to the dist folder in order to adapt demos for static deployment. Both plugins use the same module folder name (tinymce in the dist folder). NX detects as the folders as the same workspace in two different places and throws an error message.

Changing the module folder names on each Tinymce fix the issue.

## Steps to reproduce

1. Install dependencies with yarn
2. Execute:
```
nx build tinymce5
nx start html-tinymce5
nx build tinymce6
nx start html-tinymce6
```
3. Close both demos
4. Try to restart any demo.
---

[#taskid 31663](https://wiris.kanbanize.com/ctrl_board/2/cards/31663/details/)