### PR TITLE
Place correct formular position 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Last release of this project was 18th of March 2024.
 ### Unreleased
   - fix(ck5): Add some DOMPurify exception in order to avoid error when inserting some formula. #KB-44372
   - fix: Avoid TypeError when the selected node don't have some properties. #KB-44268
-  - fix(ck4): Place correct formular position after inserting an equation. #KB-43453
+  - fix(ck4): Place formula in the correct position after inserting italics (or bold or underlined) text in a new line. #KB-43453
 
 ### 8.8.3 2024-03-18
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Last release of this project was 18th of March 2024.
 ### Unreleased
   - fix(ck5): Add some DOMPurify exception in order to avoid error when inserting some formula. #KB-44372
   - fix: Avoid TypeError when the selected node don't have some properties. #KB-44268
+  - fix(ck4): Place correct formular position after inserting an equation. #KB-43453
 
 ### 8.8.3 2024-03-18
 
@@ -31,7 +32,7 @@ Last release of this project was 18th of March 2024.
 ### 8.8.2 2024-02-05
 
   - fix: Avoid re-decoding formulas when rendering. #KB-43787
-  - feat: move handmode config to  integrationmodal
+  - feat: Move handmode config to integrationModal
 
 ### 8.8.1 2024-01-29
 

--- a/packages/devkit/src/core.src.js
+++ b/packages/devkit/src/core.src.js
@@ -468,7 +468,6 @@ export default class Core {
             }
           }
         } else {
-          const editorSelection = this.integrationModel.getSelection();
           let range = null;
           // In IE is needed keep the range due to after focus the modal window
           // it can't be retrieved the last selection.
@@ -476,6 +475,7 @@ export default class Core {
             ({ range } = this.editionProperties);
             this.editionProperties.range = null;
           } else {
+            const editorSelection = this.integrationModel.getSelection();
             range = editorSelection.getRangeAt(0);
           }
 


### PR DESCRIPTION
## Description

Place correct formular position after inserting an equation after a styled text on Ckeditor4. 

## Steps to reproduce

- Open any CKEditor 4 plugins demo in Chrome
- Empty the editing area
- Switch to italics, or bold, or underline
- Write some text
- Click the MT or CT icon
- Write a formula and click Insert
- Check that the formula is inserted at the end

---

[#taskid 43453](https://wiris.kanbanize.com/ctrl_board/2/cards/43453/details/)
