### PR TITLE
KB 42181 - add forceHandMode configutation on integrationModelProperties 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project was 29th of January 2024.
 
+### Unreleased
+
+  - feat: move handmode config to  integrationmodal
+
 ### 8.8.1 2024-01-29
 
   - fix: MathType breaking editour source plugin. #KB-42401
@@ -25,10 +29,6 @@ Last release of this project was 29th of January 2024.
   - fix: Froala + Generic not setting GUI parameters.
   - feat: Add method that allows the integration forcing the hand mode.
   - feat(viewer): decode safe mathml
-
-## Unreleased
-
-  - fix(viewer): Formulas containing '&' symbol are not rendered. #KB-42230
 
 ### 8.7.3 2023-11-22
 

--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -76,9 +76,9 @@ export default class MathType extends Plugin {
     const { editor } = this;
 
     /**
-         * Integration model constructor attributes.
-         * @type {integrationModelProperties}
-         */
+     * Integration model constructor attributes.
+     * @type {integrationModelProperties}
+     */
     const integrationProperties = {};
     integrationProperties.environment = {};
     integrationProperties.environment.editor = 'CKEditor5';
@@ -415,7 +415,7 @@ export default class MathType extends Plugin {
      */
     editor.data.get = (options) => {
       let output = get.bind(editor.data)(options);
-      
+
       // CKEditor 5 replaces all the time the &lt; and &gt; for < and >, which our render can't understand.
       // We replace the values inserted for CKEditro5 to be able to render the formulas with the mentioned characters.
       output = output.replaceAll('"<"', '"&lt;"')
@@ -452,10 +452,10 @@ export default class MathType extends Plugin {
           modifiedData = modifiedData.replace(mathml, latex);
         }
       });
-      
+
       // Run the setData code from CKEditor5 with the modified string.
-      set.bind(editor.data)(modifiedData); 
-    };  
+      set.bind(editor.data)(modifiedData);
+    };
   }
 
   /**

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -137,13 +137,6 @@ export default class ContentManager {
      * @type {IntegrationModel}
      */
     this.integrationModel = null;
