### PR TITLE
Fix caret issues when interacting with the Close Modal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project is was 30th of September 2021.
 
-### [Unreleased]
+### Unreleased
 
-  - fix (froala): Remove Unlicensed message. #KB-25900
+  - Fix: "Cancel"+"Cancel" AND "Cancel"+"Close" does not focus the HTML Editor. #KB-24317
+  - Fix: TinyMCE Dialog cancellation "Cancel" button focuses the HTML Editor instead of the MT/CT Editor. #KB-24314
+  - Fix: Confirmation dialog closure does not place the caret next to the formula. #KB-26844
+  - Fix (froala): Remove Unlicensed message. #KB-25900
 
 ### 8.1.1 2023-01-11
 

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -522,11 +522,8 @@ export default class IntegrationModel {
   // eslint-disable-next-line class-methods-use-this, no-unused-vars
   getSelectedItem(target, isIframe) {}
 
-  static setActionsOnCancelButtons() {
-    // eslint-disable-next-line no-undef
-    if (WirisPlugin.currentInstance) {
-      WirisPlugin.currentInstance.core.editionProperties.temporalImage = null; // eslint-disable-line
-    }
+  // Set temporal image to null and make focus come back.
+  static setActionsOnCancelButtons() {    
 
     // Make focus come back on the previous place it was when click cancel button
     const currentInstance = WirisPlugin.currentInstance;
@@ -537,6 +534,14 @@ export default class IntegrationModel {
       const { range } = currentInstance.core.editionProperties;
       currentInstance.core.editionProperties.range = null;
       editorSelection.addRange(range);
+      if (range.startOffset !== range.endOffset) {
+        currentInstance.core.placeCaretAfterNode(currentInstance.core.editionProperties.temporalImage);
+      }
+    }
+
+    // eslint-disable-next-line no-undef
+    if (WirisPlugin.currentInstance) {
+      WirisPlugin.currentInstance.core.editionProperties.temporalImage = null; // eslint-disable-line
     }
   }
 }

--- a/packages/devkit/src/popupmessage.js
+++ b/packages/devkit/src/popupmessage.js
@@ -133,7 +133,7 @@ export default class PopUpMessage {
       this.callbacks.cancelCallback();
       // Set temporal image to null to prevent loading
       // an existent formula when strarting one from scrath. Make focus come back too.
-      IntegrationModel.setActionsOnCancelButtons();
+      // IntegrationModel.setActionsOnCancelButtons();
     }
   }
 
@@ -146,6 +146,7 @@ export default class PopUpMessage {
     if (typeof this.callbacks.closeCallback !== 'undefined') {
       this.callbacks.closeCallback();
     }
+    IntegrationModel.setActionsOnCancelButtons();
   }
 
   /**


### PR DESCRIPTION
## Description

This PR improves the way we treat the caret comes back when editing formulas.

### What is solved

* The caret focused on the editor when clicked on the Cancel + Cancel button.
* The caret didn't come back when editing an existing formula, instead it selected the formula.

## Steps to reproduce

1. Install dependencies with `yarn` and build the desired package with `nx build <PACKAGE>`.
2. Open the desired demo with `nx start html-<PACKAGE>`
3. Place the caret anywhere in the HTML Editor.
4. Click on the MT/CT icon.
5. Insert any formula in the MT/CT Editor.
6. Click on Cancel in the MT/CT Editor.
7. Click on Cancel in the Confirmation Dialog.
8. Verify that the caret is in the Modal Editor.
9. Click on Cancel in the MT/CT Editor.
10. Click on Close in the Confirmation Dialog.
11. Make sure that the focus comes back.

---

[#taskid 26844](https://wiris.kanbanize.com/ctrl_board/2/cards/26844/details/)
[#taskid 24314](https://wiris.kanbanize.com/ctrl_board/2/cards/24314/details/)
[#taskid 24317](https://wiris.kanbanize.com/ctrl_board/2/cards/24317/details/)
