### PR TITLE
feature: Include mechanism to force hand mode when editor is opened

### DIFF
--- a/demos/html/generic/src/app.js
+++ b/demos/html/generic/src/app.js
@@ -22,7 +22,7 @@ document.head.appendChild(jsDemoImagesTransform);
 const editableDiv = document.getElementById('editable');
 const toolbarDiv = document.getElementById('toolbar');
 
-// Initialyze the editor.
+// Initialize the editor.
 window.wrs_int_init(editableDiv, toolbarDiv);
 
 document.onreadystatechange = function () {

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -504,6 +504,48 @@ export default class ContentManager {
   }
 
   /**
+   * Sets the editor to be used in Hand mode.
+   * 
+   * This method relies completely on the classes used on different HTML elements within the editor itself, meaning
+   * any change on those classes will make this code stop working properly.
+   * 
+   * On top of that, some of those classes are changed on runtime (for example, the one that makes some buttons change). 
+   * This forces us to use some delayed code (this is, a timeout) to make sure everything exists when we need it.
+   * @param {*} forced (boolean) Forces the user to stay in Hand mode by hiding the keyboard mode button.
+   */
+  setHandMode(forced) {
+    const inHandMode = document.querySelector('.wrs_editor.wrs_handOpen') !== null;
+
+    // "Open hand mode" button takes a little bit to be available, that's why the inner logic is run 
+    // after a delay.
+    setTimeout(() => {
+      // If in "forced mode" Before we show the hand mode, we hide the "keyboard button" so the user can't go to that mode
+      if (forced) {
+        // This selector gets the hand <-> keyboard mode switch, but since we don't need neither of them in this case, we can't just
+        // hide it for good.
+        const openKeyboardMode = document.querySelector("div.wrs_editor.wrs_flexEditor.wrs_withHand.wrs_animated .wrs_handWrapper input[type=button]");
+
+        if (openKeyboardMode) {
+          openKeyboardMode.style.visibility = 'hidden';
+        }
+      }
+
+      if (inHandMode) {
+        return;
+      }
+
+      // This complex selector is necessary because the classes used for the hand button aren't consistent, so basically
+      // we ensure we are selecting the correct button by making sure it is not the keyboard button (which shares most of the classes)
+      const openHandButton = document.querySelector("div.wrs_editor.wrs_flexEditor.wrs_withHand.wrs_animated:not(.wrs_handOpen.wrs_disablePalette) .wrs_handWrapper input[type=button]");
+
+      if (openHandButton) {
+        openHandButton.click();
+      }
+
+    }, 600); // Depending on the user's machine, this timeout may not be enough.
+  }
+
+  /**
    * Sets the correct toolbar depending if exist other custom toolbars
    * at the same time (e.g: Chemistry).
    */

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -140,7 +140,7 @@ export default class ContentManager {
 
 
     /**
-     * TODO
+     * Options object containing any configuration values to be used by the content manager. 
      * @type {Object}
      */
     this.options = contentManagerAttributes.options || {};

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -532,9 +532,9 @@ export default class ContentManager {
     // "Open hand mode" button takes a little bit to be available, that's why the inner logic is run 
     // after a delay.
     setTimeout(() => {
-      // If in "forced mode" Before we show the hand mode, we hide the "keyboard button" so the user can't go to that mode
+      // If in "forced mode", before we show the hand mode, we hide the "keyboard button" so the user can't go to that mode
       if (forced) {
-        // This selector gets the hand <-> keyboard mode switch, but since we don't need neither of them in this case, we can't just
+        // This selector gets the hand <-> keyboard mode switch, but since we don't need neither of them in this case, we cant just
         // hide it for good.
         const openKeyboardMode = document.querySelector("div.wrs_editor.wrs_flexEditor.wrs_withHand.wrs_animated .wrs_handWrapper input[type=button]");
 
@@ -548,7 +548,7 @@ export default class ContentManager {
       }
 
       // This complex selector is necessary because the classes used for the hand button aren't consistent, so basically
-      // we ensure we are selecting the correct button by making sure it is not the keyboard button (which shares most of the classes)
+      // we ensure we are selecting the correct button by discarding it is not the keyboard button
       const openHandButton = document.querySelector("div.wrs_editor.wrs_flexEditor.wrs_withHand.wrs_animated:not(.wrs_handOpen.wrs_disablePalette) .wrs_handWrapper input[type=button]");
 
       if (openHandButton) {

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -22,6 +22,7 @@ export default class ContentManager {
    * create a new instance.
    */
   constructor(contentManagerAttributes) {
+
     /**
      * An object containing MathType editor parameters. See
      * http://docs.wiris.com/en/mathtype/mathtype_web/sdk-api/parameters for further information.
@@ -136,6 +137,13 @@ export default class ContentManager {
      * @type {IntegrationModel}
      */
     this.integrationModel = null;
+
+
+    /**
+     * TODO
+     * @type {Object}
+     */
+    this.options = contentManagerAttributes.options || {};
   }
 
   /**
@@ -488,6 +496,11 @@ export default class ContentManager {
     }
 
     Core.globalListeners.fire('onModalOpen', {});
+
+    if (this.options.forcedHandMode) {
+      this.setHandMode();
+    }
+
   }
 
   /**
@@ -513,7 +526,7 @@ export default class ContentManager {
    * This forces us to use some delayed code (this is, a timeout) to make sure everything exists when we need it.
    * @param {*} forced (boolean) Forces the user to stay in Hand mode by hiding the keyboard mode button.
    */
-  setHandMode(forced) {
+  setHandMode(forced = true) {
     const inHandMode = document.querySelector('.wrs_editor.wrs_handOpen') !== null;
 
     // "Open hand mode" button takes a little bit to be available, that's why the inner logic is run 

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -44,12 +44,12 @@ export default class ContentManager {
     }
 
     /**
-* Environment properties. This object contains data about the integration platform.
-* @type {Object}
-* @property {String} editor - Editor name. Usually the HTML editor.
-* @property {String} mode - Save mode. Xml by default.
-* @property {String} version - Plugin version.
-  */
+    * Environment properties. This object contains data about the integration platform.
+    * @type {Object}
+    * @property {String} editor - Editor name. Usually the HTML editor.
+    * @property {String} mode - Save mode. Xml by default.
+    * @property {String} version - Plugin version.
+    */
     this.environment = {};
     if ('environment' in contentManagerAttributes) {
       this.environment = contentManagerAttributes.environment;
@@ -326,8 +326,8 @@ export default class ContentManager {
       'iPhone',
       'iPod',
     ].includes(navigator.platform)
-    // iPad on iOS 13 detection
-    || (navigator.userAgent.includes('Mac') && 'ontouchend' in document);
+      // iPad on iOS 13 detection
+      || (navigator.userAgent.includes('Mac') && 'ontouchend' in document);
   }
 
   /**
@@ -396,7 +396,7 @@ export default class ContentManager {
 
       // On WordPress integration, the focus gets lost right after setting it.
       // To fix this, we enforce another focus some milliseconds after this behaviour.
-      setTimeout(() => {this.editor.focus()}, 100);
+      setTimeout(() => { this.editor.focus() }, 100);
     }
   }
 

--- a/packages/devkit/src/core.src.js
+++ b/packages/devkit/src/core.src.js
@@ -539,7 +539,7 @@ export default class Core {
       }
       this.placeCaretAfterNode(this.editionProperties.temporalImage);
     }
-    
+
     // Build the telemeter payload separated to delete null/undefined entries.
     const mathml = element?.dataset?.mathml;
     let payload = {
@@ -555,7 +555,7 @@ export default class Core {
     Object.keys(payload).forEach(key => {
       if (key === 'mathml_origin' || key === 'editor_origin') !payload[key] ? delete payload[key] : {}
     });
-    
+
     try {
       Telemeter.telemeter.track("INSERTED_FORMULA", {
         ...payload,
@@ -717,9 +717,9 @@ export default class Core {
     // Editor parameters in backend, usually configuration.ini.
     const serverEditorParameters = Configuration.get('editorParameters');
     // Editor parameters through JavaScript configuration.
-    const cliendEditorParameters = this.integrationModel.editorParameters;
+    const clientEditorParameters = this.integrationModel.editorParameters;
     Object.assign(editorAttributes, defaultEditorAttributes, serverEditorParameters);
-    Object.assign(editorAttributes, defaultEditorAttributes, cliendEditorParameters);
+    Object.assign(editorAttributes, defaultEditorAttributes, clientEditorParameters);
 
     // Now, update backwards: if user has set a custom language, pass that back to core properties
     this.language = editorAttributes.language;

--- a/packages/devkit/src/core.src.js
+++ b/packages/devkit/src/core.src.js
@@ -570,7 +570,7 @@ export default class Core {
    * @param {HTMLElement} target - The target HTMLElement where formulas should be inserted.
    * @param {Boolean} isIframe - True if the target HTMLElement is an iframe. False otherwise.
    */
-  openModalDialog(target, isIframe) {
+  openModalDialog(target, isIframe, editorOptions = {}) {
 
     // Count the time since the editor is open
     this.editionProperties.editionStartTime = Date.now();
@@ -732,6 +732,7 @@ export default class Core {
     contentManagerAttributes.language = this.language;
     contentManagerAttributes.customEditors = this.customEditors;
     contentManagerAttributes.environment = this.environment;
+    contentManagerAttributes.options = editorOptions || {};
 
     if (this.modalDialog == null) {
       this.modalDialog = new ModalDialog(editorAttributes);

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -170,6 +170,8 @@ export default class IntegrationModel {
         }
       });
     }
+
+    this.editorOptions = integrationModelProperties.editorOptions || {};
   }
 
   /**
@@ -204,6 +206,7 @@ export default class IntegrationModel {
 
     const coreProperties = {};
     coreProperties.serviceProviderProperties = this.serviceProviderProperties;
+
     this.setCore(new Core(coreProperties));
     this.core.addListener(listener);
     this.core.language = this.language;
@@ -542,7 +545,7 @@ export default class IntegrationModel {
     if (window.navigator.onLine) {
       this.core.editionProperties.dbclick = false;
       this.core.editionProperties.isNewElement = true;
-      this.core.openModalDialog(this.target, this.isIframe);
+      this.core.openModalDialog(this.target, this.isIframe, this.editorOptions);
     } else {
       let modal = document.getElementById("wrs_modal_offline");
       modal.style.display = "block";
@@ -556,7 +559,7 @@ export default class IntegrationModel {
   openExistingFormulaEditor() {
     if (window.navigator.onLine) {
       this.core.editionProperties.isNewElement = false;
-      this.core.openModalDialog(this.target, this.isIframe);
+      this.core.openModalDialog(this.target, this.isIframe, this.editorOptions);
     } else {
       let modal = document.getElementById("wrs_modal_offline");
       modal.style.display = "block";

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -12,8 +12,7 @@ import warnIcon from '../styles/icons/general/warn_icon.svg';  //eslint-disable-
  * @typedef {Object} IntegrationModelProperties
  * @property {string} configurationService - Configuration service path.
  * This parameter is needed to determine all services paths.
- * @property {HTMLElement} 
- * .target - HTML target.
+ * @property {HTMLElement} integrationModelProperties.target - HTML target.
  * @property {string} integrationModelProperties.scriptName - Integration script name.
  * Usually the name of the integration script.
  * @property {Object} integrationModelProperties.environment - integration environment properties.

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -12,7 +12,8 @@ import warnIcon from '../styles/icons/general/warn_icon.svg';  //eslint-disable-
  * @typedef {Object} IntegrationModelProperties
  * @property {string} configurationService - Configuration service path.
  * This parameter is needed to determine all services paths.
- * @property {HTMLElement} integrationModelProperties.target - HTML target.
+ * @property {HTMLElement} 
+ * .target - HTML target.
  * @property {string} integrationModelProperties.scriptName - Integration script name.
  * Usually the name of the integration script.
  * @property {Object} integrationModelProperties.environment - integration environment properties.
@@ -256,7 +257,7 @@ export default class IntegrationModel {
     document.body.appendChild(this.offlineModal);
 
     let modal = document.getElementById("wrs_modal_offline");
-    this.offlineModalClose.addEventListener('click', function() {modal.style.display = "none";});
+    this.offlineModalClose.addEventListener('click', function () { modal.style.display = "none"; });
 
     // Store editor name for telemetry purposes.
     let editorName = this.environment.editor;
@@ -314,7 +315,7 @@ export default class IntegrationModel {
     ];
 
     // Filter hosts to remove empty objects and empty keys.
-    hosts = hosts.filter(function( element ) {
+    hosts = hosts.filter(function (element) {
       if (element) Object.keys(element).forEach(key => element[key] === "unknown" ? delete element[key] : {});
       return element !== undefined;
     });
@@ -349,25 +350,25 @@ export default class IntegrationModel {
 
     let userAgent = window.navigator.userAgent;
 
-    if(/Brave/.test(userAgent)) {
+    if (/Brave/.test(userAgent)) {
       detectedBrowser = "brave";
       if (userAgent.indexOf("Brave/")) {
         let start = userAgent.indexOf("Brave") + 6;
         let end = userAgent.substring(start).indexOf(' ');
         end = (end === -1) ? userAgent.lastIndexOf("") : end;
-        versionBrowser = (userAgent.substring(start, end + start).replace( '_', '.' )).replace(/[^\d.-]/g, '');
+        versionBrowser = (userAgent.substring(start, end + start).replace('_', '.')).replace(/[^\d.-]/g, '');
       }
     } else if (userAgent.indexOf('Edg/') !== -1) {
       detectedBrowser = "edge_chromium";
       let start = userAgent.indexOf("Edg/") + 4;
-      versionBrowser = (userAgent.substring(start).replace( '_', '.' )).replace(/[^\d.-]/g, '');
+      versionBrowser = (userAgent.substring(start).replace('_', '.')).replace(/[^\d.-]/g, '');
     } else if (/Edg/.test(userAgent)) {
       detectedBrowser = "edge";
       let start = userAgent.indexOf("Edg") + 3;
       start = start + userAgent.substring(start).indexOf('/');
       let end = userAgent.substring(start).indexOf(' ');
       end = (end === -1) ? userAgent.lastIndexOf("") : end;
-      versionBrowser = (userAgent.substring(start, end + start).replace( '_', '.' )).replace(/[^\d.-]/g, '');
+      versionBrowser = (userAgent.substring(start, end + start).replace('_', '.')).replace(/[^\d.-]/g, '');
     } else if (/Firefox/.test(userAgent) || /FxiOS/.test(userAgent)) {
       detectedBrowser = "firefox";
       let start = userAgent.indexOf("Firefox");
@@ -375,13 +376,13 @@ export default class IntegrationModel {
       start = start + userAgent.substring(start).indexOf('/') + 1;
       let end = userAgent.substring(start).indexOf(' ');
       end = (end === -1) ? userAgent.lastIndexOf("") : end;
-      versionBrowser = (userAgent.substring(start, end + start).replace( '_', '.' ));
+      versionBrowser = (userAgent.substring(start, end + start).replace('_', '.'));
     } else if (/OPR/.test(userAgent)) {
       detectedBrowser = "opera";
       let start = userAgent.indexOf("OPR/") + 4;
       let end = userAgent.substring(start).indexOf(' ');
       end = (end === -1) ? userAgent.lastIndexOf("") : end;
-      versionBrowser = (userAgent.substring(start, end + start).replace( '_', '.' )).replace(/[^\d.-]/g, '');
+      versionBrowser = (userAgent.substring(start, end + start).replace('_', '.')).replace(/[^\d.-]/g, '');
     } else if (/Chrome/.test(userAgent) || /CriOS/.test(userAgent)) {
       detectedBrowser = "chrome";
       let start = userAgent.indexOf("Chrome");
@@ -389,14 +390,14 @@ export default class IntegrationModel {
       start = start + userAgent.substring(start).indexOf('/') + 1;
       let end = userAgent.substring(start).indexOf(' ');
       end = (end === -1) ? userAgent.lastIndexOf("") : end;
-      versionBrowser = (userAgent.substring(start, end + start).replace( '_', '.' ));
+      versionBrowser = (userAgent.substring(start, end + start).replace('_', '.'));
     } else if (/Safari/.test(userAgent)) {
       detectedBrowser = "safari";
       let start = userAgent.indexOf("Version/");
       start = start + userAgent.substring(start).indexOf('/') + 1;
       let end = userAgent.substring(start).indexOf(' ');
       end = (end === -1) ? userAgent.lastIndexOf("") : end;
-      versionBrowser = (userAgent.substring(start, end + start).replace( '_', '.' ));
+      versionBrowser = (userAgent.substring(start, end + start).replace('_', '.'));
     }
 
     return { detectedBrowser, versionBrowser };
@@ -426,14 +427,14 @@ export default class IntegrationModel {
       if (userAgent.indexOf("OS X") !== -1) {
         let start = userAgent.indexOf("OS X") + 5;
         let end = userAgent.substring(start).indexOf(' ');
-        versionOS = (userAgent.substring(start, end + start).replace( '_', '.' )).replace(/[^\d.-]/g, '');
+        versionOS = (userAgent.substring(start, end + start).replace('_', '.')).replace(/[^\d.-]/g, '');
       }
     } else if (iosPlatforms.indexOf(platform) !== -1) {
       detectedOS = 'ios';
       if (userAgent.indexOf("OS ") !== -1) {
         let start = userAgent.indexOf("OS ") + 3;
         let end = userAgent.substring(start).indexOf(')');
-        versionOS = (userAgent.substring(start, end + start).replace( '_', '.' )).replace(/[^\d.-]/g, '');
+        versionOS = (userAgent.substring(start, end + start).replace('_', '.')).replace(/[^\d.-]/g, '');
       }
     } else if (windowsPlatforms.indexOf(platform) !== -1) {
       detectedOS = 'windows';
@@ -442,7 +443,7 @@ export default class IntegrationModel {
       if (end === -1) {
         end = userAgent.substring(start).indexOf(')');
       }
-      versionOS = (userAgent.substring(start, end + start).replace( '_', '.' )).replace(/[^\d.-]/g, '');
+      versionOS = (userAgent.substring(start, end + start).replace('_', '.')).replace(/[^\d.-]/g, '');
     } else if (/Android/.test(userAgent)) {
       detectedOS = 'android';
       let start = userAgent.indexOf("Android");
@@ -450,13 +451,13 @@ export default class IntegrationModel {
       if (end === -1) {
         end = userAgent.substring(start).indexOf(')');
       }
-      versionOS = (userAgent.substring(start, end + start).replace( '_', '.' )).replace(/[^\d.-]/g, '');
-    }else if (/CrOS/.test(userAgent)) {
-        detectedOS = 'chromeos';
-        let start = userAgent.indexOf("CrOS ") + 5;
-        start = start + userAgent.substring(start).indexOf(' ');
-        let end = userAgent.substring(start).indexOf(')');
-        versionOS = (userAgent.substring(start, end + start).replace( '_', '.' )).replace(/[^\d.-]/g, '');
+      versionOS = (userAgent.substring(start, end + start).replace('_', '.')).replace(/[^\d.-]/g, '');
+    } else if (/CrOS/.test(userAgent)) {
+      detectedOS = 'chromeos';
+      let start = userAgent.indexOf("CrOS ") + 5;
+      start = start + userAgent.substring(start).indexOf(' ');
+      let end = userAgent.substring(start).indexOf(')');
+      versionOS = (userAgent.substring(start, end + start).replace('_', '.')).replace(/[^\d.-]/g, '');
     } else if (detectedOS === "unknown" && /Linux/.test(platform)) {
       detectedOS = 'linux';
     }
@@ -610,7 +611,7 @@ export default class IntegrationModel {
    * @returns {ReturnObject} - Object with the information of the node or latex to insert.
    */
   insertFormula(focusElement, windowTarget, mathml, wirisProperties) {
-    const obj =  this.core.insertFormula(focusElement, windowTarget, mathml, wirisProperties);
+    const obj = this.core.insertFormula(focusElement, windowTarget, mathml, wirisProperties);
 
     // Delete temporal image when inserted
     this.core.editionProperties.temporalImage = null;
@@ -781,7 +782,7 @@ export default class IntegrationModel {
    */
 
   // eslint-disable-next-line class-methods-use-this, no-unused-vars
-  getMathmlFromTextNode(textNode, caretPosition) {}
+  getMathmlFromTextNode(textNode, caretPosition) { }
 
   /**
    * Wrapper
@@ -791,7 +792,7 @@ export default class IntegrationModel {
    * @param {string} mathml valid mathml.
    */
   // eslint-disable-next-line class-methods-use-this, no-unused-vars
-  fillNonLatexNode(event, window, mathml) {}
+  fillNonLatexNode(event, window, mathml) { }
 
   /**
     Wrapper.
@@ -800,7 +801,7 @@ export default class IntegrationModel {
    * @param {boolean} iframe
    */
   // eslint-disable-next-line class-methods-use-this, no-unused-vars
-  getSelectedItem(target, isIframe) {}
+  getSelectedItem(target, isIframe) { }
 
   // Set temporal image to null and make focus come back.
   static setActionsOnCancelButtons() {

--- a/packages/generic/wirisplugin-generic.src.js
+++ b/packages/generic/wirisplugin-generic.src.js
@@ -106,7 +106,8 @@ export default class GenericIntegration extends IntegrationModel {
             toolbar: toolbar,
             trigger: trigger,
           });
-        } catch (err) {trigger
+        } catch (err) {
+          trigger
           console.error(err);
         }
       } else {
@@ -185,7 +186,7 @@ export default class GenericIntegration extends IntegrationModel {
     // Try to get editorParameters.language, fail silently otherwise
     try {
       return this.editorParameters.language;
-    } catch (e) {}
+    } catch (e) { }
     if (typeof _wrs_int_langCode !== 'undefined') { // eslint-disable-line camelcase
       console.warn('Deprecated property wirisformulaeditorlang. Use mathTypeParameters on instead.');
       return _wrs_int_langCode; // eslint-disable-line camelcase, no-undef

--- a/packages/generic/wirisplugin-generic.src.js
+++ b/packages/generic/wirisplugin-generic.src.js
@@ -23,7 +23,7 @@ export const currentInstance = null;
  * @param {HTMLElement} target - DOM target, in this integration the editable iframe.
  * @param {HTMLElement} toolbar - DOM element where icons will be inserted.
  */
-export function wrsInitEditor(target, toolbar, mathtypeProperties) {
+export function wrsInitEditor(target, toolbar, mathtypeProperties = undefined, editorOptions = {}) {
   /**
      * @type {integrationModelProperties}
      */
@@ -35,7 +35,7 @@ export function wrsInitEditor(target, toolbar, mathtypeProperties) {
   }
 
   // GenericIntegration instance.
-  const genericIntegrationInstance = new GenericIntegration(genericIntegrationProperties); // eslint-disable-line no-use-before-define
+  const genericIntegrationInstance = new GenericIntegration(genericIntegrationProperties, editorOptions); // eslint-disable-line no-use-before-define
   genericIntegrationInstance.init();
   genericIntegrationInstance.listeners.fire('onTargetReady', {});
 
@@ -66,7 +66,7 @@ export default class GenericIntegration extends IntegrationModel {
      * @constructs
      * @param {IntegrationModelProperties} integrationModelProperties
      */
-  constructor(integrationModelProperties) {
+  constructor(integrationModelProperties, editorOptions = {}) {
     if (typeof (integrationModelProperties.serviceProviderProperties) === 'undefined') {
       integrationModelProperties.serviceProviderProperties = {
         URI: process.env.SERVICE_PROVIDER_URI,
@@ -78,6 +78,7 @@ export default class GenericIntegration extends IntegrationModel {
     integrationModelProperties.environment = {};
     integrationModelProperties.environment.editor = 'GenericHTML';
     integrationModelProperties.environment.editorVersion = '1.0.0';
+    integrationModelProperties.editorOptions = editorOptions;
 
     super(integrationModelProperties);
 


### PR DESCRIPTION
## Description

This PR includes a mechanism to force the editor to be opened in hand mode.

## Steps to reproduce

To activate this feature, you'll need to modify how the Wiris editor is initialized. You can do so modifying line 26 in `app.js`:

```
window.wrs_int_init(editableDiv, toolbarDiv, undefined, { forcedHandMode: true }); // will activate forced hand mode
```

You can try this other modifications to experiment the different behaviours:

```
window.wrs_int_init(editableDiv, toolbarDiv); // won't activate forced hand mode
window.wrs_int_init(editableDiv, toolbarDiv, undefined); // won't activate forced hand mode
window.wrs_int_init(editableDiv, toolbarDiv, undefined, {}); // won't activate forced hand mode
window.wrs_int_init(editableDiv, toolbarDiv, undefined, { forcedHandMode: false }); // won't activate forced hand mode
```
As you can see, the configuration object has been included as an extra argument to the `wrs_int_init` method. I decided to do so to avoid changing the content of the rest of the arguments and make sure we won't break any existing production code from our clients). I know it's ugly having an undefined argument, but since I'm not sure when it's really used or not, I've prefered to keep it that way for the sake of retro compatibility, as I mentioned before.

Anny commentary regarding variable names, and how the configuration argument is sent all the way to the ContentManager will be appreciated.
---

[#taskid 41415](https://wiris.kanbanize.com/ctrl_board/2/cards/41415/details/)
