### PR TITLE
feat: allow set custom headers

### DIFF
--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -45,12 +45,12 @@ export default class ContentManager {
     }
 
     /**
-    * Environment properties. This object contains data about the integration platform.
-    * @type {Object}
-    * @property {String} editor - Editor name. Usually the HTML editor.
-    * @property {String} mode - Save mode. Xml by default.
-    * @property {String} version - Plugin version.
-    */
+     * Environment properties. This object contains data about the integration platform.
+     * @type {Object}
+     * @property {String} editor - Editor name. Usually the HTML editor.
+     * @property {String} mode - Save mode. Xml by default.
+     * @property {String} version - Plugin version.
+     */
     this.environment = {};
     if ('environment' in contentManagerAttributes) {
       this.environment = contentManagerAttributes.environment;
@@ -230,6 +230,7 @@ export default class ContentManager {
     const script = document.createElement('script');
     script.type = 'text/javascript';
     let editorUrl = Configuration.get('editorUrl');
+
     // We create an object url for parse url string and work more efficiently.
     const anchorElement = document.createElement('a');
 
@@ -655,6 +656,15 @@ export default class ContentManager {
   setToolbar(toolbar) {
     this.toolbar = toolbar;
     this.editor.setParams({ toolbar: this.toolbar });
+  }
+
+  /**
+   * Sets the custom headers added on editor requests.
+   * @returns {Object} headers - key value headers.
+   */
+  setCustomHeaders(headers) {
+    let headersObj = typeof headers === 'string' ? Util.convertStringToObject(headers) : headers;
+    this.editor.setParams({ customHeaders: headersObj });
   }
 
   /**

--- a/packages/devkit/src/core.src.js
+++ b/packages/devkit/src/core.src.js
@@ -237,6 +237,16 @@ export default class Core {
     }
   }
 
+
+  /**
+   * Sets the custom headers added on editor requests if contentManager isn't undefined.
+   * @returns {Object} headers - key value headers.
+   */
+  setHeaders(headers) {
+    this?.contentManager?.setCustomHeaders(headers);
+    Configuration.set('customHeaders', headers);
+  }
+
   /**
    * Returns the current {@link ModalDialog} instance.
    * @returns {ModalDialog} The current {@link ModalDialog} instance.
@@ -728,6 +738,9 @@ export default class Core {
     StringManager.language = this.language;
 
     editorAttributes.rtl = this.integrationModel.rtl;
+
+    const customHeaders = Configuration.get('customHeaders');
+    editorAttributes.customHeaders = typeof customHeaders === 'string' ? Util.convertStringToObject(customHeaders) : customHeaders;
 
     const contentManagerAttributes = {};
     contentManagerAttributes.editorAttributes = editorAttributes;

--- a/packages/devkit/src/serviceprovider.js
+++ b/packages/devkit/src/serviceprovider.js
@@ -200,7 +200,7 @@ export default class ServiceProvider {
       } else {
         httpRequest.send(null);
       }
-   
+
       return httpRequest.responseText;
     }
     return '';

--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -202,6 +202,26 @@ export default class Util {
   }
 
   /**
+   * Convert a string representation of key-value pairs to an object.
+   * @param {string} keyValueString - String with key-value pairs in the format key1='value1', key2='value2'
+   * @returns {Object} - Object containing the key-value pairs
+   */
+  static convertStringToObject(keyValueString) {
+    if (!keyValueString) {
+      return {};
+    }
+
+    return keyValueString.split(',')
+      .map(pair => pair.trim().split('='))
+      .reduce((resultObject, [key, value]) => {
+        if (key && value) {
+          resultObject[key] = value;
+        }
+        return resultObject;
+      }, {});
+  }
+
+  /**
    * Cross-browser solution for creating new elements.
    * @param {string} tagName - tag name of the wished element.
    * @param {Object} attributes - an object where each key is a wished


### PR DESCRIPTION
## Description

This pull request introduces a new feature that allow users to include custom headers that will be sent on all requests to the wiris.net editor and integration services.

To configure default custom headers, simply update the configuration.ini file in the integration services, adhering to the following format:

```
wiriscustomheaders = key1=value1, key2=value2
```

Additionally, a new function, setHeaders, has been incorporated into the core.js file from devkit. This function allows the modification of custom header values directly from the frontend:

```
window.WirisPlugin.currentInstance.core.setHeaders('key1=value1updated, key2=value2updated')
```

## Steps to reproduce

Read [this document](https://docs.google.com/document/d/1Qk3yCsr5w2UZVTu1LQsjCkINF1tG06u3b4fpfqYAivk/edit) and follow the steps to reproduce:
* The ones on development or testing environment. Both if you want.
* The ones to update the custom headers.

The document will let you test the custom headers on plugins, html-integrations and the viewer.

<!---
**Old steps to reproduce**
Using plugins repository:

1. In the default-configuration.ini file, configure the parameters as follows:
```
wirisimageservicehost = pre-www.wiris.net
wiriscustomheaders = key1=value1, key2=value2
```
2. Open a demo.
3. Access the inspector and navigate to the Network tab.
4. Inspect requests made (e.g., showImage) to ensure that the wiriscustomheaders values are reflected in the Request Headers.
5. To update custom headers, execute the following line in the inspector console:
```
window.WirisPlugin.currentInstance.core.setHeaders('key1=value1updated, key2=value2updated')
```
6. Insert a formula and confirm that the custom headers now reflect the values set in step 5.
-->

---

[#taskid 37925](https://wiris.kanbanize.com/ctrl_board/2/cards/37925/details/)
