### PR TITLE
Fix that the default formulas were opened with ChemType

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Last release of this project is was 30th of September 2021.
   - Fix: Prevent initialize multiple telemetes. #KB-35935
   - Fix (froala): Console error when uploading an image with the MathType plugin enabled. #KB-36131
   - Fix (devkit): Strange behavior when the caret is placed at the beginning of the HTML Editor. #KB-21754
+  - Fix: The default formulas were opened with CT Modal. #KB-36421
 
 ### 8.4.0 2023-06-15
 

--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -404,7 +404,7 @@ export default class Util {
     // Get all the annotation content including the tags.
     let annotation = html.match(annotationRegex);
     // Sanitize html code without removing the <semantics> and <annotation> tags.
-    html = DOMPurify.sanitize(html, { ADD_TAGS: ['semantics', 'annotation'], ALLOWED_ATTR: ['linebreak']});
+    html = DOMPurify.sanitize(html, { ADD_TAGS: ['semantics', 'annotation'], ALLOWED_ATTR: ['mathvariant', 'class', 'linebreak']});
     // Readd old annotation content.
     return html.replace(annotationRegex, annotation);
   }


### PR DESCRIPTION
## Description

This PR fixes an issue where the default formulas were being opened with the ChemType modal on CKEditor5 demos. The bug was caused by the DOM purify, which removed the attributes in charge of differentiating if the formula was Math or Chem.

## Steps to reproduce

1. Open the CKEditor5 demo.
2. Validate that the ChemType formulas are opened with the CT modal on double-click.

---

[#taskid 36421](https://wiris.kanbanize.com/ctrl_board/2/cards/36421/details/)
