### PR TITLE
[KB-42503] Froala inline toolbar throws error when inserting equation

### DIFF
--- a/packages/froala/wiris.src.js
+++ b/packages/froala/wiris.src.js
@@ -186,7 +186,9 @@ export class FroalaIntegration extends IntegrationModel {
     // Save a image to a temporal register to detect when we want to
     // change between MT and CT.
     // Will be deleted when inserting the formula or canceling it
-    this.core.editionProperties.temporalImage = element;
+    // When double clicking a word, Froala assigns the whole div that contains that word to `element`.
+    // We only really want temporalImage to be an img element, not divs:
+    this.core.editionProperties.temporalImage = element.tagName.toLowerCase() === 'img' ? element : null;
     super.doubleClickHandler(element);
   }
 


### PR DESCRIPTION
## Description

On Froala with inline toolbar, adding equations throws an error that kills the demo. This PR fixes that problem.

## Steps to reproduce

1. Modify `demos/html/froala/src/app,js` to add `toolbarInline: true` to the Froala settings.
2. Start a Froala demo (`nx start html-froala`).
3. Test that you can insert and edit MathType formulas.

---

[#taskid 42503](https://wiris.kanbanize.com/ctrl_board/2/cards/42503/details/)
