### PR TITLE
Add custom headers to API requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Last release of this project is was 30th of September 2021.
   - Fix: Confirmation dialog closure does not place the caret next to the formula. #KB-26844
   - Fix (froala): Remove Unlicensed message. #KB-25900
   - Refactor (generic): Remove editor language conf from generic demo. #KB-32550
+  - Feat: Add custom headers to API requests. #KB-34463
 
 ### 8.1.1 2023-01-11
 

--- a/packages/devkit/src/serviceprovider.js
+++ b/packages/devkit/src/serviceprovider.js
@@ -1,5 +1,6 @@
 import Util from './util';
 import Listeners from './listeners';
+import Configuration from './configuration';
 
 /**
  * @typedef {Object} ServiceProviderProperties
@@ -185,13 +186,21 @@ export default class ServiceProvider {
         httpRequest.open('POST', currentPath + url, false);
       }
 
+      let header = Configuration.get('customHeaders');
+      if (header) {
+        header = header.toString()
+        header.split(",")
+          .map(element => element.trim().split('='))
+          .forEach(([key, val]) => httpRequest.setRequestHeader(key, val));
+      }
+
       if (typeof postVariables !== 'undefined' && postVariables) {
         httpRequest.setRequestHeader('Content-type', 'application/x-www-form-urlencoded; charset=UTF-8');
         httpRequest.send(Util.httpBuildQuery(postVariables));
       } else {
         httpRequest.send(null);
       }
-
+   
       return httpRequest.responseText;
     }
     return '';


### PR DESCRIPTION
## Description

This PR adds the front-end logic to append and pass custom headers to our API requests. This new feature, should not change the way our requests work.

## Steps to reproduce

1. Go to the `wepack.config.json` file of the demo you want to try and set the following parameters:
     ```
     'SERVICE_PROVIDER_URI': demo_url,
     'SERVICE_PROVIDER_SERVER': backend,
     ```
     Where a backend example could be `'php'` and a demo_url is the one where the demo is running, for example: `'http://localhost:8080/plugin/3.50/generic-demo/generic_wiris/integration/'`.
2. Build and open a demo using the plugins project.
3. Add the desired custom headers and its values to the `configuration.ini` file.
4. Validate that the API requests you make contain those headers.


---

[#taskid 34463](https://wiris.kanbanize.com/ctrl_board/2/cards/34463/details/)
