### PR TITLE
KB 32550 - Remove language configuration on Generic demo

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Last release of this project is was 30th of September 2021.
   - Fix: TinyMCE Dialog cancellation "Cancel" button focuses the HTML Editor instead of the MT/CT Editor. #KB-24314
   - Fix: Confirmation dialog closure does not place the caret next to the formula. #KB-26844
   - Fix (froala): Remove Unlicensed message. #KB-25900
+  - Refactor (generic): Remove editor language conf from generic demo. #KB-32550
 
 ### 8.1.1 2023-01-11
 

--- a/demos/html/generic/src/app.js
+++ b/demos/html/generic/src/app.js
@@ -20,16 +20,13 @@ Generic.copyContentFromxToy('editable', 'transform_content');
 
 const editableDiv = document.getElementById('editable');
 const toolbarDiv = document.getElementById('toolbar');
-const mathTypeParameters = {
-  editorParameters: { language: 'en' }, // MathType config, including language
-};
 
 // Initialyze the editor.
-window.wrs_int_init(editableDiv, toolbarDiv, mathTypeParameters);
+window.wrs_int_init(editableDiv, toolbarDiv);
 
 document.onreadystatechange = function () {
   if (document.readyState === 'interactive') {
-    const versionWiris = WirisPlugin.currentInstance.version;             //eslint-disable-line
+    const versionWiris = WirisPlugin.currentInstance.version; //eslint-disable-line
     document.getElementById('version_wiris').innerHTML += versionWiris;
   }
 };


### PR DESCRIPTION
## Description

The Generic demo have the editor next language configurated:

```js
const mathTypeParameters = {
   editorParameters: { language: 'en' }, // MathType config, including language
};
```

The `editorParameters` are also saved inside an annotation tag on each formula. This is causing incompatibilities with tests on generic demo, as the other demos doesn't have this configuration. For consistency, this PR remove the language configuration from generic demo.

## Steps to reproduce

1. Open generic demo.
2. Insert a formula.
3. Open the browser inspecto.
4. Check that the inserted formula doesn't have the annotations tag.

---

[#taskid 32550](https://wiris.kanbanize.com/ctrl_board/2/cards/32550/details/)