### PR TITLE
fix: DOMPurify remove attr open close

### DIFF
--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -335,7 +335,7 @@ export default class MathType extends Plugin {
     function createViewImage(modelItem, { writer: viewWriter }) {
       const htmlDataProcessor = new HtmlDataProcessor(viewWriter.document);
 
-      const mathString = modelItem.getAttribute('formula').replace('ref="<"', 'ref="&lt;"');
+      const mathString = modelItem.getAttribute('formula').replace('"<"', '"&lt;"').replace('">"', '"&gt;"');
       const imgHtml = Parser.initParse(mathString, editor.config.get('language'));
       const imgElement = htmlDataProcessor.toView(imgHtml).getChild(0);
 

--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -404,7 +404,7 @@ export default class Util {
     // Get all the annotation content including the tags.
     let annotation = html.match(annotationRegex);
     // Sanitize html code without removing the <semantics> and <annotation> tags.
-    html = DOMPurify.sanitize(html, { ADD_TAGS: ['semantics', 'annotation'], ALLOWED_ATTR: ['mathvariant', 'class', 'linebreak']});
+    html = DOMPurify.sanitize(html, { ADD_TAGS: ['semantics', 'annotation'], ALLOWED_ATTR: ['mathvariant', 'class', 'linebreak', 'open', 'close']});
     // Readd old annotation content.
     return html.replace(annotationRegex, annotation);
   }


### PR DESCRIPTION
## Description

On CKEditor5 DOMPurifty is removing attr open and close from <mfenced> elements

## Steps to reproduce
1. Open MathType for CKEditor5 demo.
2. Insert next mathml on MT Editor.

```
<math xmlns="http://www.w3.org/1998/Math/MathML"><mfenced open="{" close="}"><mrow><mn>4</mn><mo>,</mo><mn>2</mn></mrow></mfenced></math>
```

3. Insert the formula.

The formula must be rendered with the correct brackets `{4, 3}`

---

[#taskid 40148](https://wiris.kanbanize.com/ctrl_board/2/cards/40148/details/)