### PR TITLE
fix: convert special symbols to entities when using ck5 getData()

### DIFF
--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -337,7 +337,7 @@ export default class MathType extends Plugin {
     function createViewImage(modelItem, { writer: viewWriter }) {
       const htmlDataProcessor = new HtmlDataProcessor(viewWriter.document);
 
-      const mathString = modelItem.getAttribute('formula');
+      const mathString = modelItem.getAttribute('formula').replace('ref="<"', 'ref="&lt;"');
       const imgHtml = Parser.initParse(mathString, editor.config.get('language'));
       const imgElement = htmlDataProcessor.toView(imgHtml).getChild(0);
 
@@ -410,8 +410,8 @@ export default class MathType extends Plugin {
      * Hack to transform $$latex$$ into <math> in editor.getData()'s output.
      */
     editor.data.get = (options) => {
-      const output = get.bind(editor.data)(options);
-      return Parser.endParse(MathML.mathMLEntities(output));
+      let output = get.bind(editor.data)(options);
+      return Parser.endParse(output);
     };
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4396,11 +4396,6 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.1.tgz#34bdc31727a1889198855913db2f270ace6d7bf8"
   integrity sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==
 
-"@wiris/mathtype-html-integration-devkit@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@wiris/mathtype-html-integration-devkit/-/mathtype-html-integration-devkit-1.2.0.tgz#86c4f189f7ab1f42db5765a9d86eda3c5eb0e4e8"
-  integrity sha512-cf8fu7QuqHAglc5vLbz/gNthG8druiFfVP2YrzVq9ry13iZGP41swkxcSkPqjVVyaXoq4db4DKgBIRON35uTsA==
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
## Description

When user set a custom toolbar with the buttons `<` or `>`, for example:

```
"<toolbar ref='general'><tab ref='symbols' empty='true'><section rows='3'><item ref='&gt;' extra='false'/></section></tab></toolbar>"
```
:warning: We use `&gt;` and `&lt;` instead  `<` and `>` to avoid conflicts with `showimage` service. 

The custom toolbar xml is added on the `<annotation>` tag from inserted formulas.

CKEditor5 convert the `&gt;` and `&lt;` to `<` and `>` again, causing issues with `showimage` service on users that have custom tags with this two buttons set when they use the getData() function.

This issue have been fixed on this PR and now the special characters are converted to HTML Entity (decimal) when using getData() function.

## Steps to reproduce

1. Set next custom toolbar on editorParameters on CKEditor5: 
```
"<toolbar ref='general'><tab ref='symbols' empty='true'><section rows='3'><item ref='&gt;' extra='false'/></section></tab></toolbar>"
```
3. Open the CKEditor5 demo
4. Insert a formula
5. Open the inspector
6. Insert next code on the inspector console:
```
const data = editor.getData();
editor.setData(data);
```

No error appears on inspector console.

---

[#taskid 34675](https://wiris.kanbanize.com/ctrl_board/2/cards/34675/details/)
