### PR TITLE
Make control buttons accessible for Keyboard

### DIFF
--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -570,22 +570,35 @@ export default class ContentManager {
           this.editor.focus();
           keyboardEvent.stopPropagation();
           keyboardEvent.preventDefault();
+        } else if (document.querySelector('[title="Manual"]') === document.activeElement) {
+          // Focus is on minimize button (_).
+          this.modalDialogInstance.closeDiv.focus();
+          keyboardEvent.stopPropagation();
+          keyboardEvent.preventDefault();
         } else {
-          const element = document.querySelector('[title="Manual"]');
-          if (document.activeElement === element) {
-            // Focus is on editor help.
-            this.modalDialogInstance.cancelButton.focus();
+          if (document.activeElement === this.modalDialogInstance.minimizeDiv) {
+            // Focus on cancel button.
+            if (!(this.modalDialogInstance.properties.state === 'minimized')) {
+              this.modalDialogInstance.cancelButton.focus();
+              keyboardEvent.stopPropagation();
+              keyboardEvent.preventDefault();
+            }
+          }
+        }     
+      } else if (keyboardEvent.key === 'Tab') { // Code to detect Tab event.
+        if (document.activeElement === this.modalDialogInstance.cancelButton) {
+          // Focus is on X button.
+          this.modalDialogInstance.minimizeDiv.focus();
+          keyboardEvent.stopPropagation();
+          keyboardEvent.preventDefault();
+        } else if (document.activeElement === this.modalDialogInstance.closeDiv) {
+          // Focus on help button.
+          if (!(this.modalDialogInstance.properties.state === 'minimized')) {
+            const element = document.querySelector('[title="Manual"]');
+            element.focus();
             keyboardEvent.stopPropagation();
             keyboardEvent.preventDefault();
           }
-        }
-      } else if (keyboardEvent.key === 'Tab') { // Code to detect Tab event.
-        if (document.activeElement === this.modalDialogInstance.cancelButton) {
-          // Focus is on cancel button.
-          const element = document.querySelector('[title="Manual"]');
-          element.focus();
-          keyboardEvent.stopPropagation();
-          keyboardEvent.preventDefault();
         } else {
           // There should be only one element with class name 'wrs_formulaDisplay'.
           const element = document.getElementsByClassName('wrs_formulaDisplay')[0];

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -118,6 +118,7 @@ export default class ModalDialog {
     attributes.style = {};
     this.closeDiv = Util.createElement('a', attributes);
     this.closeDiv.setAttribute('role', 'button');
+    this.closeDiv.setAttribute('tabindex', 3);
     // Apply styles and events after the creation as createElement doesn't process them correctly
     let generalStyle = `background-size: 10px; background-image: url(data:image/svg+xml;base64,${window.btoa(closeIcon)})`;
     let hoverStyle = `background-size: 10px; background-image: url(data:image/svg+xml;base64,${window.btoa(closeHoverIcon)})`;
@@ -131,6 +132,7 @@ export default class ModalDialog {
     attributes.title = StringManager.get('exit_fullscreen');
     this.stackDiv = Util.createElement('a', attributes);
     this.stackDiv.setAttribute('role', 'button');
+    this.stackDiv.setAttribute('tabindex', 2);
     generalStyle = `background-size: 10px; background-image: url(data:image/svg+xml;base64,${window.btoa(minsIcon)})`;
     hoverStyle = `background-size: 10px; background-image: url(data:image/svg+xml;base64,${window.btoa(minsHoverIcon)})`;
     this.stackDiv.setAttribute('style', generalStyle);
@@ -143,6 +145,7 @@ export default class ModalDialog {
     attributes.title = StringManager.get('fullscreen');
     this.maximizeDiv = Util.createElement('a', attributes);
     this.maximizeDiv.setAttribute('role', 'button');
+    this.maximizeDiv.setAttribute('tabindex', 2);
     generalStyle = `background-size: 10px; background-repeat: no-repeat; background-image: url(data:image/svg+xml;base64,${window.btoa(fullsIcon)})`;
     hoverStyle = `background-size: 10px; background-repeat: no-repeat; background-image: url(data:image/svg+xml;base64,${window.btoa(fullsHoverIcon)})`;
     this.maximizeDiv.setAttribute('style', generalStyle);
@@ -155,6 +158,7 @@ export default class ModalDialog {
     attributes.title = StringManager.get('minimize');
     this.minimizeDiv = Util.createElement('a', attributes);
     this.minimizeDiv.setAttribute('role', 'button');
+    this.minimizeDiv.setAttribute('tabindex', 1);
     generalStyle = `background-size: 10px; background-repeat: no-repeat; background-image: url(data:image/svg+xml;base64,${window.btoa(minIcon)})`;
     hoverStyle = `background-size: 10px; background-repeat: no-repeat; background-image: url(data:image/svg+xml;base64,${window.btoa(minHoverIcon)})`;
     this.minimizeDiv.setAttribute('style', generalStyle);
@@ -959,6 +963,29 @@ export default class ModalDialog {
     this.stackDiv.addEventListener('click', this.stack.bind(this), true);
     this.minimizeDiv.addEventListener('click', this.minimize.bind(this), true);
     this.closeDiv.addEventListener('click', this.cancelAction.bind(this));
+    this.maximizeDiv.addEventListener('keypress', function(e) {
+      if (e.key === 'Enter' || e.key === ' ' || e.keyCode === 13 || e.keyCode === 32) { // Handle enter and space.
+        e.target.click();
+      }
+    }, true);
+    this.stackDiv.addEventListener('keypress', function(e) {
+      if (e.key === 'Enter' || e.key === ' ' || e.keyCode === 13 || e.keyCode === 32) { // Handle enter and space.
+        e.target.click();
+        e.preventDefault();
+      }
+    }, true);
+    this.minimizeDiv.addEventListener('keypress', function(e) {
+      if (e.key === 'Enter' || e.key === ' ' || e.keyCode === 13 || e.keyCode === 32) { // Handle enter and space.
+        e.target.click();
+        e.preventDefault();
+      }
+    }, true);
+    this.closeDiv.addEventListener('keypress', function(e) {
+      if (e.key === 'Enter' || e.key === ' ' || e.keyCode === 13 || e.keyCode === 32) { // Handle enter and space.
+        e.target.click();
+        e.preventDefault();
+      }
+    });
     this.title.addEventListener('click', this.reExpand.bind(this));
 
     // Overlay events (close).


### PR DESCRIPTION
## Description

Minimize, maximize, stack and close buttons on the top right of the modal editor were not accessible through the Keyboard, and therefore made the MathType not user-friendly. This PR fixes the issue by changing the logic of the Keyboard interaction with these buttons.

## Steps to reproduce

1. Install dependencies with `yarn`.
2. Build the desired package with `nx build <PACKAGE>`.
3. Start the desired demo with `nx start html-<PACKAGE>`.
4. Verify that the top right buttons are accessible through the keyboard. Verify that they work. Verify that once the modal is minimized or maximized, the buttons are also working

> Since the issue is reproducible in all packages and demos, it'll be preferible to perform the tests in more than one demo & package.

---

[#taskid 30749](https://wiris.kanbanize.com/ctrl_board/2/cards/30749/details/)
