### PR TITLE
Fix re-decode of formulas when rendering them

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project was 29th of January 2024.
 
+### Unreleased
+
+  - fix: Avoid re-decoding formulas when rendering. #KB-43787
+
 ### 8.8.1 2024-01-29
 
   - fix: MathType breaking editour source plugin. #KB-42401

--- a/packages/viewer/src/utils.ts
+++ b/packages/viewer/src/utils.ts
@@ -22,13 +22,11 @@ export function htmlEntitiesToXmlEntities(text: string): string {
   text = decodeEntities(text);
 
   // Replaces the '<', '&', '>', and '"' characters to its HTMLEntity to avoid render issues.
-  text = text.split('"<"').join('"&lt;"')
-    .split('">"')
-    .join('"&gt;"')
-    .split('><<')
-    .join('>&lt;<')
-    .split('&')
-    .join('&amp;');
+  text = text.split('&').join('&amp;')
+    .split('"<"').join('"&lt;"')
+    .split('">"').join('"&gt;"')
+    .split('><<').join('>&lt;<');
+
 
   let result = '';
   for (let i = 0; i < text.length; i++) {


### PR DESCRIPTION
## Description

The `<` symbol broke in the latest release (`8.8.1`) of the viewer due to a change which introduced re-decoding some, already decoded, characters. This broke the formulas, hence they could not be rendered.
This PR fixes the issue by avoiding the re-decoding of the `&` character, which was breaking the formulas with the `<` one.

## Steps to reproduce

1. Build the viewer with `nx build viewer`
2. Start a demo using the local build viewer.
3. Add a formula containing the `<` character. For example: `3 < 4`.
4. Add a formula containing the `&` character. For example `$$\begin{pmatrix}&&&\\&&&\\&&&\\&&&\end{pmatrix}$$`
5. Click on the update button.
6. All the formulas should render properly.

---

[#taskid 43787](https://wiris.kanbanize.com/ctrl_board/2/cards/43787/details/)
