### PR TITLE
[KB-36808] Add browsing pages to staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -57,12 +57,68 @@ jobs:
       - name: Clean previous deployment of this branch
         run: aws s3 rm s3://wiris-integrations-staging-html/${{ matrix.branch }} --recursive
 
+  deploy-staging-common:
+    name: Deploy the staging environment (common elements)
+    runs-on: ubuntu-latest
+    needs:
+      - prepare
+      - clean-staging
+    strategy:
+      fail-fast: true
+      matrix:
+        branch: ${{ fromJson(needs.prepare.outputs.branches) }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }}
+          aws-region: eu-west-2
+
+      - name: Upload the common files
+        run: |
+          # Replace token %BRANCH% with branch name in staging/branch
+          find staging/branch -type f -exec sed -i 's/%BRANCH%/${{ matrix.branch }}/g' {} \;
+          aws s3 cp staging/branch s3://wiris-integrations-staging-html/${{ matrix.branch }} --recursive
+          aws s3 cp staging/root s3://wiris-integrations-staging-html/ --recursive
+
+      - name: Add branch to the list of branches
+        run: |
+          BRANCHES=branches
+
+          # Check if the remote list of branches exists
+          aws s3api head-object --bucket wiris-integrations-staging-html --key branches || NOT_EXIST=true
+          if [ $NOT_EXIST ]; then
+            # Create empty list of branches
+            touch "${BRANCHES}"
+          else
+            # Copy list of branches from S3 to local
+            aws s3 cp "s3://wiris-integrations-staging-html/${BRANCHES}" "${BRANCHES}"
+          fi
+
+          # Check if branch name is already in the file
+          if ! grep -q -F "${{ matrix.branch }}" "${BRANCHES}"; then
+            # Update local list of branches
+            echo ${{ matrix.branch }} >> "${BRANCHES}"
+            # Upload updated file
+            aws s3 cp "${BRANCHES}" "s3://wiris-integrations-staging-html/${BRANCHES}"
+          fi
+
   deploy-staging:
     name: Deploy the staging environment
     runs-on: ubuntu-latest
     needs:
       - prepare
       - clean-staging
+      - deploy-staging-common
     strategy:
       fail-fast: false
       matrix:
@@ -105,9 +161,13 @@ jobs:
           aws-region: eu-west-2
 
       - name: Build the demos
+<<<<<<< HEAD
         env:
           FROALA_API_KEY: ${{ secrets.FROALA_API_KEY }}
           REACT_APP_FROALA_API_KEY: ${{ secrets.FROALA_API_KEY }}
+=======
+
+>>>>>>> 725d9715 (feat: Add browsing pages to staging)
         run: |
           npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_TOKEN }}
           yarn
@@ -164,6 +224,7 @@ jobs:
     needs:
       - prepare
       - clean-staging
+      - deploy-staging-common
       - deploy-staging
     steps:
 

--- a/.github/workflows/dismantle-staging.yml
+++ b/.github/workflows/dismantle-staging.yml
@@ -32,5 +32,18 @@ jobs:
         run: |
           aws s3 rm s3://wiris-integrations-staging-html/${{ github.event.ref }} --recursive
 
+      - name: Remove branch from the list of branches
+        run: |
+          BRANCHES=branches
+          # Copy list of branches from S3 to local
+          aws s3 cp "s3://wiris-integrations-staging-html/${BRANCHES}" "${BRANCHES}"
+          # Check if branch name is in the file
+          if grep -q -F "${{ matrix.branch }}" "${BRANCHES}"; then
+            # Update local list of branches
+            sed -i '/^${{ github.event.ref }}$/d' "${BRANCHES}"
+            # Upload updated file
+            aws s3 cp "${BRANCHES}" "s3://wiris-integrations-staging-html/${BRANCHES}"
+          fi
+
       - name: Invalidate CloudFront cache
         run: aws cloudfront create-invalidation --distribution-id $(aws cloudfront list-distributions --query "DistributionList.Items[?Aliases.Items!=null] | [?contains(Aliases.Items, 'integrations.wiris.kitchen')].Id | [0]" --output text) --paths '/*'

--- a/staging/branch/angular/index.html
+++ b/staging/branch/angular/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+  <meta charset="utf-8">
+  <title>Demos %BRANCH% / Angular</title>
+  <link rel="stylesheet" href="../../styles.css"/>
+</head>
+<body>
+  <h1><a href="../..">All demos</a> / <a href="..">Branch %BRANCH%</a> / Angular</h1>
+  <nav>
+    <section>
+      <h2>Angular</h2>
+      <ul>
+        <li><a href="ckeditor5">CKEditor 5</a></li>
+        <li><a href="froala">Froala</a></li>
+        <li><a href="generic">Generic</a></li>
+        <li><a href="tinymce5">TinyMCE 5</a></li>
+      </ul>
+    </section>
+  </nav>
+</body>
+</html>

--- a/staging/branch/html/index.html
+++ b/staging/branch/html/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+  <meta charset="utf-8">
+  <title>Demos %BRANCH% / HTML</title>
+  <link rel="stylesheet" href="../../styles.css"/>
+</head>
+<body>
+  <h1><a href="../..">All demos</a> / <a href="..">Branch %BRANCH%</a> / HTML</h1>
+  <nav>
+    <section>
+      <h2>HTML</h2>
+      <ul>
+        <li><a href="ckeditor4">CKEditor 4</a></li>
+        <li><a href="ckeditor5">CKEditor 5</a></li>
+        <li><a href="froala">Froala</a></li>
+        <li><a href="generic">Generic</a></li>
+        <li><a href="tinymce5">TinyMCE 5</a></li>
+        <li><a href="tinymce6">TinyMCE 6</a></li>
+      </ul>
+    </section>
+  </nav>
+</body>
+</html>

