### PR TITLE
Fix setData on CKEditor5 not understanding math LaTeX formulas

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project is was 30th of September 2021.
 
+### Unreleased
+
+  - fix(ck5): setData understanding math LaTeX. #KB-39004
+
 ### 8.6.0 2023-10-10
 
   - Feat: Add branch name and commit hash to demo page


### PR DESCRIPTION
## Description

The CKEditor 5 `setData` method was unable to understand MathML LaTeX formulas and resulted in error. This PR fixes the behavior by transforming MathML LaTeX formulas into LaTeX notation before inserting the content in the editor.

## Steps to reproduce

1. Open the CKEditor5 staging demo.
2. Add the following text on the editor: `hello $$\sqrt 1$$`
3. Add a formula if there's none.
4. Open the Console inspector and run the following command: `editor.setData(editor.getData())`.
5. The previous commands set the editor content in the editor, so it should be the same.
6. Try also to run the following command:
```
editor.setData('<p>MathType - Keyboard:&nbsp;<math><msqrt><mi>x</mi></msqrt></math></p><p>MathType - Handwriting:&nbsp;<math><semantics><mfrac><mi>x</mi><mn>3</mn></mfrac><annotation encoding="application/json">{"x":[[8,64,120],[50,74],[49,75],[50,79,80,50,51,63,74,79,78,66,54,48]],"y":[[89,89,89],[7,72],[72,7],[105,105,105,147,147,146,152,168,204,213,211,197]],"t":[[0,0,0],[0,0],[0,0],[0,0,0,0,0,0,0,0,0,0,0,0]],"version":"2.0.0"}</annotation></semantics></math></p><p>ChemType - Keyboard:&nbsp;<math class="wrs_chemistry"><msup><mi mathvariant="normal">x</mi><mn>2</mn></msup></math></p><p>aa <math><semantics><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><annotation encoding="LaTeX">x+1</annotation></semantics></math></p><p>ChemType - Handwriting:&nbsp;<math class="wrs_chemistry"><semantics><msub><mi>x</mi><mn>4</mn></msub><annotation encoding="application/json">{"x":[[5,29],[4,30],[52,52,52,41,41,56]],"y":[[7,72],[72,7],[100,48,48,84,84,84]],"t":[[0,0],[0,0],[0,0,0,0,0,0]],"version":"2.0.0"}</annotation></semantics></math></p>');
```
7. The initial demo content with an additional line with a LaTeX formula should be inserted on the editor and rendered properly.

---

[#taskid 39004](https://wiris.kanbanize.com/ctrl_board/2/cards/39004/details/)
