### PR TITLE
[KB-32826] fix: don't add an extra whitespace between <math and xmlns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ Last release of this project is was 30th of September 2021.
   - Fix: Confirmation dialog closure does not place the caret next to the formula. #KB-26844
   - Fix (froala): Remove Unlicensed message. #KB-25900
   - Refactor (generic): Remove editor language conf from generic demo. #KB-32550
+  - Fix: don't add an extra whitespace between `<math` and `xmlns`. #KB-32826
 
 ### 8.1.1 2023-01-11
 

--- a/packages/devkit/src/mathml.js
+++ b/packages/devkit/src/mathml.js
@@ -196,7 +196,11 @@ export default class MathML {
 
     // Trivial case: class attribute value equal to editor name. Then
     // class attribute is removed.
-    if (mathml.indexOf(`class="wrs_${customEditor}"`) !== -1) {
+    // First try to remove it with a space before if there is one
+    // Otherwise without the space
+    if (mathml.indexOf(` class="wrs_${customEditor}"`) !== -1) {
+      return mathml.replace(` class="wrs_${customEditor}"`, '');
+    } else if (mathml.indexOf(`class="wrs_${customEditor}"`) !== -1) {
       return mathml.replace(`class="wrs_${customEditor}"`, '');
     }
 


### PR DESCRIPTION
## Description

An extra blank space is added in the MathML between "math" and "xmlns" when editing a ChemType formula and converting it to a MT formula:

```
«math  xmlns=¨http://www.w3.org/1998/Math/MathML¨»«msqrt»«mi»x«/mi»«/msqrt»«....
```

## Steps to reproduce

- Open the HTML demo for Generic.
- Type CTRL+A + DELETE (it deletes everything in the HTML Editor)
- Insert a ChemType formula
- Type CTRL+A (it selects the ChemType formula in the HTML Editor)
- Click on the MT button in the HTML Editor (it opens the MT Editor containing the ChemType formula in it)
- Delete the ChemType formula in the MT Editor
- Type a MT formula, for example, "square root of x" in the MT Editor.
- Click on the Insert button in the MT Editor (the formula is inserted in the HTML-Editor)

### Actual result

The MathML of the formula is the next one (it has two blank spaces between math and xmlns):

```
«math  xmlns=¨http://www.w3.org/1998/Math/MathML¨»«msqrt»«mi»x«/mi»«/msqrt»«/math»
```

### Expected result

The MathML of the formula should be the next one (just one blank space between math and xmlns):

```
«math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«msqrt»«mi»x«/mi»«/msqrt»«/math»
```

---

[#taskid 32826](https://wiris.kanbanize.com/ctrl_board/2/cards/32826/details/)