### PR TITLE
KB 32324 - Add open/close MT/CT Editor global events.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Last release of this project is was 30th of September 2021.
   - Fix: TinyMCE Dialog cancellation "Cancel" button focuses the HTML Editor instead of the MT/CT Editor. #KB-24314
   - Fix: Confirmation dialog closure does not place the caret next to the formula. #KB-26844
   - Fix (froala): Remove Unlicensed message. #KB-25900
+  - Feat: Add close/open global events. #KB-32324
 
 ### 8.1.1 2023-01-11
 

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -4,3 +4,21 @@
 
 To integrate MathType on your website, take a look at the [demos](../demos/README.md) we have prepared.
 In the case of Angular and React, each of the demos contains a README.md file explaining how MathType has been integrated.
+
+## MathType Events
+
+To capture events triggered by MathType editor, use the next code:
+
+```js
+// Capture onModalOpen event triggered when MT/CT editor is open
+let modalOpenListener = window.WirisPlugin.Listeners.newListener('onModalOpen', () => {
+  ... // Your callback function
+});
+
+window.WirisPlugin.Core.addGlobalListener(modalOpenListener);
+```
+
+### List of Global Events
+
+- `onModalOpen()` Triggered when MT/CT editor modal is open
+- `onModalClose()` Triggered when MT/CT editor modal is close

