### PR TITLE
Fix TypeError when insert a math equation into the first line

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Last release of this project was 18th of March 2024.
 
 ### Unreleased
   - fix(ck5): Add some DOMPurify exception in order to avoid error when inserting some formula. #KB-44372
+  - fix: Avoid TypeError when the selected node don't have some properties. #KB-44268
 
 ### 8.8.3 2024-03-18
 
@@ -30,9 +31,6 @@ Last release of this project was 18th of March 2024.
 ### 8.8.2 2024-02-05
 
   - fix: Avoid re-decoding formulas when rendering. #KB-43787
-
-### Unreleased
-
   - feat: move handmode config to  integrationmodal
 
 ### 8.8.1 2024-01-29

--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -795,12 +795,12 @@ export default class Util {
           // In case that a formula is detected but not selected,
           // we create an empty span where we could insert the new formula.
           if (range.startOffset === range.endOffset) {
-            if (position !== 0 && node.childNodes[position - 1].localName === 'span' && node.childNodes[position].classList.contains('Wirisformula')) {
+            if (position !== 0 && node.childNodes[position - 1].localName === 'span' && node.childNodes[position].classList?.contains('Wirisformula')) {
               node.childNodes[position - 1].remove();
               return Util.getSelectedItem(target, isIframe, forceGetSelection);
             }
             else if (node.childNodes[position].classList?.contains('Wirisformula')) {
-              if ((position > 0 && node.childNodes[position - 1].classList.contains('Wirisformula')) || position === 0 ) {
+              if ((position > 0 && node.childNodes[position - 1].classList?.contains('Wirisformula')) || position === 0 ) {
                 var emptySpan = document.createElement('span');
                 node.insertBefore(emptySpan, node.childNodes[position]);
                 return {


### PR DESCRIPTION
Prevent read Wirisformula class from node when don't have it

## Description

Fix TypeError when insert a math equation into the first line and edit it with MT/CT

## Steps to reproduce

- Insert a math equation into the first line
- Click on Insert math equation. Do not close the modal
- Click on Insert chemistry formula
- Check there is no console error
---

[#taskid 44268](https://wiris.kanbanize.com/ctrl_board/2/cards/44268/details/) 
