### PR TITLE
[KB-36582] Add missing retrocompatibility with the com.wiris.js.JsPluginViewer API

### DIFF
--- a/packages/viewer/docs/spec.md
+++ b/packages/viewer/docs/spec.md
@@ -116,3 +116,76 @@ The following table contains a specification of each of the properties.
 | lang                       | The language for the alt text.                                                                                                                                                                                                                                                                                                            | Frontend |                                                  | en                                      |
 | dpi                        | Resolution in dots per inch of the generated image. This feature scales the formula with a factor of dpi/96.                                                                                                                                                                                                                              | Frontend | Positive integer                                 | 96                                      |
 | zoom                       | The scale of the generated image.                                                                                                                                                                                                                                                                                                         | Frontend | Positive floating point number                   | 1                                       |
+
+
+## API
+
+The viewer exposes an API to the global window object with utilities related to rendering formulas.
+This API is obsolete and will eventually be removed or replaced by a newer API.
+
+All of the following methods are exposed inside of `window.com.wiris.js.JsPluginViewer` whenever the script is included in the page.
+
+- `parseSafeMathMLElement`.
+  Render all the formulas written in SafeMathML inside the given element.
+
+  This method is deprecated.
+  There is currently no replacement for rendering SafeMathML formulas.
+  Please consider using {@link renderLatex} or {@link renderMathML}.
+
+  Parameters:
+  - {`HTMLElement`} `element` - Element wherein to render SafeMathML formulas.
+  - `asynchronously` - Currently ignored, only included for retrocompatibility purposes.
+  - `callbackFunc` - Currently ignored, only included for retrocompatibility purposes.
+
+  Return: `void`.
+
+- `parseDocument`.
+  Render all the formulas in the document.
+
+  This method is deprecated.
+  Please consider using `renderMathML`.
+
+  Parameters:
+  - `asynchronously` - Currently ignored, only included for retrocompatibility purposes.
+  - `callbackFunc` - Currently ignored, only included for retrocompatibility purposes.
+  - `safeXml` - Currently ignored, only included for retrocompatibility purposes.
+
+  Return: `Promise<void>`.
+
+- `parseElement`.
+  Render all the formulas inside the given element.
+
+  This method is deprecated.
+  Please consider using `renderMathML`.
+
+  Parameters:
+  - {`HTMLElement`} `element` - Element wherein to render formulas.
+  - `asynchronously` - Currently ignored, only included for retrocompatibility purposes.
+  - `callbackFunc` - Currently ignored, only included for retrocompatibility purposes.
+
+  Return: `Promise<void>`.
+
+- `parseLatexDocument`.
+  Convert all the LaTeX formulas in the document to MathML.t
+
+  This method is deprecated.
+  Please consider using `renderLatex`.
+
+  Parameters:
+  - `asynchronously` - Currently ignored, only included for retrocompatibility purposes.
+  - `callbackFunc` - Currently ignored, only included for retrocompatibility purposes.
+
+  Return: `Promise<void>`.
+
+- `parseLatexElement`.
+  Convert all the LaTeX formulas inside the given element to MathML.
+
+  This method is deprecated.
+  Please consider using `renderLatex`.
+
+  Parameters:
+  - {`HTMLElement`} `element` - Element wherein to convert formulas.
+  - `asynchronously` - Currently ignored, only included for retrocompatibility purposes.
+  - `callbackFunc` - Currently ignored, only included for retrocompatibility purposes.
+
+  Return: `Promise<void>`.

--- a/packages/viewer/index.html
+++ b/packages/viewer/index.html
@@ -7,7 +7,7 @@
   <script src="dist/WIRISplugins.js?viewer=image" defer></script>
   <script>
     window.document.addEventListener('viewerLoaded', () => {
-      // window.viewer.Properties can be modified here
+      // window.viewer.properties can be modified here
       // Changes are reflected live
     });
   </script>

--- a/packages/viewer/src/app.ts
+++ b/packages/viewer/src/app.ts
@@ -1,6 +1,7 @@
 import { Properties } from './properties';
 import { renderLatex } from './latex';
 import { renderMathML } from './mathml';
+import { bypassEncapsulation } from './retro';
 
 // This should be the only code executed outside of a function
 // and the only code containing browser globals (e.g. window)
@@ -69,6 +70,9 @@ async function main(w: Window): Promise<void> {
     // `DOMContentLoaded` has already fired
     start();
   }