-
-
-    /**
-     * Options object containing any configuration values to be used by the content manager. 
-     * @type {Object}
-     */
-    this.options = contentManagerAttributes.options || {};
   }
 
   /**
@@ -442,14 +435,14 @@ export default class ContentManager {
 
   /**
    * Sets an empty MathML as {@link ContentManager.editor} content.
-   * This will open the MT/CT editor with the hand mode. 
+   * This will open the MT/CT editor with the hand mode.
    * It adds dir rtl in case of it's activated.
    */
   setEmptyMathML() {
     const isMobile = this.deviceProperties.isAndroid || this.deviceProperties.isIOS;
     const isRTL = this.editor.getEditorModel().isRTL();
 
-    if (isMobile || this.options.forcedHandMode) {
+    if (isMobile || this.integrationModel.forcedHandMode) {
       // For mobile devices or forced hand mode, set an empty annotation MATHML to maintain the editor in Hand mode.
       const mathML = `<math${isRTL ? ' dir="rtl"' : ''}><semantics><annotation encoding="application/json">[]</annotation></semantics></math>`;
       this.setMathML(mathML, true);
@@ -497,7 +490,7 @@ export default class ContentManager {
 
     Core.globalListeners.fire('onModalOpen', {});
 
-    if (this.options.forcedHandMode) {
+    if (this.integrationModel.forcedHandMode) {
       this.hideHandModeButton();
 
       // In case we have a keyboard written formula, we still want it to be opened with handMode.
@@ -523,11 +516,11 @@ export default class ContentManager {
 
   /**
    * Hides the hand <-> keyboard mode switch.
-   * 
+   *
    * This method relies completely on the classes used on different HTML elements within the editor itself, meaning
    * any change on those classes will make this code stop working properly.
-   * 
-   * On top of that, some of those classes are changed on runtime (for example, the one that makes some buttons change). 
+   *
+   * On top of that, some of those classes are changed on runtime (for example, the one that makes some buttons change).
    * This forces us to use some delayed code (this is, a timeout) to make sure everything exists when we need it.
    * @param {*} forced (boolean) Forces the user to stay in Hand mode by hiding the keyboard mode button.
    */
@@ -562,7 +555,7 @@ export default class ContentManager {
 
   /**
    * It will open any formula written in Keyboard mode with the hand mode with the default hand trace.
-   * 
+   *
    * @param {String} mathml The original KeyBoard MathML
    * @param {Object} editor The editor object.
    */
@@ -576,19 +569,19 @@ export default class ContentManager {
     // We wait until the hand editor object exists.
     await this.waitForHand(editor);
 
-    // Logic to get the hand traces and open the formula in hand mode. 
+    // Logic to get the hand traces and open the formula in hand mode.
     // This logic comes from the editor.
     const handEditor = editor.hand;
     editor.handTemporalMathML = editor.getMathML();
     const handCoordinates = editor.editorModel.getHandStrokes();
-    handEditor.setStrokes(handCoordinates);    
+    handEditor.setStrokes(handCoordinates);
     handEditor.fitStrokes(true);
     editor.openHand();
   }
 
   /**
    * Waits until the hand editor object exists.
-   * @param {Obect} editor The editor object. 
+   * @param {Obect} editor The editor object.
    */
   async waitForHand(editor) {
     while (!editor.hand) {

--- a/packages/devkit/src/core.src.js
+++ b/packages/devkit/src/core.src.js
@@ -570,7 +570,7 @@ export default class Core {
    * @param {HTMLElement} target - The target HTMLElement where formulas should be inserted.
    * @param {Boolean} isIframe - True if the target HTMLElement is an iframe. False otherwise.
    */
-  openModalDialog(target, isIframe, editorOptions = {}) {
+  openModalDialog(target, isIframe) {
 
     // Count the time since the editor is open
     this.editionProperties.editionStartTime = Date.now();
@@ -732,7 +732,6 @@ export default class Core {
     contentManagerAttributes.language = this.language;
     contentManagerAttributes.customEditors = this.customEditors;
     contentManagerAttributes.environment = this.environment;
-    contentManagerAttributes.options = editorOptions || {};
 
     if (this.modalDialog == null) {
       this.modalDialog = new ModalDialog(editorAttributes);

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -47,10 +47,7 @@ export default class IntegrationModel {
      * Service parameters
      * @type {ServiceProviderProperties}
      */
-    this.serviceProviderProperties = {};
-    if ('serviceProviderProperties' in integrationModelProperties) {
-      this.serviceProviderProperties = integrationModelProperties.serviceProviderProperties;
-    }
+    this.serviceProviderProperties = integrationModelProperties.serviceProviderProperties ?? {};
 
     /**
      * Configuration service path. The integration service is needed by Core class to
@@ -91,19 +88,13 @@ export default class IntegrationModel {
     /**
      * Object containing the arguments needed by the callback function.
      */
-    this.callbackMethodArguments = {};
-    if ('callbackMethodArguments' in integrationModelProperties) {
-      this.callbackMethodArguments = integrationModelProperties.callbackMethodArguments;
-    }
+    this.callbackMethodArguments = integrationModelProperties.callbackMethodArguments ?? {};
 
     /**
      * Contains information about the integration environment:
      * like the name of the editor, the version, etc.
      */
-    this.environment = {};
-    if ('environment' in integrationModelProperties) {
-      this.environment = integrationModelProperties.environment;
-    }
+    this.environment = integrationModelProperties.environment ?? {};
 
     /**
      * Indicates if the DOM target is - or not - and iframe.
@@ -117,28 +108,22 @@ export default class IntegrationModel {
      * Instance of the integration editor object. Usually the entry point to access the API
      * of a HTML editor.
      */
-    this.editorObject = null;
-    if ('editorObject' in integrationModelProperties) {
-      this.editorObject = integrationModelProperties.editorObject;
-    }
+    this.editorObject = integrationModelProperties.editorObject ?? null;
 
     /**
      * Specifies if the direction of the text is RTL. false by default.
      */
-    this.rtl = false;
-    if ('rtl' in integrationModelProperties) {
-      this.rtl = integrationModelProperties.rtl;
-    }
+    this.rtl = integrationModelProperties.rtl ?? false;
 
     /**
      * Specifies if the integration model exposes the locale strings. false by default.
      */
-    this.managesLanguage = false;
-    if ('managesLanguage' in integrationModelProperties) {
-      this.managesLanguage = integrationModelProperties.managesLanguage;
-    }
+    this.managesLanguage = integrationModelProperties.managesLanguage ?? false;
 
-    this.forcedHandMode = integrationModelProperties.forcedHandMode ?? false;
+    /**
+     * Specify if editor will open in hand mode only
+     */
+    this.forcedHandMode = integrationModelProperties?.integrationParameters.forcedHandMode ?? false;
 
     /**
      * Indicates if an image is selected. Needed to resize the image to the original size in case

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -138,6 +138,8 @@ export default class IntegrationModel {
       this.managesLanguage = integrationModelProperties.managesLanguage;
     }
 
+    this.forcedHandMode = integrationModelProperties.forcedHandMode ?? false;
+
     /**
      * Indicates if an image is selected. Needed to resize the image to the original size in case
      * the image is resized.
@@ -169,8 +171,6 @@ export default class IntegrationModel {
         }
       });
     }
-
-    this.editorOptions = integrationModelProperties.editorOptions || {};
   }
 
   /**
@@ -544,7 +544,7 @@ export default class IntegrationModel {
     if (window.navigator.onLine) {
       this.core.editionProperties.dbclick = false;
       this.core.editionProperties.isNewElement = true;
-      this.core.openModalDialog(this.target, this.isIframe, this.editorOptions);
+      this.core.openModalDialog(this.target, this.isIframe);
     } else {
       let modal = document.getElementById("wrs_modal_offline");
       modal.style.display = "block";
@@ -558,7 +558,7 @@ export default class IntegrationModel {
   openExistingFormulaEditor() {
     if (window.navigator.onLine) {
       this.core.editionProperties.isNewElement = false;
-      this.core.openModalDialog(this.target, this.isIframe, this.editorOptions);
+      this.core.openModalDialog(this.target, this.isIframe);
     } else {
       let modal = document.getElementById("wrs_modal_offline");
       modal.style.display = "block";

--- a/packages/generic/wirisplugin-generic.src.js
+++ b/packages/generic/wirisplugin-generic.src.js
@@ -23,10 +23,10 @@ export const currentInstance = null;
  * @param {HTMLElement} target - DOM target, in this integration the editable iframe.
  * @param {HTMLElement} toolbar - DOM element where icons will be inserted.
  */
-export function wrsInitEditor(target, toolbar, mathtypeProperties = undefined, editorOptions = {}) {
+export function wrsInitEditor(target, toolbar, mathtypeProperties) {
   /**
-     * @type {integrationModelProperties}
-     */
+   * @type {integrationModelProperties}
+   */
   const genericIntegrationProperties = {};
   genericIntegrationProperties.target = target;
   genericIntegrationProperties.toolbar = toolbar;
@@ -35,7 +35,7 @@ export function wrsInitEditor(target, toolbar, mathtypeProperties = undefined, e
   }
 
   // GenericIntegration instance.
-  const genericIntegrationInstance = new GenericIntegration(genericIntegrationProperties, editorOptions); // eslint-disable-line no-use-before-define
+  const genericIntegrationInstance = new GenericIntegration(genericIntegrationProperties); // eslint-disable-line no-use-before-define
   genericIntegrationInstance.init();
   genericIntegrationInstance.listeners.fire('onTargetReady', {});
 
@@ -66,7 +66,7 @@ export default class GenericIntegration extends IntegrationModel {
      * @constructs
      * @param {IntegrationModelProperties} integrationModelProperties
      */
-  constructor(integrationModelProperties, editorOptions = {}) {
+  constructor(integrationModelProperties) {
     if (typeof (integrationModelProperties.serviceProviderProperties) === 'undefined') {
       integrationModelProperties.serviceProviderProperties = {
         URI: process.env.SERVICE_PROVIDER_URI,
@@ -94,7 +94,7 @@ export default class GenericIntegration extends IntegrationModel {
    */
   telemeter = {
     /**
-     * 
+     *
      * @param {string} toolbar The MT/CT button clicked from the toolbar: 'general' for the MathType and 'chemistry' for the ChemType
      * @param {string} trigger 'button' when the modal is opened by clicking the MathType or ChemType button from the toolbar
      *                         'formula' when the modal is opened by double-click on the formula
@@ -117,7 +117,7 @@ export default class GenericIntegration extends IntegrationModel {
     },
 
     /**
-     * 
+     *
      * @param {string} toolbar The MT/CT button clicked from the toolbar: 'general' for the MathType and 'chemistry' for the ChemType
      * @param {string} trigger 'mtct_insert' when the modal is closed due to inserting or modifying a formula. 'mtct_close' otherwise
      */
@@ -139,7 +139,7 @@ export default class GenericIntegration extends IntegrationModel {
     },
 
     /**
-     * 
+     *
      * @param {string} mathml_origin If editing a formula, the original mathml that's going to be edited. Otherwise null
      * @param {string} mathml The mathml that's going to be inserted
      * @param {number} time The time passed since the MT/CT modal opened until the calling of this function


### PR DESCRIPTION
## Description

This PR move the forceHandMode configuration on the integrationModelProperties. This allow the user to add this configuration for all out integrations using the `mathTypeParameters`.

## Steps to reproduce

To test this on tinymce6:

1. On `html-integrations/demos/html/tinymce6/src/app.js` uncomment the `mathTypeParameters` from line 33.
2. Add the `forcedHandMode = true`configuration on `mathTypeParameters`:

```
  mathTypeParameters: {
    editorParameters: { language: 'de' },
    forcedHandMode: true
  },
```

3. Open the demo.

Each time you open the MathType editor to create or update a formula, will be automatically open in hand mode.

---

[#taskid 42181](https://wiris.kanbanize.com/ctrl_board/2/cards/42181/details/)
