### PR TITLE
[KB 33529] - Editor becomes unusable when reducing the screen to 550px width

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@ Last release of this project is was 30th of September 2021.
 
 ### Unreleased
 
+  - Fix: detect if device is mobile. #KB-33529
+
+### 8.2.6 2023-03-17
+
   - Fix: "Cancel"+"Cancel" AND "Cancel"+"Close" does not focus the HTML Editor. #KB-24317
   - Fix: TinyMCE Dialog cancellation "Cancel" button focuses the HTML Editor instead of the MT/CT Editor. #KB-24314
   - Fix: Confirmation dialog closure does not place the caret next to the formula. #KB-26844

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -330,6 +330,14 @@ export default class ContentManager {
   }
 
   /**
+   * Returns true if device is Mobile. Otherwise, false.
+   * @returns {Boolean}
+   */
+  static isMobile() {
+    return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+  }
+
+  /**
    * Returns true if editor is loaded. Otherwise, false.
    * @returns {Boolean}
    */
@@ -605,7 +613,7 @@ export default class ContentManager {
               keyboardEvent.preventDefault();
             }
           }
-        }     
+        }
       } else if (keyboardEvent.key === 'Tab') { // Code to detect Tab event.
         if (document.activeElement === this.modalDialogInstance.cancelButton) {
           // Focus is on X button.

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -58,7 +58,7 @@ export default class ModalDialog {
     // TODO: Detect isMobile without using editor metrics.
     const isLandscape = (landscape && this.attributes.height > deviceHeight);
     const isPortrait = portrait && this.attributes.width > deviceWidth;
-    const isMobile = isLandscape || isPortrait;
+    const isMobile =  ContentManager.isMobile();
 
     // Obtain number of current instance.
     this.instanceId = document.getElementsByClassName('wrs_modal_dialogContainer').length;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4396,9 +4396,6 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.1.tgz#34bdc31727a1889198855913db2f270ace6d7bf8"
   integrity sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==
 
-"@wiris/telemeter-wasm@file:./packages/devkit/telemeter-wasm":
-  version "1.0.3"
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
## Description

When users open the MathType editor with a desktop window smaller than 550 px width, the MathType detects as user is on mobile. This PR fix this issue detecting correctly If user is on Desktop.

## Steps to reproduce
 
1. Open a demo from `html-integrations`.
2. Reduce the screen to the minimum.
3. Press the MathType icon to insert an equation.

The MathType editor will be open correctly.

---

[#taskid 33529](https://wiris.kanbanize.com/ctrl_board/2/cards/33529/details/)