### PR TITLE
[KB-40681] Configure Git credentials in publish workflow

### DIFF
--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -17,6 +17,10 @@ import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
+// Set up the Git user identity
+execSync(`git config --global user.email "cicd@wiris.com"`, { stdio: 'inherit' });
+execSync(`git config --global user.name "wiris-ci-bot"`, { stdio: 'inherit' });
+
 // For each "shortPackageName=version" argument provided, get the
 // shortPackageName, fullPackageName, and version
 const data = argv


### PR DESCRIPTION
## Description

The publish workflow (https://github.com/wiris/html-integrations/actions/workflows/publish.yml) is supposed to publish packages on npm and afterwards make a git commit and some git tags, and push them to the origin on GitHub.

Up until now, this step would fail because the workflow was lacking a step wherein the Git user was configured (name and email). I have chosen the name and email used for [cicd-wiris](https://github.com/cicd-wiris) in other projects (see e.g. the commits made by cicd-wiris in https://github.com/wiris/atlas). It's important to notice that, after the change introduced by this PR, the commits are not made by the cicd-wiris *user*, but rather signed with its name and email.

## Steps to reproduce

1. Create a branch based off this one.
2. Add a new commit to that branch in which you comment out all instructions in `scripts/publish.mjs` that involve npm or yarn (e.g. yarn version or yarn publish), so that no irreversible effect is caused by this test.
3. Run the https://github.com/wiris/html-integrations/actions/workflows/publish.yml workflow, choosing your new branch as the target, filling in `publish_npm` in the first field, and any version in the second (e.g. `devkit=10.0.0`).

### Expected outcome

The workflow succeeds. A new commit has been created and added to your new branch, and a (or some) tag(s) has/have been created. Make sure to delete the tag(s) (e.g. manually through GitHub's UI).

### Actual outcome

The workflow fails citing a lack of configuration for the Git user.

---

[#taskid 40681](https://wiris.kanbanize.com/ctrl_board/2/cards/40681/details/)