### PR TITLE
Moodle not sending the correct course and category to Telemetry

### DIFF
--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -274,10 +274,10 @@ export default class IntegrationModel {
       lms = {
         nam: 'moodle',
         fam: 'lms',
-        ver: Configuration.get('versionMoodle'),
-        // category: Configuration.get('categoryMoodle'),
-        // id: Configuration.get('courseMoodleId'),
-        // name: Configuration.get('courseMoodleName')
+        ver: this.environment.moodleVersion,
+        category: this.environment.moodleCourseCategory,
+        id: M.cfg.courseId,
+        name: this.environment.moodleCourseName,
       }
       if (!editorName.includes('TinyMCE')) {
         editorName = 'Atto';

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -328,10 +328,10 @@ export default class IntegrationModel {
       },
       hosts: hosts,
       config: {
-        test: false, // True to use the staging Telemetry endpoint instead of the production one.
+        test: true, // True to use the staging Telemetry endpoint instead of the production one.
         debug: false, // True to show more information about Telemeter's execution and use dev-tools.
         dry_run: false, // True to skip sending data to the Telemetry endpoint (for example for unit tests).
-        api_key: "eda2ce9b-0e8a-46f2-acdd-c228a615314e", // to auth against Telemetry. Data team is the responsible of providing it.
+        api_key: "1caaff6e-ef1f-41ba-b459-911b558c2b23", // to auth against Telemetry. Data team is the responsible of providing it.
       },
       url: undefined,
     })

--- a/packages/tinymce5/editor_plugin.src.js
+++ b/packages/tinymce5/editor_plugin.src.js
@@ -269,6 +269,9 @@ export const currentInstance = null;
       }
       integrationModelProperties.environment.editor = `TinyMCE ${editorVersion}.x`;
       integrationModelProperties.environment.editorVersion = `${tinymce.majorVersion}.${tinymce.minorVersion}`;
+      integrationModelProperties.environment.moodleCourseCategory = editor.getParam('moodleCourseCategory');
+      integrationModelProperties.environment.moodleCourseName = editor.getParam('moodleCourseName');
+      integrationModelProperties.environment.moodleVersion = editor.getParam('moodleVersion');
 
       integrationModelProperties.callbackMethodArguments = callbackMethodArguments;
       integrationModelProperties.editorObject = editor;


### PR DESCRIPTION
## Description

The Telemetry events were not sending the correct Moodle course and category. Those were sent by the back-end, and were set just once, when the filter is loaded, which caused the values to never change from their original value.

This PR changes the way the data is sent from the back-end to the front-end + moodle in both TinyMCE and Atto plugins.

## Steps to reproduce

1. Go to any staging demo.
2. Validate that it's sending the proper data to Tableau.
3. Open a Moodle instance and validate that it's also sending the correct data to Tableau.

---

[#taskid 34608](https://wiris.kanbanize.com/ctrl_board/2/cards/34608/details/)
