### PR TITLE
Viewer build production mode

### DIFF
--- a/packages/viewer/README.md
+++ b/packages/viewer/README.md
@@ -49,8 +49,16 @@ yarn build
 ```
 
 to compile the package.
-The output will be found in `dist/`.
+The output will be found in `viewer/dist`.
 
+If you want to compile the package in development mode
+Then run
+
+```sh
+yarn build-dev
+```
+
+The output will be found in `viewer/dist`.
 
 ## Documentation
 

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "build": "webpack",
+    "build": "webpack --mode production",
+    "build-dev": "webpack --mode development",
     "serve": "webpack serve",
     "prepack": "yarn && npm run build"
   },

--- a/packages/viewer/project.json
+++ b/packages/viewer/project.json
@@ -13,6 +13,16 @@
         "{options.outputPath}"
       ]
     },
+    "build-dev": {
+      "executor": "nx:run-script",
+      "options": {
+        "script": "build-dev",
+        "outputPath": "packages/viewer/dist"
+      },
+      "outputs": [
+        "{options.outputPath}"
+      ]
+    },
     "lint": {
       "executor": "@nx/linter:eslint",
       "options": {

--- a/packages/viewer/webpack.config.js
+++ b/packages/viewer/webpack.config.js
@@ -3,8 +3,7 @@ const path = require('path');
 module.exports = (config, context) => {
   return {
     entry: './src/app.ts',
-    mode: 'development',
-    devtool: 'inline-source-map',
+    mode: 'none',
     module: {
       rules: [
         {
@@ -34,6 +33,9 @@ module.exports = (config, context) => {
       hot: true,
       port: 8001,
       open: true,
+    },
+    optimization: {
+      minimize: true, // enabling this reduces file size and readability
     },
   }
 };


### PR DESCRIPTION
## Description

This PR change the webpack configuration from viewer package in order to create a production build instead a development build. Also I added a script to create a development build `nx build-dev viewer` in case we want to work/debug the viewer.

## Steps to reproduce

1. Build the viewer for production using command:
```
yarn
nx build viewer
```
2. Check If the viewer works correctly using the **index.html** from the viewer package.

---

[#taskid 39494](https://wiris.kanbanize.com/ctrl_board/2/cards/39494/details/)