### PR TITLE
fix(viewer): hash all parameters before sending get showimage request

### DIFF
--- a/packages/viewer/src/services.ts
+++ b/packages/viewer/src/services.ts
@@ -113,7 +113,7 @@ export async function showImage(mml: string, lang: string, url: string, extensio
   }
 
   // Try to obtain the image via GET
-  const getParams = Parser.createShowImageSrcData({ mml }, lang);
+  const getParams = Parser.createShowImageSrcData(params);
   const getResponse = callService(getParams, 'showimage', MethodType.Get, url, extension);
   try {
     return await processJsonResponse(getResponse);


### PR DESCRIPTION
## Description

Formulas are cached including parameters: centerbaseline, metrics, and lang. However, the new Viewer is not hashing these parameters before initiating the showImage Get request. Consequently, the generated Hash does not align with the Hash saved in the cache by Integration Services. This inconsistency leads to the cache being ignored by the viewer.

## Steps to reproduce

1. Add next mathml on the body of `html-integrations/packages/viewer/infex.html`:

```
<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi><mo>=</mo><mfrac><mrow><mo>-</mo><mi>b</mi><mo>&#177;</mo><msqrt><msup><mi>b</mi><mn>2</mn></msup><mo>-</mo><mn>4</mn><mi>a</mi><mi>c</mi></msqrt></mrow><mrow><mn>2</mn><mi>a</mi></mrow></mfrac></math>
```

2. Build the viewer using command `nx build viewer`
3. Open index.html `nx serve viewer`
4. On the **Inspector > Network Tab** just will appear a showImage request with the hash **e16131cb25b408479febbfa0183a4478** 

![image](https://github.com/wiris/html-integrations/assets/91468181/2392d137-ece0-4825-9e5d-22f7f4eaafc2)

---

[#taskid 42679](https://wiris.kanbanize.com/ctrl_board/2/cards/42679/details/)