### PR TITLE
Fix Copy&Paste formulas written in hand to open in hand mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project is was 30th of September 2021.
 
+### Unreleased
+
+  - Fix (ckeditor5): Hand copied&pasted formulas not opening in hand mode. #KB-32892
+
 ### 8.3.0 2023-05-02
 
   - Fix: detect if device is mobile. #KB-33529

--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -392,11 +392,6 @@ export default class MathType extends Plugin {
 
       let mathString = Parser.endParseSaveMode(modelItem.getAttribute('formula'));
 
-      // Remove the traces from Hand. This code should be removed once PLUGINS-1307 is solved.
-      if (!Configuration.get('saveHandTraces')) {
-        mathString = MathML.removeAnnotation(mathString, 'application/json');
-      }
-
       const sourceMathElement = htmlDataProcessor.toView(mathString).getChild(0);
 
       return clone(viewWriter, sourceMathElement);


### PR DESCRIPTION
## Description

In CKEditor5, copy and pasted formulas written with hand opened on the regular editor, not the hand mode.
This was because of a configuration that deleted the information of the formula about the handwriting.

## Steps to reproduce

1. Go to the CKEditor5 staging demo.
2. Write and insert a formula in hand mode.
3. Copy & paste the formula.
4. Open the copied formula and validate that the editor opens in hand mode.

---

[#taskid 32892](https://wiris.kanbanize.com/ctrl_board/2/cards/32892/details/)
