### PR TITLE
Fix the WordPress focus on MT that was lost

### DIFF
--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -393,6 +393,10 @@ export default class ContentManager {
   onFocus() {
     if (typeof this.editor !== 'undefined' && this.editor != null) {
       this.editor.focus();
+
+      // On WordPress integration, the focus gets lost right after setting it.
+      // To fix this, we enforce another focus some miliseconds afther this behaviour.
+      setTimeout(() => {this.editor.focus()}, 100);
     }
   }
 

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -395,7 +395,7 @@ export default class ContentManager {
       this.editor.focus();
 
       // On WordPress integration, the focus gets lost right after setting it.
-      // To fix this, we enforce another focus some miliseconds afther this behaviour.
+      // To fix this, we enforce another focus some milliseconds after this behaviour.
       setTimeout(() => {this.editor.focus()}, 100);
     }
   }


### PR DESCRIPTION
## Description

The focus was lost on the way, when opening the MathType modal after the first time, due to WordPress doing.
This task fixes it and makes focus go back to the MathType modal.

## Steps to reproduce

1. Follow the instructions on the [MathType for WordPress](https://github.com/wiris/mathtype-wordpress) project to start a new instance.
2. Install dependencies on `html-integrations` with `yarn install`.
3. Build the TinyMCE package with `nx build tinymce5`.
4. Copy the `plugin.min.js` generated file from the `html-integrations/packages/tinymce5` to the `mathtype-wordpress/build` folder.
5. Refresh or start a new page on WordPress.

---

[#taskid 35995](https://wiris.kanbanize.com/ctrl_board/2/cards/35995/details/)