### PR TITLE
Fix hand formulas MathML is not filtered

### DIFF
--- a/packages/ckeditor4/package.json
+++ b/packages/ckeditor4/package.json
@@ -32,7 +32,7 @@
     "prepack": "yarn && npm run build"
   },
   "dependencies": {
-    "@wiris/mathtype-html-integration-devkit": "1.13.0"
+    "@wiris/mathtype-html-integration-devkit": "1.12.2"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",

--- a/packages/ckeditor5/package.json
+++ b/packages/ckeditor5/package.json
@@ -39,6 +39,6 @@
     "@ckeditor/ckeditor5-engine": ">=23.0.0",
     "@ckeditor/ckeditor5-ui": ">=23.0.0",
     "@ckeditor/ckeditor5-widget": ">=23.0.0",
-    "@wiris/mathtype-html-integration-devkit": "1.13.0"
+    "@wiris/mathtype-html-integration-devkit": "1.12.2"
   }
 }

--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -409,6 +409,8 @@ export default class MathType extends Plugin {
      */
     editor.data.get = (options) => {
       let output = get.bind(editor.data)(options);
+      // Ckeditor retrieves editor data and removes the image information on the formulas
+      // We transform all the retrieved data to images and then we Parse the data.
       let imageFormula = Parser.initParse(output);
       return Parser.endParse(imageFormula);
     };

--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -409,7 +409,8 @@ export default class MathType extends Plugin {
      */
     editor.data.get = (options) => {
       let output = get.bind(editor.data)(options);
-      return Parser.endParse(output);
+      let imageFormula = Parser.initParse(output);
+      return Parser.endParse(imageFormula);
     };
   }
 

--- a/packages/froala/package.json
+++ b/packages/froala/package.json
@@ -33,7 +33,7 @@
     "prepack": "yarn && npm run build"
   },
   "dependencies": {
-    "@wiris/mathtype-html-integration-devkit": "1.13.0"
+    "@wiris/mathtype-html-integration-devkit": "1.12.2"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",

--- a/packages/generic/package.json
+++ b/packages/generic/package.json
@@ -30,7 +30,7 @@
     "prepack": "yarn && npm run build"
   },
   "dependencies": {
-    "@wiris/mathtype-html-integration-devkit": "1.13.0"
+    "@wiris/mathtype-html-integration-devkit": "1.12.2"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",

--- a/packages/tinymce5/package.json
+++ b/packages/tinymce5/package.json
@@ -32,7 +32,7 @@
     "prepack": "yarn && npm run build"
   },
   "dependencies": {
-    "@wiris/mathtype-html-integration-devkit": "1.13.0"
+    "@wiris/mathtype-html-integration-devkit": "1.12.2"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",

--- a/packages/tinymce6/package.json
+++ b/packages/tinymce6/package.json
@@ -32,7 +32,7 @@
     "prepack": "yarn && npm run build"
   },
   "dependencies": {
-    "@wiris/mathtype-html-integration-devkit": "1.13.0"
+    "@wiris/mathtype-html-integration-devkit": "1.12.2"
   },
   "devDependencies": {
     "@babel/core": "^7.15.0",


### PR DESCRIPTION
## Description

The hand formulas MathML was not filtered due to CKEditor5 `get` method.
This PR solved the issue by changing the CKEditor5 `get` method and parsing the retrieved data to create the image formulas and then to get the MathML filtered by us.

## Steps to reproduce

1. Insert a Hand formula. E.g., 5,6
2. Insert the same formula using the keyboard (without Hand).
3. Click the update button.
4. Compare the MathML between the generated formulas (Keyboard, Hand). They should match.

---

[#taskid 37876](https://wiris.kanbanize.com/ctrl_board/2/cards/37876/details/)
