### PR TITLE
fix: htmlSanitize stripping away valid MML tags

### DIFF
--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -48,7 +48,7 @@
     "webpack-cli": "^5.0.0"
   },
   "dependencies": {
-    "dompurify": "^2.3.9",
+    "dompurify": "^3.0.8",
     "raw-loader": "^4.0.2",
     "uuid": "^8.3.2"
   }


### PR DESCRIPTION
## Description

The DOMPurify dependency has been upgraded to the latest version. 
The previous version is old and lack support for certain tags etc. 
E.g. support for the mprescripts tag was added in  3.0.2

The newer version should be compatible with how DOMPurify is used today.

## Steps to reproduce

Edit this MathML in e.g. CKEditor5: 
```
<math xmlns="http://www.w3.org/1998/Math/MathML">
  <mmultiscripts>
    <msubsup>
      <mi>c</mi>
      <mi>h</mi>
      <mi>h</mi>
    </msubsup>
    <mprescripts/>
    <mi>h</mi>
    <mi>h</mi>
  </mmultiscripts>
</math>
```
and observe `mprescripts` tag is removed resulting in a different expression.

