### PR TITLE
avoid unnecesary request made by the viewer

### DIFF
--- a/packages/viewer/src/app.ts
+++ b/packages/viewer/src/app.ts
@@ -3,6 +3,15 @@ import { renderLatex } from './latex';
 import { renderMathML } from './mathml';
 import { bypassEncapsulation } from './retro';
 
+declare global {
+  interface Window {
+    viewer: {
+      properties: Properties,
+      isLoaded: boolean
+    };
+  }
+}
+
 // This should be the only code executed outside of a function
 // and the only code containing browser globals (e.g. window)
 // TODO try to set up the linter to check these two constraints
@@ -17,9 +26,12 @@ async function main(w: Window): Promise<void> {
   const properties: Properties = await Properties.generate();
 
   // Expose the globals to the browser
-  (w as any).viewer = {
-    properties,
-  };
+  if (!w.viewer) {
+    w.viewer = {
+      properties,
+      isLoaded: false,
+    };
+  }
 
   const document = w.document;
 
@@ -40,6 +52,11 @@ async function main(w: Window): Promise<void> {
   // Initial function to call once document is loaded
   // Renders formulas and sets observer
   const start = async () => {
+    // Check if the viewer is alredy loaded
+    if (w.viewer.isLoaded) return;
+
+    w.viewer.isLoaded = true;
+
     // First render
     properties.render();
 

--- a/packages/viewer/src/properties.ts
+++ b/packages/viewer/src/properties.ts
@@ -66,7 +66,6 @@ export class Properties {
     const script: HTMLScriptElement = document.querySelector(`script[src*="${pluginName}"]`);
 
     if (!!script) {
-
       const pluginNamePosition: number = script.src.lastIndexOf(pluginName);
       const params: string = script.src.substring(pluginNamePosition + pluginName.length);
       const urlParams = new URLSearchParams(params);
@@ -86,8 +85,9 @@ export class Properties {
       if (urlParams.get('zoom') !== null && urlParams.get('zoom') !== undefined) {
         instance.config.zoom = +urlParams.get('zoom');
       }
-
     }
+
+    instance.checkServices();
 
     // Get backend parameters calling the configurationjson service
     try {
@@ -106,6 +106,24 @@ export class Properties {
     }
 
     return instance;
+  }
+
+  /**
+   * Check if is inside Integrations Services
+   * @deprecated This will be removed once the viewer uncouple from the integration services.
+   */
+  private checkServices(): void {
+    const path = ((document.currentScript as HTMLScriptElement).src);
+
+    if (path.includes('pluginwiris_engine')) {
+      // If the path includes pluginwiris_engine use Java Integrations Services
+      this.config.editorServicesRoot = path;
+      this.config.editorServicesExtension = '';
+    } else if (path.includes('integration/WIRISplugins')) {
+      // If the path includes 'integration/WIRISplugins' use PHP Integrations Services
+      this.config.editorServicesRoot = path;
+      this.config.editorServicesExtension = '.php';
+    }
   }
 
   get editorServicesRoot(): string {


### PR DESCRIPTION
## Description

This PR avoid unnecesary request made by the viewer. We found that the viewers installed locally on the Integration Services are not using the Integration Services and are making request to the wiris.net. 

To mitigate this, the updated viewer now detects its context within the integration services, to dynamically modify the default services endpoint accordingly.

Additionally, this pull request checks If  the viewer is already loaded to prevent duplicate requests. This is especially relevant in scenarios where there might be more than one viewer script inserted into the DOM.

## Steps to reproduce

To validate the changes, follow these steps using a PHP Integration Services demo with CKEditor 4:

1. Deploy a demo from the plugins repository with PHP and CKEditor 4
2. Switch to branch KB-41112 in the html-integrations repository used by plugins.
3. Update the output parameter in the file html-integrations/packages/viewer/webpack.config.js to:

```
    output: {
      filename: 'WIRISplugins.js',
      path: '{absolut path to plugins project}/plugins/output/php/ckeditor4-demo/ckeditor4/plugins/ckeditor_wiris/integration/',
    },
```

4. Execute the following command in html-integrations:

```
nx build viewer
```

5. Once the viewer is built, open the demo, launch the browser's inspector, navigate to the Network tab, and refresh the demo. Verify that the number of requests to the showImage service aligns with expectations.

---

[#taskid 41112](https://wiris.kanbanize.com/ctrl_board/2/cards/41112/details/)