--- a/packages/ckeditor5/src/integration.js
+++ b/packages/ckeditor5/src/integration.js
@@ -244,7 +244,7 @@ export default class CKEditor5Integration extends IntegrationModel {
         writer.insertText(`$$${returnObject.latex}$$`, startNode.getAttributes(), startPosition);
       });
     } else {
-      mathmlOrigin = this.core.editionProperties.temporalImage.dataset.mathml;
+      mathmlOrigin = this.core.editionProperties.temporalImage?.dataset.mathml;
       try {
         returnObject.node = this.editorObject.editing.view.domConverter.viewToDom(
           this.editorObject.editing.mapper.toViewElement(
@@ -266,7 +266,7 @@ export default class CKEditor5Integration extends IntegrationModel {
         elapsed_time: Date.now() - this.core.editionProperties.editionStartTime,
         editor_origin: null, // TODO read formula to find out whether it comes from Oxygen Desktop
         toolbar: this.core.modalDialog.contentManager.toolbar,
-        size: mathml.length,
+        size: mathml?.length,
       });
     } catch (err) {
       console.error(err);

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -1,4 +1,5 @@
 import Configuration from './configuration';
+import Core from './core.src';
 import EditorListener from './editorlistener';
 import Listeners from './listeners';
 import MathML from './mathml';
@@ -467,6 +468,8 @@ export default class ContentManager {
     } catch (err) {
       console.error(err);
     }
+
+    Core.globalListeners.fire('onModalOpen', {});
   }
 
   /**
@@ -599,7 +602,7 @@ export default class ContentManager {
               keyboardEvent.preventDefault();
             }
           }
-        }     
+        }
       } else if (keyboardEvent.key === 'Tab') { // Code to detect Tab event.
         if (document.activeElement === this.modalDialogInstance.cancelButton) {
           // Focus is on X button.

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -3,6 +3,7 @@ import EditorListener from './editorlistener';
 import Listeners from './listeners';
 import MathML from './mathml';
 import Util from './util';
+import Telemeter from './telemeter';
 
 export default class ContentManager {
   /**
@@ -445,7 +446,7 @@ export default class ContentManager {
     } else {
       this.setMathML(this.mathML);
     }
-    this.updateToolbar();
+    let toolbar = this.updateToolbar();
     this.onFocus();
 
     if (this.deviceProperties.isIOS) {
@@ -455,6 +456,16 @@ export default class ContentManager {
         // Open editor in Keyboard mode if user use iOS, Safari and page is zoomed.
         this.setKeyboardMode();
       }
+    }
+
+    let trigger = this.isNewElement ? 'button' : 'formula';
+    try {
+      Telemeter.telemeter.track("OPENED_MTCT_EDITOR", {
+        toolbar: toolbar,
+        trigger: trigger,
+      });
+    } catch (err) {
+      console.error(err);
     }
   }
 
@@ -478,8 +489,10 @@ export default class ContentManager {
   updateToolbar() {
     this.updateTitle(this.modalDialogInstance);
     const customEditor = this.customEditors.getActiveEditor();
+
+    let toolbar;
     if (customEditor) {
-      const toolbar = customEditor.toolbar
+      toolbar = customEditor.toolbar
         ? customEditor.toolbar
         : _wrs_int_wirisProperties.toolbar;
 
@@ -487,12 +500,14 @@ export default class ContentManager {
         this.setToolbar(toolbar);
       }
     } else {
-      const toolbar = this.getToolbar();
+      toolbar = this.getToolbar();
       if (this.toolbar == null || this.toolbar !== toolbar) {
         this.setToolbar(toolbar);
         this.customEditors.disable();
       }
     }
+
+    return toolbar;
   }
 
   /**

--- a/packages/devkit/src/core.src.js
+++ b/packages/devkit/src/core.src.js
@@ -527,7 +527,8 @@ export default class Core {
         item.startPosition,
         item.endPosition);
     } else {
-      mathmlOrigin = this.editionProperties.temporalImage.dataset.mathml;
+      console.log('else')
+      mathmlOrigin = this.editionProperties.temporalImage?.dataset.mathml;
       if (element && element.nodeName.toLowerCase() === 'img') { // Editor empty, formula has been erased on edit.
         // There are editors (e.g: CKEditor) that put attributes in images.
         // We don't allow that behaviour in our images.
@@ -540,7 +541,7 @@ export default class Core {
       this.placeCaretAfterNode(this.editionProperties.temporalImage);
     }
 
-    const mathml = element.dataset.mathml;
+    const mathml = element?.dataset?.mathml;
     try {
       Telemeter.telemeter.track("INSERTED_FORMULA", {
         mathml_origin: mathmlOrigin,
@@ -548,7 +549,7 @@ export default class Core {
         elapsed_time: Date.now() - this.editionProperties.editionStartTime,
         editor_origin: null, // TODO read formula to find out whether it comes from Oxygen Desktop
         toolbar: this.modalDialog.contentManager.toolbar,
-        size: mathml.length,
+        size: mathml?.length,
       });
     } catch (err) {
       console.error(err);

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -489,15 +489,6 @@ export default class IntegrationModel {
   openNewFormulaEditor() {
     this.core.editionProperties.isNewElement = true;
     this.core.openModalDialog(this.target, this.isIframe);
-
-    try {
-      Telemeter.telemeter.track("OPENED_MTCT_EDITOR", {
-        toolbar: this.core.modalDialog.contentManager.toolbar,
-        trigger: "button",
-      });
-    } catch (err) {
-      console.error(err);
-    }
   }
 
   /**
@@ -507,15 +498,6 @@ export default class IntegrationModel {
   openExistingFormulaEditor() {
     this.core.editionProperties.isNewElement = false;
     this.core.openModalDialog(this.target, this.isIframe);
-
-    try {
-      Telemeter.telemeter.track("OPENED_MTCT_EDITOR", {
-        toolbar: this.core.modalDialog.contentManager.getToolbar(),
-        trigger: "formula",
-      });
-    } catch (err) {
-      console.error(err);
-    }
   }
 
   /**
@@ -597,6 +579,8 @@ export default class IntegrationModel {
       eventTarget,
       (element, event) => {
         this.doubleClickHandler(element, event);
+        // Avoid creating the doublick listener more than once for each element.
+        event.stopImmediatePropagation();
       },
       (element, event) => {
         this.mousedownHandler(element, event);

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -7,6 +7,7 @@ import StringManager from './stringmanager';
 import ContentManager from './contentmanager';
 import Telemeter from './telemeter';
 import IntegrationModel from './integrationmodel';
+import Core from './core.src';
 
 import closeIcon from '../styles/icons/general/close_icon.svg';  //eslint-disable-line
 import closeHoverIcon from '../styles/icons/hover/close_icon_h.svg';  //eslint-disable-line
@@ -580,6 +581,8 @@ export default class ModalDialog {
     this.saveModalProperties();
     this.unlockWebsiteScroll();
     this.properties.open = false;
+
+    Core.globalListeners.fire('onModalClose', {});
   }
 
   /**


### PR DESCRIPTION
## Description

This PR adds two global Events on Devkit module to capture when the MathType/ChemType editor is open/close.

### List of Global Events added:

- `onModalOpen()` Triggered when MT/CT editor modal is open
- `onModalClose()` Triggered when MT/CT editor modal is close

## Steps to reproduce

1. Add next code inside `app.js` from any demo, after editor is created:

```js
let modalOpenListener = window.WirisPlugin.Listeners.newListener('onModalOpen', () => {
    console.log('onModalOpen');
});

window.WirisPlugin.Core.addGlobalListener(modalOpenListener);

let modalCloseListener = window.WirisPlugin.Listeners.newListener('onModalClose', () => {
    console.log('onModalClose');
});

window.WirisPlugin.Core.addGlobalListener(modalCloseListener);
```
2. Open the demo.
3. On the demo, open the browser inspector.
4. Open MathType editor.

A console log with the text onModalOpen will appear.

5. Close the MathType ediro

A console log with the text onModalClose will appear.

---

[#taskid 32324](https://wiris.kanbanize.com/ctrl_board/2/cards/32324/details/)