### PR TITLE
fix: #881 keep valid attrs when sanitizing MathML

### DIFF
--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -404,7 +404,7 @@ export default class Util {
     // Get all the annotation content including the tags.
     let annotation = html.match(annotationRegex);
     // Sanitize html code without removing the <semantics> and <annotation> tags.
-    html = DOMPurify.sanitize(html, { ADD_TAGS: ['semantics', 'annotation'], ALLOWED_ATTR: ['mathvariant', 'class', 'linebreak', 'open', 'close']});
+    html = DOMPurify.sanitize(html, { ADD_TAGS: ['semantics', 'annotation'], ADD_ATTR: ['linebreak']});
     // Readd old annotation content.
     return html.replace(annotationRegex, annotation);
   }


### PR DESCRIPTION
## Description

Prevents removing all valid attributes from MathML.
**Note:** 'open', 'close', 'class', 'mathvariant' are already valid attributes supported by DOMPurify,  'linebreak' is not. 

## Steps to reproduce

Please see original issue.

---

Closes #881 
