### PR TITLE
[KB-34039] Update how steps output are store in Github actions workflows.

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -34,7 +34,7 @@ jobs:
         id: get_branches
         run: |
           BRANCHES_ARRAY=$(git branch --points-at HEAD | tr -d "* " | jq -R -s -c 'split("\n")[:-1]')
-          echo "::set-output name=branches::${BRANCHES_ARRAY}"
+          echo "branches=${BRANCHES_ARRAY}" >> $GITHUB_OUTPUT
           echo "${BRANCHES_ARRAY}"
 
   clean-staging:


### PR DESCRIPTION
## Description

In this PR the github actions workflows are updated so the outputs are stored correctly, following these instructions https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Associated KB card: https://wiris.kanbanize.com/ctrl_board/2/cards/34039/details/