### PR TITLE
fix(ckeditor5): use getLanguage to interpret config

### DIFF
--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -146,7 +146,7 @@ export default class MathType extends Plugin {
         view.bind('isEnabled').to(editor.commands.get('MathType'), 'isEnabled');
 
         view.set({
-          label: StringManager.get('insert_math', editor.config.get('language')),
+          label: StringManager.get('insert_math', integration.getLanguage()),
           icon: mathIcon,
           tooltip: true,
         });
@@ -172,7 +172,7 @@ export default class MathType extends Plugin {
         view.bind('isEnabled').to(editor.commands.get('ChemType'), 'isEnabled');
 
         view.set({
-          label: StringManager.get('insert_chem', editor.config.get('language')),
+          label: StringManager.get('insert_chem', integration.getLanguage()),
           icon: chemIcon,
           tooltip: true,
         });
@@ -267,7 +267,7 @@ export default class MathType extends Plugin {
             - A <mathml> element with a formula attribute set to the given formula, or
             - If the original <math> had a LaTeX annotation, then the annotation surrounded by "$$...$$" */
       const modelNode = isLatex
-        ? writer.createText(Parser.initParse(formula, editor.config.get('language')))
+        ? writer.createText(Parser.initParse(formula, integration.getLanguage()))
         : writer.createElement('mathml', { formula });
 
       // Find allowed parent for element that we are going to insert.
@@ -342,7 +342,7 @@ export default class MathType extends Plugin {
       const htmlDataProcessor = new HtmlDataProcessor(viewWriter.document);
 
       const mathString = modelItem.getAttribute('formula').replaceAll('ref="<"', 'ref="&lt;"');
-      const imgHtml = Parser.initParse(mathString, editor.config.get('language'));
+      const imgHtml = Parser.initParse(mathString, integration.getLanguage());
       const imgElement = htmlDataProcessor.toView(imgHtml).getChild(0);
 
       /* Although we use the HtmlDataProcessor to obtain the attributes,

--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -55,7 +55,7 @@ export default class MathType extends Plugin {
     this._addSchema();
 
     // Add the downcast and upcast converters
-    this._addConverters();
+    this._addConverters(integration);
 
     // Expose the WirisPlugin variable to the window
     this._exposeWiris();
@@ -207,7 +207,7 @@ export default class MathType extends Plugin {
   /**
      * Add the downcast and upcast converters
      */
-  _addConverters() {
+  _addConverters(integration) {
     const { editor } = this;
 
     // Editing view -> Model


### PR DESCRIPTION

## Description

Change uses of editor.config.get('language') to integration.getLanguage( ) in the CKEditor 5 package. 

## Steps to reproduce

The current code assumes that the editor language config is a string. This is not always the case, as according to the [CKEditor5 documentation](https://ckeditor.com/docs/ckeditor5/latest/features/ui-language.html#setting-the-language-of-the-content) it can be an object like:

`editor.config.language = {
  ui: 'fr',
  content: 'en',
  ...
}`

To reproduce:
1. Have an instance of CKEditor5 with wiris and `editor.config.language = {  ui: 'fr',  content: 'en' }`
2. Once the instance is loaded the warning `Unknown language [object Object] set in StringManager.` will appear and wiris will be in English instead of French.