### PR TITLE
Fix strange behavior when the caret at the beginnig

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Last release of this project is was 30th of September 2021.
 ### Unreleased
 
   - Fix (froala): Console error when uploading an image with the MathType plugin enabled. #KB-36131
+  - Fix (devkit): Strange behavior when the caret is placed at the beginning of the HTML Editor. #KB-21754
 
 ### 8.4.0 2023-06-15
 

--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -791,6 +791,24 @@ export default class Util {
         const position = range.startOffset;
 
         if (node.childNodes[position]) {
+
+          // In case that a formula is detected but not selected,
+          // we create an empty span where we could insert the new formula.
+          if (range.startOffset === range.endOffset) {
+            if (position !== 0 && node.childNodes[position - 1].localName === 'span' && node.childNodes[position].classList.contains('Wirisformula')) {
+              node.childNodes[position - 1].remove();
+              return Util.getSelectedItem(target, isIframe, forceGetSelection);
+            }
+            else if (node.childNodes[position].classList.contains('Wirisformula')) {
+              if ((position > 0 && node.childNodes[position - 1].classList.contains('Wirisformula')) || position === 0 ) {
+                var emptySpan = document.createElement('span');
+                node.insertBefore(emptySpan, node.childNodes[position]);
+                return {
+                  node: node.childNodes[position],
+                }
+              }
+            } 
+          }
           return {
             node: node.childNodes[position],
           };


### PR DESCRIPTION
## Description

When the caret was at the beginning of the editor where there's a formula, instead of opening a new formula, it edits the one on top. This PR fixes the mentioned behavior by changing the nodes where the formulas should be added.

This bug was happening also in between 2 formulas when they were at the beginning of the editor.

## Steps to reproduce

1. Install dependencies with `yarn`.
2. Build the desired demo with `nx build <PACKAGE>`.
3. Start the demo with `nx start html-<PACKAGE>`.
4. Empty the content of the text area.
5. Insert a formula.
6. Place the caret at the beginning of the text are and insert a formula.
7. Verify that when clicking on the MT/CT button, the first formula was not being edited. Verify also that the new added formula is placed where it should.

> The issue was present on all editors but CKEditor5. They should all be tested.

---
[#taskid 21754](https://wiris.kanbanize.com/ctrl_board/2/cards/21754/details/)
