### PR TITLE
Get froala api key from secrets on staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -87,6 +87,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Create environment.prod.ts file
+        run: node scripts/createEnvFile.js
+        if: ${{ matrix.framework == 'angular' && matrix.editor == 'froala' }}
+        env:
+          FROALA_API_KEY: ${{ secrets.FROALA_API_KEY }}
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -95,7 +101,9 @@ jobs:
           aws-region: eu-west-2
 
       - name: Build the demos
-        
+        env:
+          FROALA_API_KEY: ${{ secrets.FROALA_API_KEY }}
+          REACT_APP_FROALA_API_KEY: ${{ secrets.FROALA_API_KEY }}
         run: |
           npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_TOKEN }}
           yarn

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ terraform.rc
 
 app.*.json
 app.*.js
+
+**/environments/environment.prod.ts

--- a/demos/angular/froala/src/app/app.component.css
+++ b/demos/angular/froala/src/app/app.component.css
@@ -5,13 +5,3 @@ body {
 .fr-wrapper {
   min-height: 200px;
 }
-
-/* Hide License message */
-div.fr-wrapper>div>a {
-  /* display: none !important; */
-  /* position: fixed; */
-  /* z-index: -99999 !important; */
-  font-size: 0px !important;
-  padding: 0px !important;
-  height: 0px !important;
-}

--- a/demos/angular/froala/src/app/app.component.ts
+++ b/demos/angular/froala/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 
 // Import common resources.
 import * as Generic from 'resources/demos/imports';
+import { environment } from 'src/environments/environment';
 
 // Apply specific demo names to all the objects.
 document.getElementById('header_title_name').innerHTML = 'MathType for Froala on Angular';
@@ -46,6 +47,8 @@ export class AppComponent {
 		htmlAllowedTags:  ['.*'],
     htmlAllowedAttrs: ['.*'],
 
+    key: environment.froalaKey,
+
     // List of tags that are not removed when they have no content inside
     // so that formulas renderize propertly
     htmlAllowedEmptyTags: ['mprescripts', 'none'],
@@ -67,8 +70,7 @@ export class AppComponent {
         Generic.setEditorAndWirisVersion((window as any).FroalaEditor.VERSION, (window as any).WirisPlugin.currentInstance.version);        //eslint-disable-line
 
         // Set initial content
-      this.html.set(editorContent);
-
+        this.html.set(editorContent);
       },
     },
   };

--- a/demos/angular/froala/src/environments/environment.prod.ts
+++ b/demos/angular/froala/src/environments/environment.prod.ts
@@ -1,4 +1,0 @@
-// eslint-disable-next-line import/prefer-default-export
-export const environment = {
-  production: true,
-};

--- a/demos/angular/froala/src/environments/environment.ts
+++ b/demos/angular/froala/src/environments/environment.ts
@@ -5,6 +5,7 @@
 // eslint-disable-next-line import/prefer-default-export
 export const environment = {
   production: false,
+  froalaKey: ''
 };
 
 /*

--- a/demos/html/froala/src/app.js
+++ b/demos/html/froala/src/app.js
@@ -21,6 +21,8 @@ new FroalaEditor('#editor', {                                                   
   // Add [MW] buttons to the image editing popup Toolbar.
   imageEditButtons: ['wirisEditor', 'wirisChemistry', 'imageDisplay', 'imageAlign', 'imageInfo', 'imageRemove'],
 
+  key: process.env.FROALA_API_KEY || '',
+
   // Allow all the tags to understand the mathml
   htmlAllowedTags: ['.*'],
   htmlAllowedAttrs: ['.*'],

--- a/demos/html/froala/src/static/style.css
+++ b/demos/html/froala/src/static/style.css
@@ -5,13 +5,3 @@ body {
 .fr-wrapper {
   min-height: 200px;
 }
-
-/* Hide License message */
-div.fr-wrapper>div>a {
-  /* display: none !important; */
-  /* position: fixed; */
-  /* z-index: -99999 !important; */
-  font-size: 0px !important;
-  padding: 0px !important;
-  height: 0px !important;
-}

--- a/demos/html/froala/webpack.config.js
+++ b/demos/html/froala/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const CopyPlugin = require("copy-webpack-plugin");
+const webpack = require("webpack");
 
 module.exports = (config, context) => {
   return {
@@ -33,6 +34,12 @@ module.exports = (config, context) => {
             to: path.resolve(__dirname, "dist/froala-editor"),
           },
         ],
+      }),
+      // Add the DefinePlugin to define process.env variable
+      new webpack.DefinePlugin({
+        'process.env': {
+          FROALA_API_KEY: JSON.stringify(process.env.FROALA_API_KEY)
+        },
       }),
     ],
     mode: 'none',

--- a/demos/react/froala/src/index.css
+++ b/demos/react/froala/src/index.css
@@ -5,13 +5,3 @@ body {
 .fr-wrapper {
   min-height: 200px;
 }
-
-/* Hide License message */
-div.fr-wrapper>div>a {
-  /* display: none !important; */
-  /* position: fixed; */
-  /* z-index: -99999 !important; */
-  font-size: 0px !important;
-  padding: 0px !important;
-  height: 0px !important;
-}

--- a/demos/react/froala/src/index.js
+++ b/demos/react/froala/src/index.js
@@ -51,6 +51,8 @@ const froalaConfig = {
   // Add [MW] buttons to the image editing popup Toolbar.
   imageEditButtons: ['wirisEditor', 'wirisChemistry', 'imageDisplay', 'imageAlign', 'imageInfo', 'imageRemove'],
 
+  key: process.env.REACT_APP_FROALA_API_KEY || '',
+
   // Allow all the tags to understand the mathml
   htmlAllowedTags: ['.*'],
   htmlAllowedAttrs: ['.*'],

--- a/demos/vue/tinymce-vue-demo/package.json
+++ b/demos/vue/tinymce-vue-demo/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "tinymce-vue-demo",
+  "version": "0.1.0",
+  "private": true,
+  "devDependencies": {
+    "@vue/cli-service": "~5.0.0"
+  }
+}

--- a/scripts/createEnvFile.js
+++ b/scripts/createEnvFile.js
@@ -1,0 +1,29 @@
+/**
+ * Create environment.prod.ts file for the Angular + Froala demo.
+ *
+ * This script is run on the deploy-staging workflow in order to
+ * set the  Froala Key from GitHub secret on staging demo.
+ */
+
+const fs = require('fs');
+
+const dir = './demos/angular/froala/src/environments';
+const prodFile = 'environment.prod.ts';
+
+const content = `export const environment = { production: true, froalaKey: "${process.env.FROALA_API_KEY || ''}" }`;
+
+fs.access(dir, fs.constants.F_OK, (err) => {
+  if (err) {
+    // Create environments folder on angular demo If doesn't exist
+    fs.mkdir(dir, {recursive: true}, (err) => {
+      if (err) throw err;
+    });
+  }
+
+  // Create environment.prod.ts with the froalaKey.
+  try {
+    fs.writeFileSync(dir + '/' + prodFile, content)
+  } catch (err) {
+    process.exit(1);
+  }
+})


### PR DESCRIPTION
## Description

This PR gets the froala api key from github secrets when deploying the [staging demos](https://integrations.wiris.kitchen/stable/html/froala/).

If we don't set the api key the froala editor will self-destruct after a while when not using the localhost.

---

[#taskid 36829](https://wiris.kanbanize.com/ctrl_board/2/cards/36829/details/)
