### PR TITLE
fix: ck5 memory leak with ClassicEditor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Last release of this project is was 30th of September 2021.
 ### Unreleased
 
   - Fix (ckeditor5): Hand copied&pasted formulas not opening in hand mode. #KB-32892
+  - Fix: ck5 memory leak with ClassicEditor. #KB-34718
 
 ### 8.3.0 2023-05-02
 

--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -65,7 +65,7 @@ export default class MathType extends Plugin {
    * Inherited from Plugin class: Executed when CKEditor5 is destroyed
    */
   destroy() { // eslint-disable-line class-methods-use-this
-    currentInstance.removeEvents();
+    currentInstance.destroy();
   }
 
   /**

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -268,7 +268,7 @@ export default class IntegrationModel {
     // If moodle, add information to hosts and solution.
     let isMoodle = (!!((typeof M === 'object' && M !== null))),
       lms;
-    
+
     if (isMoodle) {
       solutionTelemeter = 'Moodle';
       lms = {
@@ -409,7 +409,7 @@ export default class IntegrationModel {
    *                   versionOS = Operating System version.
    */
   getOS() {
-    
+
     // default value for OS just in case nothing is detected
     let detectedOS = "unknown",
       versionOS = "unknown";
@@ -615,7 +615,7 @@ export default class IntegrationModel {
 
     // Delete temporal image when inserted
     this.core.editionProperties.temporalImage = null;
-    
+
     return obj;
   }
 
@@ -665,6 +665,14 @@ export default class IntegrationModel {
   removeEvents() {
     const eventTarget = this.isIframe ? this.target.contentWindow.document : this.target;
     Util.removeElementEvents(eventTarget);
+  }
+
+  /**
+   * Remove events and set this.editorObject to null in order to prevent memory leaks.
+   */
+  destroy() {
+    this.removeEvents();
+    this.editorObject = null;
   }
 
   /**
@@ -796,7 +804,7 @@ export default class IntegrationModel {
   getSelectedItem(target, isIframe) {}
 
   // Set temporal image to null and make focus come back.
-  static setActionsOnCancelButtons() {    
+  static setActionsOnCancelButtons() {
 
     // Make focus come back on the previous place it was when click cancel button
     const currentInstance = WirisPlugin.currentInstance;


### PR DESCRIPTION
## Description

Two objects from our CK5 plugin (ClassicEditor and CKEditor5Integration) are not been correctly destroyed by the garbage collector the first time that a CK5 Editor is destroyed. This two objects are created again when the editor is recreated. This just happen the first time that the editor is recreated.

![image](https://user-images.githubusercontent.com/91468181/233375631-a5c9a64e-ef5c-4b01-9a47-f2c93f086d02.png)

## Steps to reproduce

Use this demo from [integrations-sandbox](https://github.com/wiris/integrations-sandbox/tree/KB-17299) using the branch **KB-34718** to destroy and recreate the CKEditor5.

1. Open the `integrations-sandbox/compositions/html5/ckeditor5-memory-leak-demo` demo.
2. Change the src code from `node_module/@wiris/...` packages from the src code from this PR.
3. Open the inspector and go to the Memory page.
4. Make a Snapshot.
5. Press the Reload CKEditor button. The editor will be destroyed and created again.
6. Make a second Snapshot.

---

[#taskid 34718](https://wiris.kanbanize.com/ctrl_board/2/cards/34718/details/)