### PR TITLE
Fix formulas with '&' symbol not rendereting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@ Last release of this project is was 20th of December 2023.
   - feat: Add method that allows the integration forcing the hand mode.
   - feat(viewer): decode safe mathml
 
+## Unreleased
+
+  - fix(viewer): Formulas containing '&' symbol are not rendered. #KB-42230
+
 ### 8.7.3 2023-11-22
 
   - fix(tinymce): non blur chemtype svg icon 

--- a/packages/viewer/src/utils.ts
+++ b/packages/viewer/src/utils.ts
@@ -21,12 +21,14 @@ function decodeEntities(text: string): string {
 export function htmlEntitiesToXmlEntities(text: string): string {
   text = decodeEntities(text);
 
-  // Replaces the < & > characters to its HTMLEntity to avoid render issues.
+  // Replaces the '<', '&', '>', and '"' characters to its HTMLEntity to avoid render issues.
   text = text.split('"<"').join('"&lt;"')
     .split('">"')
     .join('"&gt;"')
     .split('><<')
-    .join('>&lt;<');
+    .join('>&lt;<')
+    .split('&')
+    .join('&amp;');
 
   let result = '';
   for (let i = 0; i < text.length; i++) {


### PR DESCRIPTION
## Description

Formulas containing the `&` and `"` symbols were breaking; causing console errors and breaking all the following formulas.
The cause was that the mentioned symbols were not being transformed into their HTML Entities, and it caused render issues.
This PR replaces the characters for their corresponding HTML Entity.

## Steps to reproduce

1. Create a broken equation for the viewer, such as an empty matrix with latex: 
    `$$\begin{pmatrix}&&&\\&&&\\&&&\\&&&\end{pmatrix}$$`
2. Insert equations after the latex.
3. Render the formulas.
4. No error console appears and all the formulas are properly rendered.

---

[#taskid 42230](https://wiris.kanbanize.com/ctrl_board/2/cards/42230/details/)