+
+  // Expose the old Viewer API as a global
+  bypassEncapsulation(properties, w);
 
   // Dispatch an event notifying that the viewer has been loaded
   document.dispatchEvent(new Event('viewerLoaded'));

--- a/packages/viewer/src/app.ts
+++ b/packages/viewer/src/app.ts
@@ -12,9 +12,12 @@ main(window);
  * @param {Window} w - The window instance of the browser.
  */
 async function main(w: Window): Promise<void> {
+
+  const properties: Properties = await Properties.generate();
+
   // Expose the globals to the browser
   (w as any).viewer = {
-    Properties,
+    properties,
   };
 
   const document = w.document;
@@ -25,11 +28,11 @@ async function main(w: Window): Promise<void> {
    * @param {Document} document - The DOM document in which to search for the rendering root.
    * @param {MutationObserver} observer - Mutation observer to activate or reactivate every time the rendering root changes.
    */
-  Properties.render = async () => {
-    const element: HTMLElement = document.querySelector(Properties.element);
+  properties.render = async () => {
+    const element: HTMLElement = document.querySelector(properties.element);
     if (element) {
-      await renderLatex(element);
-      await renderMathML(element);
+      await renderLatex(properties, element);
+      await renderMathML(properties, element);
     }
   };
 
@@ -37,14 +40,14 @@ async function main(w: Window): Promise<void> {
   // Renders formulas and sets observer
   const start = async () => {
     // First render
-    Properties.render();
+    properties.render();
 
     // Callback called every time there is a mutation in the watched DOM element
     new MutationObserver(async (mutationList, observer) => {
       for (const mutation of mutationList) {
         for (const node of mutation.addedNodes) {
           if (node instanceof HTMLElement) {
-            await Properties.render();
+            await properties.render();
           }
         }
       }
@@ -69,5 +72,4 @@ async function main(w: Window): Promise<void> {
 
   // Dispatch an event notifying that the viewer has been loaded
   document.dispatchEvent(new Event('viewerLoaded'));
-
 }

--- a/packages/viewer/src/latex.ts
+++ b/packages/viewer/src/latex.ts
@@ -8,26 +8,28 @@ interface LatexPosition {
 
 /**
  * Parse the DOM looking for LaTeX nodes and replaces them with the corresponding rendered images.
+ * @param {Properties} properties - Properties of the viewer.
  * @param {HTMLElement} root - Any DOM element that can contain MathML.
  */
-export async function renderLatex(root: HTMLElement) {
+export async function renderLatex(properties: Properties, root: HTMLElement) {
 
-  if (Properties.viewer !== 'image') {
+  if (properties.viewer !== 'image') {
     return;
   }
 
   const latexNodes = findLatexTextNodes(root);
 
   for (const latexNode of latexNodes) {
-    await replaceLatexInTextNode(latexNode);
+    await replaceLatexInTextNode(properties, latexNode);
   }
 }
 
 /**
  * Replace LaTeX instances with MathML inside a given node.
+ * @param {Properties} properties - Properties of the viewer.
  * @param {Node} node - Text node in which to search and replace LaTeX instances.
  */
-async function replaceLatexInTextNode(node: Node) {
+async function replaceLatexInTextNode(properties: Properties, node: Node) {
   const textContent: string = node.textContent || '';
   let pos: number = 0;
 
@@ -44,7 +46,7 @@ async function replaceLatexInTextNode(node: Node) {
       // Get LaTeX text.
       const latex = textContent.substring(nextLatexPosition.start + '$$'.length, nextLatexPosition.end);
       // Convert LaTeX to mathml.
-      const response = await latexToMathml(latex, Properties.editorServicesRoot, Properties.editorServicesExtension);
+      const response = await latexToMathml(latex, properties.editorServicesRoot, properties.editorServicesExtension);
       // Insert mathml node.
       const fragment = document.createRange().createContextualFragment(response.text);
 
@@ -95,7 +97,7 @@ function findLatexTextNodes(root: any): Node[] {
  * @
  */
 function getNextLatexPos(pos: number, text: string): LatexPosition {
-	const firstLatexTags = text.indexOf('$$', pos);
-	const secondLatexTags = firstLatexTags == -1 ? -1 : text.indexOf('$$', firstLatexTags + '$$'.length);
-	return firstLatexTags != -1 && secondLatexTags != -1 ? {'start': firstLatexTags, 'end': secondLatexTags} : null;
+  const firstLatexTags = text.indexOf('$$', pos);
+  const secondLatexTags = firstLatexTags == -1 ? -1 : text.indexOf('$$', firstLatexTags + '$$'.length);
+  return firstLatexTags != -1 && secondLatexTags != -1 ? {'start': firstLatexTags, 'end': secondLatexTags} : null;
 }

--- a/packages/viewer/src/mathml.ts
+++ b/packages/viewer/src/mathml.ts
@@ -13,11 +13,12 @@ interface FormulaData {
 
 /**
  * Parse the DOM looking for <math> elements and replace them with the corresponding rendered images within the given element.
+ * @param {Properties} properties - Properties of the viewer.
  * @param {HTMLElement} root - Any DOM element that can contain MathML.
  */
-export async function renderMathML(root: HTMLElement): Promise<void> {
+export async function renderMathML(properties: Properties, root: HTMLElement): Promise<void> {
 
-  if (Properties.viewer !== 'image') {
+  if (properties.viewer !== 'image') {
     return;
   }
 
@@ -26,12 +27,12 @@ export async function renderMathML(root: HTMLElement): Promise<void> {
 
     let result;
 
-    if (Properties.wirispluginperformance === 'true') {
+    if (properties.wirispluginperformance === 'true') {
       // Transform mml to img.
-      result = await showImage(mml, Properties.lang, Properties.editorServicesRoot, Properties.editorServicesExtension);
+      result = await showImage(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
     } else {
       // createimage returns the URL to showimage of the corresponding image
-      let url = await createImage(mml, Properties.lang, Properties.editorServicesRoot, Properties.editorServicesExtension);
+      let url = await createImage(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
       // This line is necessary due to a bug in how the services interoperate.
       // TODO fix the causing bug
       url = url.replace('pluginsapp', 'plugins/app');
@@ -39,7 +40,7 @@ export async function renderMathML(root: HTMLElement): Promise<void> {
     }
 
     // Set img properties.
-    const img = await setImageProperties(result, mml, Properties.wiriseditormathmlattribute);
+    const img = await setImageProperties(properties, result, mml);
     // const fragment = document.createRange().createContextualFragment(data.result.content);
 
     // Replace the MathML for the generated formula image.
@@ -49,12 +50,12 @@ export async function renderMathML(root: HTMLElement): Promise<void> {
 
 /**
  * Returns an image formula containing all MathType properties.
+ * @param {Properties} properties - Properties of the viewer.
  * @param {FormulaData} data - Object containing image values.
  * @param {string} mml - The MathML of the formula image beeing created.
- * @param {string} wiriseditormathmlattribute - The name of the HTML attribute to store the MathML in.
  * @returns {Promise<HTMLImageElement>} - Formula image.
  */
-async function setImageProperties(data: FormulaData, mml: string, wiriseditormathmlattribute: string): Promise<HTMLImageElement> {
+async function setImageProperties(properties: Properties, data: FormulaData, mml: string): Promise<HTMLImageElement> {
 
   // Create imag element.
   let img = document.createElement('img');
@@ -63,7 +64,7 @@ async function setImageProperties(data: FormulaData, mml: string, wiriseditormat
   img.src = `data:image/svg+xml;charset=utf8,${encodeURIComponent(data.content)}`;
 
   // Set other image properties.
-  img.setAttribute(wiriseditormathmlattribute, mml);
+  img.setAttribute(properties.wiriseditormathmlattribute, mml);
   img.setAttribute('class', 'Wirisformula');
   img.setAttribute('role', 'math');
 
@@ -75,7 +76,7 @@ async function setImageProperties(data: FormulaData, mml: string, wiriseditormat
   }
 
   // Set the alt text.
-  const { text } = await mathml2accessible(mml, Properties.lang, Properties.editorServicesRoot, Properties.editorServicesExtension);
+  const { text } = await mathml2accessible(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
   img.alt = text;
 
   return img;

--- a/packages/viewer/src/properties.ts
+++ b/packages/viewer/src/properties.ts
@@ -48,7 +48,10 @@ export class Properties {
   // Get URL properties (retrocompatibility).
   config: Config = defaultValues;
 
-  // Constructors cannot be async so we make them private and force instantiation through the async generate() method below.
+  /**
+   * Do not use this method. Instead, use {@link Properties.generate}.
+   * Constructors cannot be async so we make it private and force instantiation through an alternative static method.
+   */
   private new() {}
 
   /**

--- a/packages/viewer/src/retro.ts
+++ b/packages/viewer/src/retro.ts
@@ -1,0 +1,255 @@
+import { renderLatex } from "./latex";
+import { renderMathML } from "./mathml";
+import { Properties } from "./properties";
+
+/**
+ * Exposes the {@link JsPluginViewer} singleton instance as window.com.wiris.js.JsPluginViewer.
+ * @param {Properties} properties - Properties of the viewer.
+ * @param {Window} w - Instance of the global window.
+ * @deprecated Consider using {@link renderLatex} or {@link renderMathML}.
+ */
+export function bypassEncapsulation(properties: Properties, w: Window) {
+  const wany = w as any;
+
+  if (typeof wany.com === 'undefined') {
+    wany.com = {};
+  }
+
+  if (typeof wany.com.wiris === 'undefined') {
+    wany.com.wiris = {};
+  }
+
+  if (typeof wany.com.wiris.js === 'undefined') {
+    wany.com.wiris.js = {};
+  }
+
+  if (typeof wany.com.wiris.js.JsPluginViewer === 'undefined') {
+    wany.com.wiris.js.JsPluginViewer = JsPluginViewer.getInstance();
+    JsPluginViewer.properties = properties;
+  }
+}
+
+/**
+ * This class is a compatibility layer with the old Viewer.
+ * See haxe/src-haxe/com/wiris/js/JsPluginViewer.hx in in the repo wiris/plugins previous to commit df1248a.
+ *
+ * WARNING: the methods in this class may contain direct references to globals such as window and document.
+ *
+ * @deprecated Consider using {@link renderLatex} or {@link renderMathML}.
+ */
+class JsPluginViewer {
+  static instance: JsPluginViewer;
+  static properties: Properties;
+
+  static getInstance(): JsPluginViewer {
+    if (JsPluginViewer.instance == null) {
+      JsPluginViewer.instance = new JsPluginViewer();
+    }
+
+    return JsPluginViewer.instance;
+  }
+
+  /**
+   * Render all the formulas written in SafeMathML inside the given element.
+   * @param {HTMLElement} element - Element wherein to render SafeMathML formulas.
+   * @param asynchronously - Currently ignored, only included for retrocompatibility purposes.
+   * @param callbackFunc - Currently ignored, only included for retrocompatibility purposes.
+   * @deprecated There is currently no replacement for rendering SafeMathML formulas.
+   * Please consider using {@link renderLatex} or {@link renderMathML}.
+   */
+  parseSafeMathMLElement(element: HTMLElement, asynchronously?: boolean, callbackFunc?: () => void): void {
+    var mathmlPositions = [];
+    JsPluginViewer.getMathMLPositionsAtElementAndChildren(element, mathmlPositions);
+    for (let i = 0; i < mathmlPositions.length; i++) {
+      var mathmlPosition = mathmlPositions[i];
+      var newNode = document.createElement("math");
+      mathmlPosition.nextElement.parentNode.insertBefore(newNode, mathmlPosition.nextElement);
+      newNode.outerHTML = JsPluginViewer.decodeSafeMathML(mathmlPosition.safeMML);
+    }
+  }
+
+  /**
+   * Render all the formulas in the document.
+   * @param asynchronously - Currently ignored, only included for retrocompatibility purposes.
+   * @param callbackFunc - Currently ignored, only included for retrocompatibility purposes.
+   * @param safeXml - Currently ignored, only included for retrocompatibility purposes.
+   * @deprecated Please consider using {@link renderMathML}.
+   */
+  async parseDocument(asynchronously?: boolean, callbackFunc?: () => void, safeXml?: boolean): Promise<void> {
+    return renderMathML(JsPluginViewer.properties, document.documentElement);
+  }
+
+  /**
+   * Render all the formulas inside the given element.
+   * @param {HTMLElement} element - Element wherein to render formulas.
+   * @param asynchronously - Currently ignored, only included for retrocompatibility purposes.
+   * @param callbackFunc - Currently ignored, only included for retrocompatibility purposes.
+   * @deprecated Please consider using {@link renderMathML}.
+   */
+  async parseElement(element: HTMLElement, asynchronously?: boolean, callbackFunc?: () => void): Promise<void> {
+    return renderMathML(JsPluginViewer.properties, element);
+  }
+
+  /**
+   * Convert all the LaTeX formulas in the document to MathML.
+   * @param asynchronously - Currently ignored, only included for retrocompatibility purposes.
+   * @param callbackFunc - Currently ignored, only included for retrocompatibility purposes.
+   * @deprecated Please consider using {@link renderLatex}.
+   */
+  async parseLatexDocument(asynchronously?: boolean, callbackFunc?: () => void): Promise<void> {
+    return renderLatex(JsPluginViewer.properties, document.documentElement);
+  }
+
+  /**
+   * Convert all the LaTeX formulas inside the given element to MathML.
+   * @param {HTMLElement} element - Element wherein to convert formulas.
+   * @param asynchronously - Currently ignored, only included for retrocompatibility purposes.
+   * @param callbackFunc - Currently ignored, only included for retrocompatibility purposes.
+   * @deprecated Please consider using {@link renderLatex}.
+   */
+  async parseLatexElement(element: HTMLElement, asynchronously?: boolean, callbackFunc?: () => void): Promise<void> {
+    return renderLatex(JsPluginViewer.properties, element);
+  }
+
+  private static decodeSafeMathML(input: string): string {
+    var safeXMLCharactersEntities = JsCharacters.getSafeXMLCharactersEntities();
+    var xmlCharacters = JsCharacters.getXMLCharacters();
+    var safeXMLCharacters = JsCharacters.getSafeXMLCharacters();
+
+    var tagOpenerEntity = safeXMLCharactersEntities.tagOpener;
+    var tagCloserEntity = safeXMLCharactersEntities.tagCloser;
+    var doubleQuoteEntity = safeXMLCharactersEntities.doubleQuote;
+    var realDoubleQuoteEntity = safeXMLCharactersEntities.realDoubleQuote;
+
+
+    // Important to not change function parameter.
+    var inputCopy = input.slice();
+
+    // Decoding entities.
+    inputCopy = inputCopy.split(tagOpenerEntity).join(safeXMLCharacters.tagOpener);
+    inputCopy = inputCopy.split(tagCloserEntity).join(safeXMLCharacters.tagCloser);
+    inputCopy = inputCopy.split(doubleQuoteEntity).join(safeXMLCharacters.doubleQuote);
+    inputCopy = inputCopy.split(realDoubleQuoteEntity).join(safeXMLCharacters.realDoubleQuote);
+
+    var tagOpener = safeXMLCharacters.tagOpener;
+    var tagCloser = safeXMLCharacters.tagCloser;
+    var doubleQuote = safeXMLCharacters.doubleQuote;
+    var realDoubleQuote = safeXMLCharacters.realDoubleQuote;
+    var ampersand = safeXMLCharacters.ampersand;
+    var quote = safeXMLCharacters.quote;
+
+    // Decoding characters.
+    inputCopy = inputCopy.split(tagOpener).join(xmlCharacters.tagOpener);
+    inputCopy = inputCopy.split(tagCloser).join(xmlCharacters.tagCloser);
+    inputCopy = inputCopy.split(doubleQuote).join(xmlCharacters.doubleQuote);
+    inputCopy = inputCopy.split(ampersand).join(xmlCharacters.ampersand);
+    inputCopy = inputCopy.split(quote).join(xmlCharacters.quote);
+
+    // We are replacing $ by & when its part of an entity for retrocompatibility.
+    // Now, the standard is replace § by &.
+    var returnValue = '';
+    var currentEntity = null;
+
+    var i = 0;
+    while (i < inputCopy.length) {
+      var character = inputCopy.charAt(i);
+      if (currentEntity == null) {
+        if (character == '$') {
+          currentEntity = '';
+        } else {
+          returnValue += character;
+        }
+      } else if (character == ';') {
+        returnValue += '&' + currentEntity;
+        currentEntity = null;
+      } else if (character.match(/([a-zA-Z0-9#._-] | '-')/)) { // Character is part of an entity.
+        currentEntity += character;
+      } else {
+        returnValue += '$' + 'currentEntity'; // Is not an entity.
+        currentEntity = null;
+        i -= 1; // Parse again the current character.
+      }
+      i++;
+    }
+
+    return returnValue;
+  }
+
+  private static getMathMLPositionsAtElementAndChildren(element: Node, mathmlPositions) {
+    JsPluginViewer.getMathMLPositionsAtNode(element, mathmlPositions);
+    // Copy current children because DOM will be changed and element.childNodes won't be
+    // consistent on call getMathMLPositionsAtElementAndChildren().
+    var childNodes = Array.from(element.childNodes);
+    if (childNodes.length > 0) {
+      for (let i = 0; i < childNodes.length; i++) {
+        var child = childNodes[i];
+        JsPluginViewer.getMathMLPositionsAtElementAndChildren(child, mathmlPositions);
+      }
+    }
+  }
+
+  private static getMathMLPositionsAtNode(node: Node, mathmlPositions) {
+    var safeXMLCharacters = JsCharacters.getSafeXMLCharacters();
+    if(node.nodeType == 3) {
+      var startMathmlTag = safeXMLCharacters.tagOpener + "math";
+      var endMathmlTag = safeXMLCharacters.tagOpener + "/math" + safeXMLCharacters.tagCloser;
+      var start = node.textContent.indexOf(startMathmlTag);
+      var end = 0;
+      while(start != -1) {
+        end = node.textContent.indexOf(endMathmlTag,start + startMathmlTag.length);
+
+        if(end == -1) break;
+
+        var nextMathML = node.textContent.indexOf(startMathmlTag,end + endMathmlTag.length);
+
+        if(nextMathML >= 0 && end > nextMathML) break;
+
+        var safeMathml = node.textContent.substring(start,end + endMathmlTag.length);
+
+        node.textContent = node.textContent.substring(0,start) + node.textContent.substring(end + endMathmlTag.length);
+        node = (node as Text).splitText(start);
+        start = node.textContent.indexOf(startMathmlTag);
+
+        mathmlPositions.push({
+          safeMML: safeMathml,
+          nextElement: node
+        });
+      }
+    }
+  }
+
+}
+
+class JsCharacters {
+  static getSafeXMLCharactersEntities(): any {
+    return {
+      tagOpener: '&laquo;',
+      tagCloser: '&raquo;',
+      doubleQuote: '&uml;',
+      realDoubleQuote: '&quot;',
+    };
+  }
+
+  static getXMLCharacters(): any {
+    return {
+      id: 'xmlCharacters',
+      tagOpener: '<', // Hex: \x3C.
+      tagCloser: '>', // Hex: \x3E.
+      doubleQuote: '"', // Hex: \x22.
+      ampersand: '&', // Hex: \x26.
+      quote: '\'', // Hex: \x27.
+    };
+  }
+
+  static getSafeXMLCharacters(): any {
+    return {
+      id: 'safeXmlCharacters',
+      tagOpener: '«', // Hex: \xAB.
+      tagCloser: '»', // Hex: \xBB.
+      doubleQuote: '¨', // Hex: \xA8.
+      ampersand: '§', // Hex: \xA7.
+      quote: '`', // Hex: \x60.
+      realDoubleQuote: '¨',
+    };
+  }
+}


### PR DESCRIPTION
## Description

When we released the new Viewer, it didn't have the exact same API for the final user as the old one. Unfortunately our demos from plugins, and possibly some clients, use these old APIs (exposed through the global object `com.wiris.js.JsPluginViewer` inside `window`).

This PR adds a retrocompatibility layer with this old API, in particular it adds the following public methods:

- `parseSafeMathMLElement`
- `parseDocument`
- `parseElement`
- `parseLatexElement`
- `parseLatexDocument`

Respecting as much as possible their old signatures, now typed with TypeScript instead of Haxe.

Nonetheless, most of the arguments for these methods will be ignored, as honoring them would require a deep reworking of the new Viewer to make it, essentially, a clone of the old one.

As a technicism, this development was incompatible with the polling method we used to keep the Properties class static, thus I had to refactor it to be a normal class. Now, the code of the Viewer uses an instance of Properties that is passed around as required.

## Steps to reproduce

You can:

- `yarn`
- `cd packages/viewer && yarn serve`
- Open the local demo (see the console output to know the exact URL) and test that the API works properly, e.g. by modifying the `packages/viewer/index.html` file to use it.

You can also run `yarn build` to generate the output, and replace it in the old plugins demos to see if they respond correctly to the adapted API.

---

[#taskid 36582](https://wiris.kanbanize.com/ctrl_board/2/cards/36582/details/)
