### PR TITLE
Fix froala id buttons not being dynamic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Last release of this project is was 22nd of November 2023.
 	- fix: Re-do action not working in TinyMCE 6 and Froala. #KB-39819
 	- fix: Error displayed when adding to the website the contents edited with an HTML editor if some text was added before some LaTeX code.
 	- fix: Drag & drop an inserted formula with brackets would change the brackets to parentheses. #KB-39549
+  - fix: Froala + Generic not setting GUI parameters. #KB-40561
 
 ### 8.6.0 2023-10-10
 

--- a/packages/froala/wiris.src.js
+++ b/packages/froala/wiris.src.js
@@ -92,24 +92,28 @@ export class FroalaIntegration extends IntegrationModel {
 
     super.init();
 
+    // Create dynamic button id.
+    let mathTypeId = 'wirisEditor-' + editor.id;
+    let chemTypeId = 'wirisChemistry-' + editor.id;
+
     // Hide MathType toolbar button if is disabled by config.
     if (!Configuration.get('editorEnabled')) {
       FroalaEditor.ICONS.wirisEditor = null;
       FroalaEditor.COMMANDS.wirisEditor = null;
-      document.getElementById('wirisEditor-1').classList.add('fr-hidden');
+      document.getElementById(mathTypeId).classList.add('fr-hidden');
     } else {
       // Translate the button title
-      document.getElementById('wirisEditor-1').title = StringManager.get('insert_math', editor.opts.language);
+      document.getElementById(mathTypeId).title = StringManager.get('insert_math', editor.opts.language);
     }
 
     // Hide ChemType toolbar button if is disabled by config.
     if (!Configuration.get('chemEnabled')) {
       FroalaEditor.ICONS.wirisChemistry = null;
       FroalaEditor.COMMANDS.wirisChemistry = null;
-      document.getElementById('wirisChemistry-1').classList.add('fr-hidden');
+      document.getElementById(chemTypeId).classList.add('fr-hidden');
     } else {
       // Translate the button title
-      document.getElementById('wirisChemistry-1').title = StringManager.get('insert_chem', editor.opts.language);
+      document.getElementById(chemTypeId).title = StringManager.get('insert_chem', editor.opts.language);
     }
   }
 


### PR DESCRIPTION
## Description

Froala creates `id` for the MathType and ChemType buttons, taking into account the current instance ID. When applying the buttons hover text according to the set language, we use those IDs. This PR fixes the fact that they were static instead of dynamic, as Froala does.

## Steps to reproduce

1. Change the Froala editor language.
2. Start the Froala demo.
3. Hover over the MathType or ChemType button and check that the text is in the set language.

---

[#taskid 40561](https://wiris.kanbanize.com/ctrl_board/2/cards/40561/details/)
