### PR TITLE
Alignment issues in TinyMCE 6 and Froala

### DIFF
--- a/demos/html/tinymce6/src/app.js
+++ b/demos/html/tinymce6/src/app.js
@@ -8,9 +8,6 @@ import * as Generic from 'resources/demos/imports';
 document.getElementById('header_title_name').innerHTML = 'MathType for TinyMCE 6 on HTML';
 document.getElementById('version_editor').innerHTML = 'TinyMCE editor: ';
 
-// Insert the initial content in the editor
-document.getElementById('editor').innerHTML = Generic.editorContentMathML;
-
 // Copy the editor content before initializing it.
 // Currently disabled by decision of QA.
 // Generic.copyContentFromxToy('editor', 'transform_content');

--- a/packages/ckeditor4/plugin.src.js
+++ b/packages/ckeditor4/plugin.src.js
@@ -69,9 +69,10 @@ export class CKEditor4Integration extends IntegrationModel {
      * @override
      */
   getLanguage() {
+    // Try to get editorParameters.language, fail silently otherwise
     try {
       return this.editorParameters.language;
-    } catch (e) { console.error(); }
+    } catch (e) {}
     // Returns the CKEDitor instance language.
     if (this.editorObject.langCode != null) {
       return this.editorObject.langCode;

--- a/packages/ckeditor5/src/integration.js
+++ b/packages/ckeditor5/src/integration.js
@@ -36,9 +36,10 @@ export default class CKEditor5Integration extends IntegrationModel {
      */
   getLanguage() {
     // Returns the CKEDitor instance language taking into account that the language can be an object.
+    // Try to get editorParameters.language, fail silently otherwise
     try {
       return this.editorParameters.language;
-    } catch (e) { console.error(); }
+    } catch (e) {}
     const languageObject = this.editorObject.config.get('language');
     if (languageObject != null) {
       if (typeof (languageObject) === 'object') {

--- a/packages/froala/wiris.src.js
+++ b/packages/froala/wiris.src.js
@@ -4,6 +4,7 @@ import Parser from '@wiris/mathtype-html-integration-devkit/src/parser';
 import Constants from '@wiris/mathtype-html-integration-devkit/src/constants';
 import MathML from '@wiris/mathtype-html-integration-devkit/src/mathml';
 import StringManager from '@wiris/mathtype-html-integration-devkit/src/stringmanager';
+import Image from '@wiris/mathtype-html-integration-devkit/src/image';
 
 import packageInfo from './package.json';
 
@@ -144,20 +145,22 @@ export class FroalaIntegration extends IntegrationModel {
   callbackFunction() {
     super.callbackFunction();
 
-    // Froala malforms data-uri in images.
-    // We need to rewrite them.
-    if (Configuration.get('imageFormat') === 'svg') {
-      this.editorObject.events.on('html.set', function () {
-        const images = this.el.getElementsByClassName('Wirisformula');
-        for (let i = 0; i < images.length; i++) {
-          if (images[i].src.substr(0, 10) === 'data:image') {
-            const firstPart = images[i].src.substr(0, 33);
-            const secondPart = images[i].src.substr(33, images[i].src.length);
-            images[i].src = firstPart + encodeURIComponent(decodeURIComponent(secondPart));
-          }
+    this.editorObject.events.on('html.set', function () {
+      const images = this.el.getElementsByClassName('Wirisformula');
+      for (let i = 0; i < images.length; i++) {
+        // Froala removes the styles of images upon inserting them
+        // We need to add the alignment back
+        Image.fixAfterResize(images[i]);
+
+        // Froala malforms data-uri in images.
+        // We need to rewrite them.
+        if (Configuration.get('imageFormat') === 'svg' && images[i].src.substr(0, 10) === 'data:image') {
+          const firstPart = images[i].src.substr(0, 33);
+          const secondPart = images[i].src.substr(33, images[i].src.length);
+          images[i].src = firstPart + encodeURIComponent(decodeURIComponent(secondPart));
         }
-      });
-    }
+      }
+    });
 
     // Froala editor can be instantiated in images.
     if (this.target.tagName.toLowerCase() !== 'img') {

--- a/packages/froala/wiris.src.js
+++ b/packages/froala/wiris.src.js
@@ -43,9 +43,10 @@ export class FroalaIntegration extends IntegrationModel {
    * When no language is set, Froala sets the toolbar to english.
    */
   getLanguage() {
+    // Try to get editorParameters.language, fail silently otherwise
     try {
       return this.editorParameters.language;
-    } catch (e) { console.error(); }
+    } catch (e) {}
     if (this.editorObject.opts.language != null) {
       return this.editorObject.opts.language;
     }

--- a/packages/generic/wirisplugin-generic.src.js
+++ b/packages/generic/wirisplugin-generic.src.js
@@ -92,9 +92,10 @@ export default class GenericIntegration extends IntegrationModel {
      * @returns {string} demo language.
      */
   getLanguage() {
+    // Try to get editorParameters.language, fail silently otherwise
     try {
       return this.editorParameters.language;
-    } catch (e) { console.error(); }
+    } catch (e) {}
     if (typeof _wrs_int_langCode !== 'undefined') { // eslint-disable-line camelcase
       console.warn('Deprecated property wirisformulaeditorlang. Use mathTypeParameters on instead.');
       return _wrs_int_langCode; // eslint-disable-line camelcase, no-undef

--- a/packages/tinymce5/editor_plugin.src.js
+++ b/packages/tinymce5/editor_plugin.src.js
@@ -69,9 +69,10 @@ export class TinyMceIntegration extends IntegrationModel {
      */
   getLanguage() {
     const editorSettings = this.editorObject.settings;
+    // Try to get editorParameters.language, fail silently otherwise
     try {
       return editorSettings.mathTypeParameters.editorParameters.language;
-    } catch (e) { console.error(); }
+    } catch (e) {}
     // Get the deprecated wirisformulaeditorlang
     if (editorSettings.wirisformulaeditorlang) {
       console.warn('Deprecated property wirisformulaeditorlang. Use mathTypeParameters on instead.');
@@ -451,7 +452,7 @@ export const currentInstance = null;
         lang_code = editor.getParam('language');
         lang_code = (lang_code.split("-")[0]).split("_")[0];
       } else lang_code = 'en';
-      
+
 
       // Check if MathType editor is enabled
       if (Configuration.get('editorEnabled')) {

--- a/packages/tinymce6/editor_plugin.src.js
+++ b/packages/tinymce6/editor_plugin.src.js
@@ -64,9 +64,10 @@ export class TinyMceIntegration extends IntegrationModel {
    */
   getLanguage() {
     const editorSettings = this.editorObject;
+    // Try to get editorParameters.language, fail silently otherwise
     try {
       return editorSettings.options.get('mathTypeParameters').editorParameters.language;
-    } catch (e) { console.error(); }
+    } catch (e) {}
     // Get the deprecated wirisformulaeditorlang
     if (editorSettings.options.get('wirisformulaeditorlang')) {
       console.warn('Deprecated property wirisformulaeditorlang. Use mathTypeParameters on instead.');
@@ -423,7 +424,7 @@ export const currentInstance = null;
           icon: mathTypeIcon,
         });
       }
-      
+
       if (chemEnabled) {
         // Dynamic customEditors buttons.
         const customEditors = WirisPlugin.instances[editor.id].getCore().getCustomEditors();


### PR DESCRIPTION
## Description

In TinyMCE 6, formulas lose alignment when clicked.

In Froala, formulas added in the demo by default came without proper alignment.

This PR fixes both of these issues.

## Steps to reproduce

1. Open up the TInyMCE 6 and Froala demos.
2. Check that the formulas are properly aligned
3. Click on any formula, and check that it stays aligned.

---

[#taskid 34325](https://wiris.kanbanize.com/ctrl_board/2/cards/34325/details/)
