### PR TITLE
KB 32324 - Add open/close MT/CT Editor global events.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@ Last release of this project is was 30th of September 2021.
 ### Unreleased
 
   - Fix: detect if device is mobile. #KB-33529
+  - Fix: don't add an extra whitespace between `<math` and `xmlns`. #KB-32826
+  - Feat: Add close/open global events. #KB-32324
 
 ### 8.2.6 2023-03-17
 
@@ -20,7 +22,6 @@ Last release of this project is was 30th of September 2021.
   - Fix: Confirmation dialog closure does not place the caret next to the formula. #KB-26844
   - Fix (froala): Remove Unlicensed message. #KB-25900
   - Refactor (generic): Remove editor language conf from generic demo. #KB-32550
-  - Fix: don't add an extra whitespace between `<math` and `xmlns`. #KB-32826
 
 ### 8.1.1 2023-01-11
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,23 @@
 
 Mono-repository for the [MathType](http://www.wiris.com/en/mathtype) Web plugins and their dependencies.
 
+## MathType Events
+
+To capture events triggered by MathType editor, use the next code:
+
+```js
+// Capture onModalOpen event triggered when MT/CT editor is open
+let modalOpenListener = window.WirisPlugin.Listeners.newListener('onModalOpen', () => {
+  ... // Your callback function
+});
+window.WirisPlugin.Core.addGlobalListener(modalOpenListener);
+```
+
+### List of Global Events
+
+- `onModalOpen()` Triggered when MT/CT editor modal is open
+- `onModalClose()` Triggered when MT/CT editor modal is close
+
 ## Table of contents
 
 - [Requirements](#requirements)

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -1,4 +1,5 @@
 import Configuration from './configuration';
+import Core from './core.src';
 import EditorListener from './editorlistener';
 import Listeners from './listeners';
 import MathML from './mathml';
@@ -481,6 +482,8 @@ export default class ContentManager {
     } catch (err) {
       console.error(err);
     }
+
+    Core.globalListeners.fire('onModalOpen', {});
   }
 
   /**

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -7,6 +7,7 @@ import StringManager from './stringmanager';
 import ContentManager from './contentmanager';
 import Telemeter from './telemeter';
 import IntegrationModel from './integrationmodel';
+import Core from './core.src';
 
 import closeIcon from '../styles/icons/general/close_icon.svg';  //eslint-disable-line
 import closeHoverIcon from '../styles/icons/hover/close_icon_h.svg';  //eslint-disable-line
@@ -597,6 +598,8 @@ export default class ModalDialog {
     this.saveModalProperties();
     this.unlockWebsiteScroll();
     this.properties.open = false;
+
+    Core.globalListeners.fire('onModalClose', {});
   }
 
   /**


### PR DESCRIPTION
## Description

This PR adds two global Events on Devkit module to capture when the MathType/ChemType editor is open/close.

### List of Global Events added:

- `onModalOpen()` Triggered when MT/CT editor modal is open
- `onModalClose()` Triggered when MT/CT editor modal is close

## Steps to reproduce

1. Add next code inside `app.js` from any demo, after editor is created:

```js
let modalOpenListener = window.WirisPlugin.Listeners.newListener('onModalOpen', () => {
    console.log('onModalOpen');
});

window.WirisPlugin.Core.addGlobalListener(modalOpenListener);

let modalCloseListener = window.WirisPlugin.Listeners.newListener('onModalClose', () => {
    console.log('onModalClose');
});

window.WirisPlugin.Core.addGlobalListener(modalCloseListener);
```
2. Open the demo.
3. On the demo, open the browser inspector.
4. Open MathType editor.

A console log with the text onModalOpen will appear.

5. Close the MathType ediro

A console log with the text onModalClose will appear.

---

[#taskid 32324](https://wiris.kanbanize.com/ctrl_board/2/cards/32324/details/)