### PR TITLE
feat(viewer): add customheaders

### DIFF
--- a/demos/vue/ckeditor5/index.html
+++ b/demos/vue/ckeditor5/index.html
@@ -7,7 +7,6 @@
     <title>Vite App</title>
   </head>
   <body>
-    <!-- <div id="app"></div> -->
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -663,8 +663,18 @@ export default class ContentManager {
    * @returns {Object} headers - key value headers.
    */
   setCustomHeaders(headers) {
-    let headersObj = typeof headers === 'string' ? Util.convertStringToObject(headers) : headers;
+    let headersObj = {};
+
+    // We control that we only get String or Object as the input.
+    if (typeof headers === "object") {
+      headersObj = headers;
+    }
+    else if (typeof headers === 'string') {
+      headersObj = Util.convertStringToObject(headers);
+    }
+
     this.editor.setParams({ customHeaders: headersObj });
+    return headersObj;
   }
 
   /**

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -31,6 +31,7 @@ export default class ContentManager {
     this.editorAttributes = {};
     if ('editorAttributes' in contentManagerAttributes) {
       this.editorAttributes = contentManagerAttributes.editorAttributes;
+      this.editorAttributes.customHeaders = this.editorAttributes.editorParameters.customHeaders || {}
     } else {
       throw new Error('ContentManager constructor error: editorAttributes property missed.');
     }
@@ -45,12 +46,12 @@ export default class ContentManager {
     }
 
     /**
-    * Environment properties. This object contains data about the integration platform.
-    * @type {Object}
-    * @property {String} editor - Editor name. Usually the HTML editor.
-    * @property {String} mode - Save mode. Xml by default.
-    * @property {String} version - Plugin version.
-    */
+     * Environment properties. This object contains data about the integration platform.
+     * @type {Object}
+     * @property {String} editor - Editor name. Usually the HTML editor.
+     * @property {String} mode - Save mode. Xml by default.
+     * @property {String} version - Plugin version.
+     */
     this.environment = {};
     if ('environment' in contentManagerAttributes) {
       this.environment = contentManagerAttributes.environment;
@@ -230,6 +231,7 @@ export default class ContentManager {
     const script = document.createElement('script');
     script.type = 'text/javascript';
     let editorUrl = Configuration.get('editorUrl');
+
     // We create an object url for parse url string and work more efficiently.
     const anchorElement = document.createElement('a');
 
@@ -655,6 +657,15 @@ export default class ContentManager {
   setToolbar(toolbar) {
     this.toolbar = toolbar;
     this.editor.setParams({ toolbar: this.toolbar });
+  }
+
+  /**
+   * Sets the custom headers added on editor requests.
+   * @returns {Object} headers - key value headers.
+   */
+  setCustomHeaders(headers) {
+    let headersObj = typeof headers === 'string' ? Util.convertStringToObject(headers) : headers;
+    this.editor.setParams({ customHeaders: headersObj });
   }
 
   /**

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -31,7 +31,6 @@ export default class ContentManager {
     this.editorAttributes = {};
     if ('editorAttributes' in contentManagerAttributes) {
       this.editorAttributes = contentManagerAttributes.editorAttributes;
-      this.editorAttributes.customHeaders = this.editorAttributes.editorParameters.customHeaders || {}
     } else {
       throw new Error('ContentManager constructor error: editorAttributes property missed.');
     }

--- a/packages/devkit/src/core.src.js
+++ b/packages/devkit/src/core.src.js
@@ -243,8 +243,8 @@ export default class Core {
    * @returns {Object} headers - key value headers.
    */
   setHeaders(headers) {
-    this?.contentManager?.setCustomHeaders(headers);
-    Configuration.set('customHeaders', headers);
+    const headerObject = this?.contentManager?.setCustomHeaders(headers) || headers;
+    Configuration.set('customHeaders', headerObject);
   }
 
   /**
@@ -740,6 +740,8 @@ export default class Core {
     editorAttributes.rtl = this.integrationModel.rtl;
 
     const customHeaders = Configuration.get('customHeaders');
+    // This is not being used in the code, we are keeping it just in case it's needed.
+    // We check if it is a string since we have a setter that will make the customHeaders an object. And we do the conversion for the case when we get the headers from the backend.
     editorAttributes.customHeaders = typeof customHeaders === 'string' ? Util.convertStringToObject(customHeaders) : customHeaders;
 
     const contentManagerAttributes = {};

--- a/packages/devkit/src/core.src.js
+++ b/packages/devkit/src/core.src.js
@@ -237,6 +237,16 @@ export default class Core {
     }
   }
 
+
+  /**
+   * Sets the custom headers added on editor requests if contentManager isn't undefined.
+   * @returns {Object} headers - key value headers.
+   */
+  setHeaders(headers) {
+    this?.contentManager?.setCustomHeaders(headers);
+    Configuration.set('customHeaders', headers);
+  }
+
   /**
    * Returns the current {@link ModalDialog} instance.
    * @returns {ModalDialog} The current {@link ModalDialog} instance.
@@ -728,6 +738,9 @@ export default class Core {
     StringManager.language = this.language;
 
     editorAttributes.rtl = this.integrationModel.rtl;
+
+    const customHeaders = Configuration.get('customHeaders');
+    editorAttributes.customHeaders = typeof customHeaders === 'string' ? Util.convertStringToObject(customHeaders) : customHeaders;
 
     const contentManagerAttributes = {};
     contentManagerAttributes.editorAttributes = editorAttributes;

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -12,8 +12,7 @@ import warnIcon from '../styles/icons/general/warn_icon.svg';  //eslint-disable-
  * @typedef {Object} IntegrationModelProperties
  * @property {string} configurationService - Configuration service path.
  * This parameter is needed to determine all services paths.
- * @property {HTMLElement} 
- * .target - HTML target.
+ * @property {HTMLElement} integrationModelProperties.target - HTML target.
  * @property {string} integrationModelProperties.scriptName - Integration script name.
  * Usually the name of the integration script.
  * @property {Object} integrationModelProperties.environment - integration environment properties.

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -12,7 +12,8 @@ import warnIcon from '../styles/icons/general/warn_icon.svg';  //eslint-disable-
  * @typedef {Object} IntegrationModelProperties
  * @property {string} configurationService - Configuration service path.
  * This parameter is needed to determine all services paths.
- * @property {HTMLElement} integrationModelProperties.target - HTML target.
+ * @property {HTMLElement} 
+ * .target - HTML target.
  * @property {string} integrationModelProperties.scriptName - Integration script name.
  * Usually the name of the integration script.
  * @property {Object} integrationModelProperties.environment - integration environment properties.

--- a/packages/devkit/src/serviceprovider.js
+++ b/packages/devkit/src/serviceprovider.js
@@ -200,7 +200,7 @@ export default class ServiceProvider {
       } else {
         httpRequest.send(null);
       }
-   
+
       return httpRequest.responseText;
     }
     return '';

--- a/packages/devkit/src/serviceprovider.js
+++ b/packages/devkit/src/serviceprovider.js
@@ -188,10 +188,10 @@ export default class ServiceProvider {
 
       let header = Configuration.get('customHeaders');
       if (header) {
-        header = header.toString()
-        header.split(",")
-          .map(element => element.trim().split('='))
-          .forEach(([key, val]) => httpRequest.setRequestHeader(key, val));
+        if (typeof header === 'string') {
+          header = Util.convertStringToObject(header);
+        }
+        Object.entries(header).forEach(([key, val]) => httpRequest.setRequestHeader(key, val));
       }
 
       if (typeof postVariables !== 'undefined' && postVariables) {

--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -207,7 +207,7 @@ export default class Util {
    * @returns {Object} - Object containing the key-value pairs
    */
   static convertStringToObject(keyValueString) {
-    if (!keyValueString) {
+    if (!keyValueString || typeof keyValueString !== 'string') {
       return {};
     }
 

--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -202,6 +202,26 @@ export default class Util {
   }
 
   /**
+   * Convert a string representation of key-value pairs to an object.
+   * @param {string} keyValueString - String with key-value pairs in the format key1='value1', key2='value2'
+   * @returns {Object} - Object containing the key-value pairs
+   */
+  static convertStringToObject(keyValueString) {
+    if (!keyValueString) {
+      return {};
+    }
+
+    return keyValueString.split(',')
+      .map(pair => pair.trim().split('='))
+      .reduce((resultObject, [key, value]) => {
+        if (key && value) {
+          resultObject[key] = value;
+        }
+        return resultObject;
+      }, {});
+  }
+
+  /**
    * Cross-browser solution for creating new elements.
    * @param {string} tagName - tag name of the wished element.
    * @param {Object} attributes - an object where each key is a wished

--- a/packages/viewer/src/app.ts
+++ b/packages/viewer/src/app.ts
@@ -25,7 +25,7 @@ main(window);
  */
 async function main(w: Window): Promise<void> {
 
-  const properties: Properties = await Properties.generate();
+  const properties: Properties = await Properties.getInstance();
 
   // Expose the globals to the browser
   if (!w.viewer) {

--- a/packages/viewer/src/properties.ts
+++ b/packages/viewer/src/properties.ts
@@ -107,7 +107,7 @@ export class Properties {
         Properties.instance.editorServicesExtension
       );
 
-      // [TODO]
+      // We'll always get a string from the wiriscustomheaders backend parameter. It needs to be converted to an object. 
       Properties.instance.config.backendConfig.wiriscustomheaders = Util.convertStringToObject(Properties.instance.config.backendConfig.wiriscustomheaders);
     } catch(e) {
       if (e instanceof StatusError) {

--- a/packages/viewer/src/services.ts
+++ b/packages/viewer/src/services.ts
@@ -1,4 +1,5 @@
 import Parser from '@wiris/mathtype-html-integration-devkit/src/parser';
+import { Properties } from './properties';
 
 enum MethodType {
   Post = "POST",
@@ -49,11 +50,17 @@ export async function processJsonResponse(response: Promise<Response>): Promise<
 export async function callService(query: object, serviceName: string, method: MethodType, serverURL: string, extension: string) : Promise<any> {
   try {
     const url = new URL(serviceName + extension, serverURL);
+
+    const properties = Properties.getInstance();
+    const headers = {
+      'Content-type': 'application/x-www-form-urlencoded; charset=utf-8',
+      ...properties.config.backendConfig.wiriscustomheaders
+    }
+
+    // const test = Properties.
     const init: RequestInit = {
       method,
-      headers: {
-        'Content-type': 'application/x-www-form-urlencoded; charset=utf-8',
-      },
+      headers
     };
 
     if (method === MethodType.Get) {

--- a/packages/viewer/src/services.ts
+++ b/packages/viewer/src/services.ts
@@ -57,7 +57,6 @@ export async function callService(query: object, serviceName: string, method: Me
       ...properties.config.backendConfig.wiriscustomheaders
     }
 
-    // const test = Properties.
     const init: RequestInit = {
       method,
       headers


### PR DESCRIPTION
## Description

Add customHeaders configuration on viewer.

## Steps to reproduce
To test this feature we will use the integration services in php deployed from plugins project.

**You will need to set html-integrations and plugins on branch KB-42329**

1. On `html-integrations/packages/viewer/properties.ts` replace the variable defaultValues (line 29) to:

```
const defaultValues: Config = {
  editorServicesRoot: 'http://localhost:8081/plugin/3.50/tinymce6-demo/tinymce6/plugins/tiny_mce_wiris/integration/',
  editorServicesExtension: '.php',
  backendConfig: {
    wirispluginperformance: 'true',
    wiriseditormathmlattribute: 'data-mathml',
    wiriscustomheaders: {},
  },
  dpi: 96,
  element: 'body',
  lang: 'en',
  viewer: 'none',
  zoom: 1,
}
```

2. Deploy php integration services with tinymce6 on plugins project.
3. On configuration.ini from the deployed integration services, located on `output/php/tinymce6-demo/tinymce6/plugins/tiny_mce_wiris/`, we will add next configuration:

```
wiriscustomheaders = X-My-Custom-Header=value1
wirisimageservicehost = pre-www.wiris.net
wirisimageservicepath = /demo/editor/render
wiriscorsenabled = true
```

4. On html-integrations: Build the viewer with `nx build viewer`, deploy viewer using `nx serve viewer`
5. On the viewer demo open the inspector and check that all requests made on integration services have the header **X-My-Custom-Header**.
---

[#taskid KB-42329](https://wiris.kanbanize.com/ctrl_board/2/cards/KB-42329/details/)