### PR TITLE
Prevent generate multiple instances of Telemeter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Last release of this project is was 30th of September 2021.
 
 ### Unreleased
 
+  - Fix: Prevent initialize multiple telemetes. #KB-35935
   - Fix (froala): Console error when uploading an image with the MathType plugin enabled. #KB-36131
   - Fix (devkit): Strange behavior when the caret is placed at the beginning of the HTML Editor. #KB-21754
 

--- a/packages/devkit/src/telemeter.js
+++ b/packages/devkit/src/telemeter.js
@@ -15,7 +15,8 @@ export default class Telemeter {
    * @param {Object} telemeterAttributes.config - Configuration parameters.
    */
   static init(telemeterAttributes) {
-    if (!this.telemeter){
+    if (!this.telemeter && !this.waitingForInit){
+      this.waitingForInit = true;
       init(telemeterAttributes.url)
         .then(() => {
           this.telemeter = new TelemeterWASM(
@@ -26,6 +27,7 @@ export default class Telemeter {
         .catch((error) => {
           console.log(error);
         })
+        .finally(() => this.waitingForInit = false);
     }
   }
 


### PR DESCRIPTION
## Description

This bug was detected on CKEditor5 with Vue but the fix can prevent future issues. When user open for first time a Vue page with multiples CKEditor5 the telemeter init could be executed multiple times too. This is causing the next runtime error:

```
telemeter_wasm.js:784 [Telemeter] Module ready (3 times)

closure invoked recursively or destroyed already
at imports.wbg.__wbindgen_throw (webpack-internal:///./node_modules/@wiris/mathtype-html-integration-devkit/telemeter-wasm/telemeter_wasm.js:841:15)
at [http://localhost:8080/b92b3f8760238484.wasm:wasm-function[1073]:0x4726b](http://localhost:8080/b92b3f8760238484.wasm:wasm-function%5B1073%5D:0x4726b)
at [http://localhost:8080/b92b3f8760238484.wasm:wasm-function[920]:0x45fc8](http://localhost:8080/b92b3f8760238484.wasm:wasm-function%5B920%5D:0x45fc8)
at __wbg_adapter_40 (webpack-internal:///./node_modules/@wiris/mathtype-html-integration-devkit/telemeter-wasm/telemeter_wasm.js:254:10)
at real (webpack-internal:///./node_modules/@wiris/mathtype-html-integration-devkit/telemeter-wasm/telemeter_wasm.js:235:20)
```

This PR fix this issue checking If the initialitzacion of the telemeter is being executed before executing a new init.

## Steps to reproduce

1. Open the Vue demo from `integrations-sandbox` on branch `main`.
 1.1. Navigate to `integrations-sandbox/composition/vue/vue-multiple-editors/`
 1.2. Execute `npm install`
2. Open the file `integrations-sandbox/composition/vue/vue-multiple-editors/node-modules/@wiris/mathtype-html-integration-devkit/src/telemeter.js`
3. Replace all code function `static init(telemeterAttributes)` from `telemeter.js` file for: 
 
```
  static init(telemeterAttributes) {
    if (!this.telemeter && !this.waitingForInit){
      this.waitingForInit = true;
      init(telemeterAttributes.url)
        .then(() => {
          this.telemeter = new TelemeterWASM(
            telemeterAttributes.solution,
            telemeterAttributes.hosts,
            telemeterAttributes.config);
          this.waitingForInit = false;
        })
        .catch((error) => {
          console.log(error);
          this.waitingForInit = false;
        })
    }
  }
```

> This code includes the fix

4. With the terminal on `integrations-sandbox/composition/vue/vue-multiple-editors/` execute `npm run dev`.

> The demo will be open on the browser. 

6. Open the browser Inspector.

> On the browser Inspector will not appear the error: `closure invoked recursively or destroyed already...`

 
---

Closes #816
[#taskid 35935](https://wiris.kanbanize.com/ctrl_board/2/cards/35935/details/)
