### PR TITLE
feat(viewer): decode safe mathml

### DIFF
--- a/demos/html/viewer/index.html
+++ b/demos/html/viewer/index.html
@@ -46,22 +46,22 @@
       MathType Viewer version: <output id="version"></output>
       <form>
         <label for="wiriseditormathmlattribute">wiriseditormathmlattribute:</label>
-        <input name="wiriseditormathmlattribute" id="wiriseditormathmlattribute" oninput="resetContent(); window.viewer.Properties.wiriseditormathmlattribute = event.target.value;"
+        <input name="wiriseditormathmlattribute" id="wiriseditormathmlattribute" oninput="resetContent(); window.viewer.properties.config.wiriseditormathmlattribute = event.target.value;"
           type="text" value="data-mathml"/>
         <br/>
 
         <label for="wirispluginperformance">wirispluginperformance:</label>
-        <input name="wirispluginperformance" id="wirispluginperformance" oninput="resetContent(); window.viewer.Properties.wirispluginperformance = event.target.value;"
+        <input name="wirispluginperformance" id="wirispluginperformance" oninput="resetContent(); window.viewer.properties.config.wirispluginperformance = event.target.value;"
           type="checkbox" checked/>
         <br/>
 
         <label for="editorServicesRoot">editorServicesRoot:</label>
-        <input name="editorServicesRoot" id="editorServicesRoot" oninput="resetContent(); window.viewer.Properties.editorServicesRoot = event.target.value;"
+        <input name="editorServicesRoot" id="editorServicesRoot" oninput="resetContent(); window.viewer.properties.config.editorServicesRoot = event.target.value;"
           type="text" value="https://www.wiris.net/demo/plugins/app/"/>
         <br/>
 
         <label for="viewer">Viewer:</label>
-        <select name="viewer" id="viewer" onchange="resetContent(); window.viewer.Properties.viewer = event.target.value;">
+        <select name="viewer" id="viewer" onchange="resetContent(); window.viewer.properties.config.viewer = event.target.value;">
           <option value="none">none</option>
           <option value="image" selected>image</option>
           <option value="mathml">mathml</option>
@@ -70,23 +70,23 @@
         <br/>
 
         <label for="element">Element:</label>
-        <input name="element" id="element" oninput="resetContent(); window.viewer.Properties.element = event.target.value;"
+        <input name="element" id="element" oninput="resetContent(); window.viewer.properties.config.element = event.target.value;"
           type="text" value="main"/>
         <br/>
 
         <label for="lang">Language:</label>
-        <input name="lang" id="lang" oninput="resetContent(); window.viewer.Properties.lang = event.target.value;"
+        <input name="lang" id="lang" oninput="resetContent(); window.viewer.properties.config.lang = event.target.value;"
           type="text" value="en"/>
         <br/>
 
         <label for="dpi">DPI:</label>
-        <input name="dpi" id="dpi" onchange="resetContent(); window.viewer.Properties.dpi = +event.target.value;" oninput="document.getElementById('dpiOutput').innerText = event.target.value"
+        <input name="dpi" id="dpi" onchange="resetContent(); window.viewer.properties.config.dpi = +event.target.value;" oninput="document.getElementById('dpiOutput').innerText = event.target.value"
           type="range" min="0" max="100" value="96"/>
         <output id="dpiOutput">96</output>
         <br/>
 
         <label for="zoom">Zoom:</label>
-        <input name="zoom" id="zoom" onchange="resetContent(); window.viewer.Properties.zoom = +event.target.value;" oninput="document.getElementById('zoomOutput').innerText = event.target.value"
+        <input name="zoom" id="zoom" onchange="resetContent(); window.viewer.properties.config.zoom = +event.target.value;" oninput="document.getElementById('zoomOutput').innerText = event.target.value"
           type="range" min="0" max="10" step="0.01" value="1"/>
         <output id="zoomOutput">1</output>
         <br/>


### PR DESCRIPTION
## Description

This PR update the viewer in order to decode `Safe MathML` to `MathML`. This is necesary for moodle filter plugin as the safe mathml rendering from Moodle is not working when using the new viewer.

## Steps to reproduce

1. Use wiris-moodle-docker and deploy `MOODLE_403_STABLE`.
2. Configure MathType filter to use the render option: `Client`.
3. If you have moodle volume on `/html/var/MOODLE_403_STABLE` you can use this webpack.config.js example to build viewer directly to the moodle-filter_wiris plugin:

```
const path = require('path');

module.exports = (config, context) => {
  return {
    entry: './src/app.ts',
    mode: 'none',
    devtool: 'inline-source-map',
    module: {
      rules: [
        {
          test: /\.tsx?$/,
          use: 'ts-loader',
          exclude: /node_modules/,
        },
        {
          test: /\.js$/,
          exclude: /node_modules/,
          use: ['babel-loader']
        },
      ],
    },
    resolve: {
      extensions: ['.tsx', '.ts', '.js'],
    },
    output: {
      filename: 'WIRISplugins.js',
      path: '/var/www/MOODLE_403_STABLE/filter/wiris/render',
    },
    devServer: {
      devMiddleware: {
        writeToDisk: true,
      },
      static:  './',
      hot: true,
      port: 8001,
      open: true,
    },
    optimization: {
      minimize: false, // enabling this reduces file size and readability
    },
  }
};
```
4. On html-integrations run the next commands to build the viewer:
```
yarn
nx build viewer
```
5. Create a course or task with some Math formula with on the description.
6. Check If is rendered correctly.
---

[#taskid 40011](https://wiris.kanbanize.com/ctrl_board/2/cards/40011/details/)