### PR TITLE
CKEditor4 - MT doesn't open after inserting LaTeX and deleting all editor content

### DIFF
--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -799,7 +799,7 @@ export default class Util {
               node.childNodes[position - 1].remove();
               return Util.getSelectedItem(target, isIframe, forceGetSelection);
             }
-            else if (node.childNodes[position].classList.contains('Wirisformula')) {
+            else if (node.childNodes[position].classList?.contains('Wirisformula')) {
               if ((position > 0 && node.childNodes[position - 1].classList.contains('Wirisformula')) || position === 0 ) {
                 var emptySpan = document.createElement('span');
                 node.insertBefore(emptySpan, node.childNodes[position]);
@@ -807,7 +807,7 @@ export default class Util {
                   node: node.childNodes[position],
                 }
               }
-            } 
+            }
           }
           return {
             node: node.childNodes[position],


### PR DESCRIPTION
## Description

This PR fix a CKEditor4 bug that doesnt allow to open MT Editor after inserting LaTeX and deleting all editor content.

## Steps to reproduce

1. Open the [demo](https://integrations.wiris.kitchen/master/html/ckeditor4/)
2. Type a LaTeX formula
3. Click on Update
4. Delete all the content in the HTML Editor (CTRL+A and DELETE)
5. Click on the MT Button

---

[#taskid 37748](https://wiris.kanbanize.com/ctrl_board/2/cards/37748/details/)
