### PR TITLE
[KB-37834] fix: MathType with the new viewer could not edit LaTeX

### DIFF
--- a/packages/viewer/src/app.ts
+++ b/packages/viewer/src/app.ts
@@ -44,22 +44,23 @@ async function main(w: Window): Promise<void> {
     properties.render();
 
     // Callback called every time there is a mutation in the watched DOM element
-    new MutationObserver(async (mutationList, observer) => {
-      for (const mutation of mutationList) {
-        for (const node of mutation.addedNodes) {
-          if (node instanceof HTMLElement) {
-            await properties.render();
-          }
-        }
-      }
-    })
-    // We need to watch over the whole document, in case the Properties.element is inserted
-    // e.g. we set Properties.element = '#renderArea' and then we append <div id="renderArea">$$2+2=4$$</div> to the document
-    .observe(document, {
-      attributes: true, // In case an attribute is changed in a <math> node, for instance
-      childList: true, // In case a new <math> or $$latex$$ node is added, for instance
-      subtree: true, // In case a <math> node is added as a descendant of the observed element, for instance
-    });
+    // Feature temporarily disabled due to KB-37834
+    // new MutationObserver(async (mutationList, observer) => {
+    //   for (const mutation of mutationList) {
+    //     for (const node of mutation.addedNodes) {
+    //       if (node instanceof HTMLElement) {
+    //         await properties.render();
+    //       }
+    //     }
+    //   }
+    // })
+    // // We need to watch over the whole document, in case the Properties.element is inserted
+    // // e.g. we set Properties.element = '#renderArea' and then we append <div id="renderArea">$$2+2=4$$</div> to the document
+    // .observe(document, {
+    //   attributes: true, // In case an attribute is changed in a <math> node, for instance
+    //   childList: true, // In case a new <math> or $$latex$$ node is added, for instance
+    //   subtree: true, // In case a <math> node is added as a descendant of the observed element, for instance
+    // });
   };
 
   // https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event#checking_whether_loading_is_already_complete


### PR DESCRIPTION
## Description

This PR fixes a bug that stops MathType from allowing to edit LaTeX formulas when the new viewer is being used.

The issue can currently only be reproduced in the plugins demos, not on the html-integrations ones. The reason is that the plugins demos take the compiled viewer (WIRISplugins.js), whereas html-integrations uses the one from www.wiris.net, which is the old version (using Haxe). The new viewer has a feature which rerenders the formulas upon modifying the DOM, so when MathType inserts LaTeX, the viewer tries to render it and causes an error.

The proposed solution is to temporarily disable this feature, in order to solve the bug immediately, and reimplement it taking this bug into account.

## Steps to reproduce

1. Start any plugins demo (`cd docker/build`, `EDITOR=<editor> docker compose run <tech>`, `cd ../<tech>`, `EDITOR=<editor> docker compose up`).
2. Write a LaTeX formula in the editor (e.g. `$$x+1$$`).
3. Place the caret inside the formula.
4. Click the MathType button.
5. Edit the formula.
6. Click insert.

### Expected behavior

The formula is successfully edited.

### Actual behavior

The formula doesn't change and an error is shown on the console.

In order to test the changes, you need to change the branch of your html-integrations project to `KB-37834`, but start the demos from plugins (on, for example, the latest commit of the `stable` branch).

---

[#taskid 37834](https://wiris.kanbanize.com/ctrl_board/2/cards/37834/details/)
