### PR TITLE
Fix language not being read from server editor parameters

### DIFF
--- a/packages/devkit/src/core.src.js
+++ b/packages/devkit/src/core.src.js
@@ -679,7 +679,9 @@ export default class Core {
       defaultEditorAttributes[key] = value;
     }
     // Custom editor parameters.
-    const editorAttributes = {};
+    const editorAttributes = {
+      language: this.language, // Default language value
+    };
     // Editor parameters in backend, usually configuration.ini.
     const serverEditorParameters = Configuration.get('editorParameters');
     // Editor parameters through JavaScript configuration.
@@ -687,7 +689,10 @@ export default class Core {
     Object.assign(editorAttributes, defaultEditorAttributes, serverEditorParameters);
     Object.assign(editorAttributes, defaultEditorAttributes, cliendEditorParameters);
 
-    editorAttributes.language = this.language;
+    // Now, update backwards: if user has set a custom language, pass that back to core properties
+    this.language = editorAttributes.language;
+    StringManager.language = this.language;
+
     editorAttributes.rtl = this.integrationModel.rtl;
 
     const contentManagerAttributes = {};


### PR DESCRIPTION
## Description

Fix a bug that stopped the front end from using the language set in configuration.ini.

## Steps to reproduce

Open a demo from the plugins project and modify the configuration.ini to use a language different than the default one. The language of the modal and the editor should be that defined in the configuration.ini file. Detailed instructions can be found on the associated card.

---

[#taskid 30880](https://wiris.kanbanize.com/ctrl_board/2/cards/30880/details/)