### PR TITLE
fix: use local viewer

### DIFF
--- a/demos/html/viewer/index.html
+++ b/demos/html/viewer/index.html
@@ -6,18 +6,19 @@
   <link rel="shortcut icon" href="data:image/x-icon;," type="image/x-icon">
   <script src="node_modules/@wiris/mathtype-viewer/dist/WIRISplugins.js?viewer=image" defer></script>
   <script>
-    window.content = `<p>MathML formula:
-  <math>
-    <mn>2</mn>
-    <mo>+</mo>
-    <mn>2</mn>
-    <mo>=</mo>
-    <mn>4</mn>
-  </math>
-</p>
-<p>LaTeX formula:
-  $$4 - 2 = 2$$
-</p>`;
+    window.content = `
+      <p>MathML formula:
+        <math>
+          <mn>2</mn>
+          <mo>+</mo>
+          <mn>2</mn>
+          <mo>=</mo>
+          <mn>4</mn>
+        </math>
+      </p>
+      <p>LaTeX formula:
+        $$4 - 2 = 2$$
+      </p>`;
 
     window.document.addEventListener('viewerLoaded', () => {
       // window.viewer.Properties can be modified here

--- a/packages/viewer/src/app.ts
+++ b/packages/viewer/src/app.ts
@@ -25,16 +25,6 @@ async function main(w: Window): Promise<void> {
 
   const properties: Properties = await Properties.generate();
 
-  // Expose the globals to the browser
-  if (!w.viewer) {
-    w.viewer = {
-      properties,
-      isLoaded: false,
-    };
-  }
-
-  const document = w.document;
-
   /**
    * Parse the DOM looking for LaTeX and <math> elements.
    * Replaces them with the corresponding rendered images within the given element.
@@ -48,6 +38,19 @@ async function main(w: Window): Promise<void> {
       await renderMathML(properties, element);
     }
   };
+
+  // Expose the globals to the browser
+  if (!w.viewer) {
+    w.viewer = {
+      properties,
+      isLoaded: false,
+    };
+  } else {
+    w.viewer.properties = properties;
+    w.viewer.isLoaded = false;
+  }
+
+  const document = w.document;
 
   // Initial function to call once document is loaded
   // Renders formulas and sets observer


### PR DESCRIPTION
## Description

Use local viewer

## Steps to reproduce

1. Open the viewer demo
2. Open the inspector
3. Check that the viewer import request is made on the next endpoint:
   http://localhost:4200/node_modules/@wiris/mathtype-viewer/dist/WIRISplugins.js?viewer=image

---

[#taskid 43631](https://wiris.kanbanize.com/ctrl_board/2/cards/43631/details/)