### PR TITLE
fix: convert special symbols to entities when using ck5 getData()

### DIFF
--- a/demos/html/ckeditor5/src/app.js
+++ b/demos/html/ckeditor5/src/app.js
@@ -34,11 +34,12 @@ ClassicEditor
     plugins: [Essentials, Paragraph, Bold, Italic, MathType, Alignment],
     toolbar: ['bold', 'italic', 'MathType', 'ChemType', 'alignment:left', 'alignment:center', 'alignment:right'],
     // language: 'de',
-    // mathTypeParameters: {
-    //   editorParameters: { language: 'es' }, // MathType config, including language
-    // },
+    mathTypeParameters: {
+      editorParameters: { toolbar: "<toolbar ref='general'><tab ref='symbols' empty='true'><section rows='3'><item ref='&gt;' extra='false'/><item ref='&lt;' extra='false'/></section></tab></toolbar>" }, // MathType config, including language
+    },
   })
   .then((editor) => {
+    alert('Remove last commit on merge');
     window.editor = editor;
     // Add listener on click button to launch updateContent function.
     // document.getElementById('btn_update').addEventListener('click', (e) => {

--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -412,11 +412,11 @@ export default class MathType extends Plugin {
     const { get } = editor.data;
 
     /**
-         * Hack to transform $$latex$$ into <math> in editor.getData()'s output.
-         */
+     * Hack to transform $$latex$$ into <math> in editor.getData()'s output.
+     */
     editor.data.get = (options) => {
       const output = get.bind(editor.data)(options);
-      return Parser.endParse(output);
+      return Parser.endParse(MathML.mathMLEntities(output));
     };
   }
 

--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -337,7 +337,7 @@ export default class MathType extends Plugin {
     function createViewImage(modelItem, { writer: viewWriter }) {
       const htmlDataProcessor = new HtmlDataProcessor(viewWriter.document);
 
-      const mathString = modelItem.getAttribute('formula');
+      const mathString = modelItem.getAttribute('formula').replace('ref="<"', 'ref="&lt;"');
       const imgHtml = Parser.initParse(mathString, editor.config.get('language'));
       const imgElement = htmlDataProcessor.toView(imgHtml).getChild(0);
 
@@ -415,8 +415,8 @@ export default class MathType extends Plugin {
      * Hack to transform $$latex$$ into <math> in editor.getData()'s output.
      */
     editor.data.get = (options) => {
-      const output = get.bind(editor.data)(options);
-      return Parser.endParse(MathML.mathMLEntities(output));
+      let output = get.bind(editor.data)(options);
+      return Parser.endParse(output);
     };
   }
 


### PR DESCRIPTION
## Description

When user set a custom toolbar with the buttons `<` or `>`, for example:

```
"<toolbar ref='general'><tab ref='symbols' empty='true'><section rows='3'><item ref='&gt;' extra='false'/></section></tab></toolbar>"
```
:warning: We use `&gt;` and `&lt;` instead  `<` and `>` to avoid conflicts with `showimage` service. 

The custom toolbar xml is added on the `<annotation>` tag from inserted formulas.

CKEditor5 convert the `&gt;` and `&lt;` to `<` and `>` again, causing issues with `showimage` service on users that have custom tags with this two buttons set when they use the getData() function.

This issue have been fixed on this PR and now the special characters are converted to HTML Entity (decimal) when using getData() function.

## Steps to reproduce

1. Set next custom toolbar on editorParameters on CKEditor5: 
```
"<toolbar ref='general'><tab ref='symbols' empty='true'><section rows='3'><item ref='&gt;' extra='false'/></section></tab></toolbar>"
```
3. Open the CKEditor5 demo
4. Insert a formula
5. Open the inspector
6. Insert next code on the inspector console:
```
const data = editor.getData();
editor.setData(data);
```

No error appears on inspector console.

---

[#taskid 34675](https://wiris.kanbanize.com/ctrl_board/2/cards/34675/details/)