### PR TITLE
fix(viewer): prevent mathml2accesible request if formula is cached

### DIFF
--- a/packages/viewer/index.html
+++ b/packages/viewer/index.html
@@ -14,13 +14,7 @@
 </head>
 <body>
   <p>
-    <math>
-      <mn>2</mn>
-      <mo>+</mo>
-      <mn>2</mn>
-      <mo>=</mo>
-      <mn>4</mn>
-    </math>
+    <math xmlns="http://www.w3.org/1998/Math/MathML"><mn>2</mn><mo>+</mo><mn>2</mn><mo>=</mo><mn>4</mn></math>
   </p>
   <p>
     $$4 - 2 = 2$$

--- a/packages/viewer/src/mathml.ts
+++ b/packages/viewer/src/mathml.ts
@@ -11,6 +11,7 @@ interface FormulaData {
   baseline: string,
   height: string,
   width: string,
+  alt?: string,
 }
 
 /**
@@ -118,8 +119,11 @@ async function setImageProperties(properties: Properties, data: FormulaData, mml
 
   // Set the alt text whenever there's a translation for the characters and MathML on the mml.
   if (!corruptMathML.some(corruptMathML => mml.includes(corruptMathML))) {
-    const { text } = await mathml2accessible(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
-    img.alt = text;
+    if (!data.alt) {
+      const { text } = await mathml2accessible(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
+      data.alt = text;
+    }
+    img.alt = data.alt;
   }
 
   return img;

--- a/packages/viewer/src/services.ts
+++ b/packages/viewer/src/services.ts
@@ -113,7 +113,7 @@ export async function showImage(mml: string, lang: string, url: string, extensio
   }
 
   // Try to obtain the image via GET
-  const getParams = Parser.createShowImageSrcData(params);
+  const getParams = Parser.createShowImageSrcData(params, params.lang);
   const getResponse = callService(getParams, 'showimage', MethodType.Get, url, extension);
   try {
     return await processJsonResponse(getResponse);


### PR DESCRIPTION
## Description

This PR prevents the viewer to make unnecessary mathml2accesible requests if formula is already cached.

## Steps to reproduce

1. Build the viewer with `nx build viewer`
2. Navigate to `/package/viewer`
3. Run the command `npm run serve`
4. Reload the page

No service **mathml2accesible** requests appear on the Network tab from the Inspector.
**Note:** As request are made to AWS maybe you will need to make some reloads to the page in order to cache the formula in diferent AWS zones.

---

[#taskid 43670](https://wiris.kanbanize.com/ctrl_board/2/cards/43670/details/)