--- a/staging/branch/index.html
+++ b/staging/branch/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+  <meta charset="utf-8">
+  <title>Demos %BRANCH%</title>
+  <link rel="stylesheet" href="../styles.css"/>
+</head>
+<body>
+  <h1><a href="..">All demos</a> / Branch %BRANCH%</h1>
+  <nav>
+    <section>
+      <h2><a href="html">HTML</a></h2>
+      <ul>
+        <li><a href="html/ckeditor4">CKEditor 4</a></li>
+        <li><a href="html/ckeditor5">CKEditor 5</a></li>
+        <li><a href="html/froala">Froala</a></li>
+        <li><a href="html/generic">Generic</a></li>
+        <li><a href="html/tinymce5">TinyMCE 5</a></li>
+        <li><a href="html/tinymce6">TinyMCE 6</a></li>
+      </ul>
+    </section>
+    <section>
+      <h2><a href="angular">Angular</a></h2>
+      <ul>
+        <li><a href="angular/ckeditor5">CKEditor 5</a></li>
+        <li><a href="angular/froala">Froala</a></li>
+        <li><a href="angular/generic">Generic</a></li>
+        <li><a href="angular/tinymce5">TinyMCE 5</a></li>
+      </ul>
+    </section>
+    <section>
+      <h2><a href="react">React</a></h2>
+      <ul>
+        <li><a href="react/ckeditor5">CKEditor 5</a></li>
+        <li><a href="react/froala">Froala</a></li>
+        <li><a href="react/generic">Generic</a></li>
+        <li><a href="react/tinymce5">TinyMCE 5</a></li>
+      </ul>
+    </section>
+  </nav>
+</body>
+</html>

--- a/staging/branch/react/index.html
+++ b/staging/branch/react/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+  <meta charset="utf-8">
+  <title>Demos %BRANCH% / React</title>
+  <link rel="stylesheet" href="../../styles.css"/>
+</head>
+<body>
+  <h1><a href="../..">All demos</a> / <a href="..">Branch %BRANCH%</a> / React</h1>
+  <nav>
+    <section>
+      <h2>React</h2>
+      <ul>
+        <li><a href="ckeditor5">CKEditor 5</a></li>
+        <li><a href="froala">Froala</a></li>
+        <li><a href="generic">Generic</a></li>
+        <li><a href="tinymce5">TinyMCE 5</a></li>
+      </ul>
+    </section>
+  </nav>
+</body>
+</html>

--- a/staging/root/index.html
+++ b/staging/root/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang=en>
+<head>
+  <meta charset="utf-8">
+  <title>All demos</title>
+  <link rel="stylesheet" href="styles.css"/>
+  <script type="module">
+    // Scan the branches file and generate links to each of them
+    const response = await fetch('branches');
+    const branchesString = await response.text();
+    const branches = branchesString
+      .split(/\r?\n|\r|\n/g)
+      .filter(line => line !== '');
+    branches.sort();
+    for (const branch of branches) {
+      const element = document.createElement('li');
+      element.innerHTML = `<a href="${branch}">${branch}</a>`;
+      document.getElementById('list').appendChild(element);
+    }
+  </script>
+</head>
+<body>
+  <h1>All demos</h1>
+  <nav>
+    <section>
+      <h2>Branches</h2>
+      <ul id="list"></ul>
+    </section>
+  </nav>
+</body>
+</html>

--- a/staging/root/styles.css
+++ b/staging/root/styles.css
@@ -1,0 +1,15 @@
+body {
+  font-family: sans-serif;
+}
+
+h2 {
+  margin: 5px;
+}
+
+section {
+  background-color: #7eff83;;
+  border: 1px solid #7eff83;;
+  border-radius: 15px;
+  padding: 10px;
+  margin: 5px;
+}


### PR DESCRIPTION
## Description

This PR adds browsing pages to the staging environment.

It adds the following pages:

https://integrations.wiris.kitchen/index.html
https://integrations.wiris.kitchen/$BRANCH/index.html
https://integrations.wiris.kitchen/$BRANCH/html/index.html
https://integrations.wiris.kitchen/$BRANCH/angular/index.html
https://integrations.wiris.kitchen/$BRANCH/react/index.html

for each branch $BRANCH that stems from branch KB-36808 (or from master once KB-36808 is merged to master).

These pages contain navigation links to browse to each demo and even through different branches.

## Steps to reproduce

You can check https://integrations.wiris.kitchen/KB-36808 to see if all the links work properly.

To test that the creation and destruction of branches is properly reflected in https://integrations.wiris.kitchen/, you can follow these steps:

- Create a branch stemming from branch KB-36808 and push it.
- Check that https://integrations.wiris.kitchen shows a link to such branch, and all the subsequent links and pages work.
- Delete the new branch and check that it is removed from https://integrations.wiris.kitchen as well.

---

[#taskid 36808](https://wiris.kanbanize.com/ctrl_board/2/cards/36808/details/)