### PR TITLE
fix: add keydown event on window to prevent end of propagation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project is was 30th of September 2021.
 
+### Unreleased
+
+  - Fix: add keydown event on window to prevent end of propagation. #KB-21649
+
 ### 8.3.1 2023-05-23
 
   - Fix (ckeditor5): Hand copied&pasted formulas not opening in hand mode. #KB-32892

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -1038,7 +1038,7 @@ export default class ModalDialog {
     Util.addEvent(window, 'mousemove', this.drag.bind(this));
     Util.addEvent(window, 'resize', this.onWindowResize.bind(this));
     // Key events.
-    Util.addEvent(this.container, 'keydown', this.onKeyDown.bind(this));
+    Util.addEvent(window, 'keydown', this.onKeyDown.bind(this));
   }
 
   /**
@@ -1051,7 +1051,7 @@ export default class ModalDialog {
     Util.removeEvent(window, 'mousemove', this.drag);
     Util.removeEvent(window, 'resize', this.onWindowResize);
     // Key events.
-    Util.removeEvent(this.container, 'keydown', this.onKeyDown);
+    Util.removeEvent(window, 'keydown', this.onKeyDown);
   }
 
   /**


### PR DESCRIPTION
## Description

This PR adds the keydown event when user press esc to close the editor modal on the window level, to prevent stop event propagation.

## Steps to reproduce

1. Open the tinymce6 demo
2. Open the handwritte formulas
3. Press ESC

Warning modal will appear.

---

[#taskid 21649](https://wiris.kanbanize.com/ctrl_board/2/cards/21649/details/)
