### PR TITLE
feat: tinymce6 for moodle compatibility

### DIFF
--- a/packages/tinymce6/editor_plugin.src.js
+++ b/packages/tinymce6/editor_plugin.src.js
@@ -135,29 +135,29 @@ export class TinyMceIntegration extends IntegrationModel {
     super.updateFormula(mathml);
   }
 
-    /**
+  /**
    * Set Moodle configuration on plugin.
    * @param {string} editor - Editor instance.
    * @param {string} pluginName - TinyMCE 6 plugin name.
    */
-    registerMoodleOption (editor, pluginName) {
-      const registerOption = editor.options.register;
-  
-      registerOption(`${pluginName}:filterEnabled`, {
-        processor: 'boolean',
-        'default': false,
-      });
-  
-      registerOption(`${pluginName}:editorEnabled`, {
-        processor: 'boolean',
-        'default': false,
-      });
-  
-      registerOption(`${pluginName}:chemistryEnabled`, {
-        processor: 'boolean',
-        'default': false,
-      });
-    }
+  registerMoodleOption (editor, pluginName) {
+    const registerOption = editor.options.register;
+
+    registerOption(`${pluginName}:filterEnabled`, {
+      processor: 'boolean',
+      'default': false,
+    });
+
+    registerOption(`${pluginName}:editorEnabled`, {
+      processor: 'boolean',
+      'default': false,
+    });
+
+    registerOption(`${pluginName}:chemistryEnabled`, {
+      processor: 'boolean',
+      'default': false,
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

This PR add changes to tinymce6 plugin to make it compatible with new TinyMCE6 Moodle plugin. You can test this PR on Moodle 4.1 using the plugin [moodle-tinymce6_wiris](https://github.com/wiris/moodle-tinyMCE6_wiris). The plugin use the changes from this PR.


## Steps to reproduce

1. Open Moodle 4.1.
2. On Moodle Administrator page set TinyMCE6 as default editor and disable Cachejs.
3. Inside Moodle folder: `...MOODLE_401_STABLE/lib/editor/tiny/plugins/` create a folder named `wiris`.
4. Inside the created `wiris` folder add all the code from the repository [moodle-tinymce6_wiris](https://github.com/wiris/moodle-tinyMCE6_wiris).
5. Log In on Moodle as Admin and create a course.
6. Try to insert/edit formulas using the TinyMCE6 MathType plugin from Description section.
---

[#taskid 33816](https://wiris.kanbanize.com/ctrl_board/2/cards/33816/details/)