### PR TITLE
fix(CK4): Drag&Drop formula between windows not editable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Last release of this project is was 30th of September 2021.
   - Fix: Confirmation dialog closure does not place the caret next to the formula. #KB-26844
   - Fix (froala): Remove Unlicensed message. #KB-25900
   - Refactor (generic): Remove editor language conf from generic demo. #KB-32550
+  - Fix (ckeditor4): Copypasted/Dragdropped formula from a window to another is not editable. #KB-24226
 
 ### 8.1.1 2023-01-11
 

--- a/packages/ckeditor4/plugin.src.js
+++ b/packages/ckeditor4/plugin.src.js
@@ -369,6 +369,11 @@ export class CKEditor4Integration extends IntegrationModel {
         WirisPlugin.instances[editor.name] = ckeditorIntegrationInstance;
         WirisPlugin.currentInstance = ckeditorIntegrationInstance;
       });
+
+      // Parse the editor content after copy & paste / drag & drop
+      editor.on('afterPaste', function (event) {
+        editor.setData(Parser.initParse(editor.getData()));
+      });
     },
   });
 }());


### PR DESCRIPTION
## Description

When dragging and dropping a formula from a window to another in CKEditor 4, the formula is not editable. 

This happens because when copy & paste or drag & drop formulas from one window to another, it does not copy the class or ID of those, hence the new pasted formula is not detected as a formula but as a plain image.

To fix the issue, we call the `initParse` function whenever we paste a formula to the editor.

## Steps to reproduce

1. Open the staging demo in two different windows in the Chrome browser.
2. Copy or drag the quadratic formula from a window and paste it in the other.
3. Double-click the pasted formula.
4. The MT window should open, and the formula should be editable.

---

[#taskid 24226](https://wiris.kanbanize.com/ctrl_board/2/cards/24226/details/)
