### PR TITLE
[KB-42660] Viewer breaks when a formula's alt text cannot be generated

### DIFF
--- a/packages/viewer/src/mathml.ts
+++ b/packages/viewer/src/mathml.ts
@@ -119,11 +119,15 @@ async function setImageProperties(properties: Properties, data: FormulaData, mml
 
   // Set the alt text whenever there's a translation for the characters and MathML on the mml.
   if (!corruptMathML.some(corruptMathML => mml.includes(corruptMathML))) {
-    if (!data.alt) {
-      const { text } = await mathml2accessible(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
-      data.alt = text;
+    try {
+      if (!data.alt) {
+        const { text } = await mathml2accessible(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
+        data.alt = text;
+      }
+      img.alt = data.alt;
+    } catch {
+      img.alt = 'Alternative text not available';
     }
-    img.alt = data.alt;
   }
 
   return img;


### PR DESCRIPTION
## Description

If a page to be rendered includes a MathML with an alt text that the `mathml2accessible` service is not capable of generating (e.g. such as a formula containing a `largeop`), it throws an error, and the rest of the equations in the page to be rendered are not rendered. 

## Steps to reproduce

1. Open the viewer demo (`nx start html-viewer`).
2. Add the following formula: `<math xmlns="http://www.w3.org/1998/Math/MathML"><msub><mo largeop="true">2</mo><mn>2</mn></msub></math>`.

### Expected behavior

The formula is rendered normally, but its alt text is not available.

### Actual behavior

The formula is not rendered and neither are subsequent formulas.

---

[#taskid 42660](https://wiris.kanbanize.com/ctrl_board/2/cards/42660/details/)
