### PR TITLE
Fix DomPurify replacing undesired tags

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Last release of this project is was 30th of September 2021.
 ### Unreleased
 
   - fix(ck5): setData understanding math LaTeX. #KB-39004
+  - fix: DomPurify replacing undesired characters. KB-39549
 
 ### 8.6.0 2023-10-10
 

--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -257,6 +257,12 @@ export default class MathType extends Plugin {
       // And obtain the complete formula
       formula = Util.htmlSanitize(`<math${mathAttributes}>${formula}</math>`);
 
+      // Replaces the < & > characters to its HTMLEntity to avoid render issues.
+      formula = formula.replace('"<"', '"&lt;"')
+        .replace('">"', '"&gt;"')
+        .replace('><<', '>&lt;<');
+
+
       /* Model node that contains what's going to actually be inserted. This can be either:
             - A <mathml> element with a formula attribute set to the given formula, or
             - If the original <math> had a LaTeX annotation, then the annotation surrounded by "$$...$$" */

--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -404,7 +404,7 @@ export default class Util {
     // Get all the annotation content including the tags.
     let annotation = html.match(annotationRegex);
     // Sanitize html code without removing the <semantics> and <annotation> tags.
-    html = DOMPurify.sanitize(html, { ADD_TAGS: ['semantics', 'annotation'], ALLOWED_ATTR: ['mathvariant', 'class', 'linebreak']});
+    html = DOMPurify.sanitize(html, { ADD_TAGS: ['semantics', 'annotation'], ALLOWED_ATTR: ['mathvariant', 'class', 'linebreak', 'open', 'close']});
     // Readd old annotation content.
     return html.replace(annotationRegex, annotation);
   }


### PR DESCRIPTION
## Description

DomPurify is not taking into account the `open` and `close` attributes from the `mfenced` MathML tag. This PR adds the mentioned attributes to the list of trusted attributes of DomPurify.
DomPurify also replaces the `&lt;` and `&gt;` values for `<` and `>`, which are not rendered by our `showimage` service, when these are values from an attribute.

## Steps to reproduce

1. Open CKEditor5 demo.
2. Create a formula with the open and close braces (`<`, `>`).
3. Drag and drop the formula.
4. No error should appear, and the formula should be correctly rendered on the place it was dropped.

---

[#taskid 39549](https://wiris.kanbanize.com/ctrl_board/2/cards/39549/details/)
