### PR TITLE
fix: Add alt to buttons on Generic

### DIFF
--- a/packages/generic/wirisplugin-generic.src.js
+++ b/packages/generic/wirisplugin-generic.src.js
@@ -119,7 +119,7 @@ export default class GenericIntegration extends IntegrationModel {
       const formulaButton = document.createElement('img');
       formulaButton.id = 'editorIcon';
       formulaButton.src = formulaIcon;
-      formulaButton.title = StringManager.get('insert_math', this.getLanguage());
+      formulaButton.title = formulaButton.alt = StringManager.get('insert_math', this.getLanguage());
       formulaButton.style.cursor = 'pointer';
 
       Util.addEvent(formulaButton, 'click', () => {
@@ -144,7 +144,7 @@ export default class GenericIntegration extends IntegrationModel {
         // Horrible hard-coded temporary fix
         if (customEditor === 'chemistry') {
           customEditorButton.src = chemIcon;
-          customEditorButton.title = StringManager.get('insert_chem', this.getLanguage());
+          customEditorButton.title = customEditorButton.alt = StringManager.get('insert_chem', this.getLanguage());
         }
         customEditorButton.id = `${customEditor}Icon`;
         customEditorButton.style.cursor = 'pointer';


### PR DESCRIPTION
## Description

The icons to open MathType or ChemType in the generic plugin don't have an alt text. This is necessary for accessibility reasons, so this PR adds the alt text to the MT and CT buttons

## Steps to reproduce

1. Install dependencies with `yarn`.
2. Build the generic plugin with `nx build generic`.
3. Open any Generic demo with `nx start <FRAMEWORK>-generic`.
4. Focus on the MT and CT buttons and verify if they have the alt text.

---

[#taskid 30748](https://wiris.kanbanize.com/ctrl_board/2/cards/30748/details/)
