### PR TITLE
Add CKEditor4 license key

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -162,6 +162,7 @@ jobs:
 
       - name: Build the demos
         env:
+          CKEDITOR4_API_KEY: ${{ secrets.CKEDITOR4_API_KEY }}
           FROALA_API_KEY: ${{ secrets.FROALA_API_KEY }}
           REACT_APP_FROALA_API_KEY: ${{ secrets.FROALA_API_KEY }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ app.*.js
 
 **/environments/environment.prod.ts
 **/git-data.json
+.env

--- a/demos/html/ckeditor4/src/app.js
+++ b/demos/html/ckeditor4/src/app.js
@@ -26,6 +26,8 @@ CKEDITOR.replace('editor', { //eslint-disable-line
     { name: 'wirisplugins', items: ['ckeditor_wiris_formulaEditor', 'ckeditor_wiris_formulaEditorChemistry'] },
     { name: 'others' },
   ],
+
+  licenseKey: process.env.CKEDITOR4_API_KEY || '',
   // language: 'de',
   // mathTypeParameters: {
   //   editorParameters: { language: 'es' }, // MathType config, including language

--- a/demos/html/ckeditor4/webpack.config.js
+++ b/demos/html/ckeditor4/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const CopyPlugin = require("copy-webpack-plugin");
+const webpack = require("webpack");
 
 module.exports = (config, context) => {
   return {
@@ -33,6 +34,12 @@ module.exports = (config, context) => {
             to: path.resolve(__dirname, "dist/ckeditor4"),
           },
         ],
+      }),
+      // Add the DefinePlugin to define process.env variable
+      new webpack.DefinePlugin({
+        'process.env': {
+          CKEDITOR4_API_KEY: JSON.stringify(process.env.CKEDITOR4_API_KEY)
+        },
       }),
     ],
     mode: 'none',

--- a/docs/development/demos/README.md
+++ b/docs/development/demos/README.md
@@ -12,6 +12,20 @@ All the commands can be executed either from the root of the project, or from th
 * [**yarn**](https://classic.yarnpkg.com/lang/en/docs/install/#debian-stable) (*currently: v1.22.19*)
 * [**nx**](https://nx.dev/getting-started/installation#installing-nx-globally) (*latest*) - Optional
 
+## Set up environment variables
+
+The following editors require a license key:
+
+* **CKEditor4**: Mandatory
+* **Froala**: Optional
+
+For that reason, you'll need to create an `env` file with those keys or add them to your existing `.env` file. Follow the example below:
+
+```bash
+CKEDITOR4_API_KEY=XXXXXX
+froala_API_KEY=XXXXXX
+```
+
 ## Build and start a demo in development mode
 
 Assuming that you already executed the `yarn` command, you'll have to build the desired package and start the demo:

--- a/scripts/createEnvFile.js
+++ b/scripts/createEnvFile.js
@@ -2,7 +2,7 @@
  * Create environment.prod.ts file for the Angular + Froala demo.
  *
  * This script is run on the deploy-staging workflow in order to
- * set the  Froala Key from GitHub secret on staging demo.
+ * set the Froala Key from GitHub secret on staging demo.
  */
 
 const fs = require('fs');

--- a/yarn.lock
+++ b/yarn.lock
@@ -6751,9 +6751,9 @@ cjs-module-lexer@^1.0.0:
   integrity sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==
 
 ckeditor4@^4.16.0:
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/ckeditor4/-/ckeditor4-4.23.0.tgz#c0c3bc4e2a66ada6010b89466a41b09202f7bb7a"
-  integrity sha512-K9DUzTa7roj8JffKLm6nOxDF02aPURDK8m7oFibvvkyAaomj24qOgpVdt7yvszmIubeJLbAB6q4k7Euk8jzD1A==
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/ckeditor4/-/ckeditor4-4.24.0.tgz#9699ddbce7eaa9cb1063f7f7d75b0ae761106405"
+  integrity sha512-ShtIqZMMNmP5r8AhZqnysSaONsx+qKjI/zf5AkU9wKxl0yHVw2/CSxWYmdd40u3dMjJR2kOthQ6USahz528lbw==
 
 ckeditor5@38.1.1, ckeditor5@^38.0.0:
   version "38.1.1"


### PR DESCRIPTION
## Description

CKEditor4 staging demo stopped working, since the CKEditor4 versions above `23.0.0` require a license. 

## Steps to reproduce

**Staging demos**

1. Go to https://integrations.wiris.kitchen/KB-43835/html/ckeditor4/ and validate that the demo is working as expected in the CKEditor4 version `+23.0.0`.

**Local demos**

1. Follow the instructions on the `docs/development/demos/README.md` file to start the demo with the `.env` file for the CKEditor4 API key.
2. Build and start the demo as usual (instructions also on the previous file).
3. Validate that the demo is working as expected with the CKEdtiro4 version `+23.0.0`.

---

[#taskid 43835](https://wiris.kanbanize.com/ctrl_board/2/cards/43835/details/)
