### PR TITLE
fix(ck5): getData returning null

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project is was 26th of October 2023.
 
+### Unreleased
+
+  - fix(ck5): getData returning null when using formulas with '<' and '>'. #KB-40736
+
 ### 8.7.0 2023-10-26
 
   - fix(ck5): setData understanding math LaTeX. #KB-39004

--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -258,9 +258,9 @@ export default class MathType extends Plugin {
       formula = Util.htmlSanitize(`<math${mathAttributes}>${formula}</math>`);
 
       // Replaces the < & > characters to its HTMLEntity to avoid render issues.
-      formula = formula.replace('"<"', '"&lt;"')
-        .replace('">"', '"&gt;"')
-        .replace('><<', '>&lt;<');
+      formula = formula.replaceAll('"<"', '"&lt;"')
+        .replaceAll('">"', '"&gt;"')
+        .replaceAll('><<', '>&lt;<');
 
 
       /* Model node that contains what's going to actually be inserted. This can be either:
@@ -341,7 +341,7 @@ export default class MathType extends Plugin {
     function createViewImage(modelItem, { writer: viewWriter }) {
       const htmlDataProcessor = new HtmlDataProcessor(viewWriter.document);
 
-      const mathString = modelItem.getAttribute('formula').replace('ref="<"', 'ref="&lt;"');
+      const mathString = modelItem.getAttribute('formula').replaceAll('ref="<"', 'ref="&lt;"');
       const imgHtml = Parser.initParse(mathString, editor.config.get('language'));
       const imgElement = htmlDataProcessor.toView(imgHtml).getChild(0);
 
@@ -418,9 +418,9 @@ export default class MathType extends Plugin {
       
       // CKEditor 5 replaces all the time the &lt; and &gt; for < and >, which our render can't understand.
       // We replace the values inserted for CKEditro5 to be able to render the formulas with the mentioned characters.
-      output = output.replace('"<"', '"&lt;"')
-        .replace('">"', '"&gt;"')
-        .replace('><<', '>&lt;<');
+      output = output.replaceAll('"<"', '"&lt;"')
+        .replaceAll('">"', '"&gt;"')
+        .replaceAll('><<', '>&lt;<');
 
       // Ckeditor retrieves editor data and removes the image information on the formulas
       // We transform all the retrieved data to images and then we Parse the data.

--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -415,6 +415,13 @@ export default class MathType extends Plugin {
      */
     editor.data.get = (options) => {
       let output = get.bind(editor.data)(options);
+      
+      // CKEditor 5 replaces all the time the &lt; and &gt; for < and >, which our render can't understand.
+      // We replace the values inserted for CKEditro5 to be able to render the formulas with the mentioned characters.
+      output = output.replace('"<"', '"&lt;"')
+        .replace('">"', '"&gt;"')
+        .replace('><<', '>&lt;<');
+
       // Ckeditor retrieves editor data and removes the image information on the formulas
       // We transform all the retrieved data to images and then we Parse the data.
       let imageFormula = Parser.initParse(output);


### PR DESCRIPTION
## Description

`editor.getData()` returns null when using formulas with '<' and '>' because CK5 replaces `&lt;` and `&gt;` for the previous characters, which our viewer can not render properly.
This PR fixes that by forcing a replacement of the characters that we can't render for the ones that we can.

## Steps to reproduce

1. Go to the CKEditor5 demo.
2. Insert a bracket angles formula: 
![Screenshot from 2023-10-27 11-42-05](https://github.com/wiris/html-integrations/assets/60604864/8804f957-8159-478e-bf4d-6ee222559841)
3. Open the console inspector with ctrl + shft + I
4. Click on the update button
5. No error on the console should appear, and the formula should be rendered as expected on the update area.

---

[#taskid 40736](https://wiris.kanbanize.com/ctrl_board/2/cards/40736/details/)
