### PR TITLE
Error when try to open plain text with editors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project was 5th of February 2024.
 
+### Unreleased
+  - fix: Error when open a plain text with MT/CT editor. #KB-44250
+
 ### 8.8.2 2024-02-05
 
   - fix: Avoid re-decoding formulas when rendering. #KB-43787

--- a/packages/devkit/src/core.src.js
+++ b/packages/devkit/src/core.src.js
@@ -419,6 +419,8 @@ export default class Core {
    * @param {Node} node - The Node element.
    */
   placeCaretAfterNode(node) {
+    if (node === null) return;
+
     this.integrationModel.getSelection();
     const nodeDocument = node.ownerDocument;
     if (typeof nodeDocument.getSelection !== 'undefined' && !!node.parentElement) {


### PR DESCRIPTION
## Description

Fix `ncaught TypeError: Cannot read properties of null (reading 'ownerDocument')` error when try to modify a plain text with MT/CT editor, then click cancel

## Steps to reproduce

1. Type any string in the HTML editor
2. Select the string typed
3. Click on “Insert equation button”
4. Click on Cancel in the modal

---
[#taskid 44250](https://wiris.kanbanize.com/ctrl_board/2/cards/44250/details/) 
