### PR TITLE
fix: demo handwritte formulas open in hand mode

### DIFF
--- a/demos/html/tinymce6/src/app.js
+++ b/demos/html/tinymce6/src/app.js
@@ -43,6 +43,9 @@ tinymce.init({
     editor.on('init', () => {
       // Get and set the editor and wiris versions in this order.
       Generic.setEditorAndWirisVersion(`${tinymce.majorVersion}.${tinymce.minorVersion}`, WirisPlugin.currentInstance.version);   //eslint-disable-line
+
+      // Insert the initial content in the editor.
+      editor.setContent(Generic.editorContentMathML);
     });
   },
 });


### PR DESCRIPTION
## Description

Now the previous inserted handwritte formulas doesn't lose the annotations tags.

## Steps to reproduce

1. Open the tinymce6 demo
2. Open the handwritte formulas

The editor is open in hand mode

---

Closes #X (*Associated GitHub issue, if any*)

[#taskid 34309](https://wiris.kanbanize.com/ctrl_board/2/cards/34309/details/)