### PR TITLE
Fix error when double-click a plain text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Last release of this project was 5th of February 2024.
 ### Unreleased
   - fix: Error when open a plain text with MT/CT editor. #KB-44250
   - feat: Add version text on html-viewer window property. #KB-43186
+  - fix: Error when double-click a plain text and open MT/CT editor. #KB-44249
 
 ### 8.8.2 2024-02-05
 

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -123,7 +123,7 @@ export default class IntegrationModel {
     /**
      * Specify if editor will open in hand mode only
      */
-    this.forcedHandMode = integrationModelProperties?.integrationParameters.forcedHandMode ?? false;
+    this.forcedHandMode = integrationModelProperties?.integrationParameters?.forcedHandMode ?? false;
 
     /**
      * Indicates if an image is selected. Needed to resize the image to the original size in case

--- a/packages/froala/wiris.src.js
+++ b/packages/froala/wiris.src.js
@@ -183,12 +183,6 @@ export class FroalaIntegration extends IntegrationModel {
       return;
     }
 
-    // Save a image to a temporal register to detect when we want to
-    // change between MT and CT.
-    // Will be deleted when inserting the formula or canceling it
-    // When double clicking a word, Froala assigns the whole div that contains that word to `element`.
-    // We only really want temporalImage to be an img element, not divs:
-    this.core.editionProperties.temporalImage = element.tagName.toLowerCase() === 'img' ? element : null;
     super.doubleClickHandler(element);
   }
 

--- a/packages/generic/wirisplugin-generic.src.js
+++ b/packages/generic/wirisplugin-generic.src.js
@@ -252,15 +252,6 @@ export default class GenericIntegration extends IntegrationModel {
     }
   }
 
-  /**
-     * @inheritdoc
-     * @param {HTMLElement} element - DOM object target.
-     */
-  doubleClickHandler(element) {
-    this.core.editionProperties.temporalImage = element;
-    super.doubleClickHandler(element);
-  }
-
   /** @inheritdoc */
   openNewFormulaEditor() {
     this.core.editionProperties.dbclick = false;


### PR DESCRIPTION
## Description
In generic and froala, there is an error in the console: `Uncaught TypeError: Cannot read properties of null (reading 'split')` because when user do double click to a text, the system recognise it as formula image .

After that error is shown, the behavior of the modal is erratic and the user is blocked.


## Steps to reproduce

1. Enter to generic and froala staging enviroument.
2. Input a plain text.
3. Double click to that text.
4. Try to edit it with MT/CT. 
5. Ensure that there is no console error.
---


[#taskid 44249](https://wiris.kanbanize.com/ctrl_board/2/cards/44249/details/) 
