### PR TITLE
Add DOMPurify exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project was 18th of March 2024.
 
+### Unreleased
+  - fix(ck5): Add some DOMPurify exception in order to avoid error when inserting some formula. #KB-44372
+
 ### 8.8.3 2024-03-18
 
   - feat: Create CKEditor5 Vue demo. #KB-36629

--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -403,8 +403,8 @@ export default class Util {
     let annotationRegex = /\<annotation.+\<\/annotation\>/
     // Get all the annotation content including the tags.
     let annotation = html.match(annotationRegex);
-    // Sanitize html code without removing the <semantics> and <annotation> tags.
-    html = DOMPurify.sanitize(html, { ADD_TAGS: ['semantics', 'annotation'], ADD_ATTR: ['linebreak', 'indentalign']});
+    // Sanitize html code without removing our supported MathML tags and attributes.
+    html = DOMPurify.sanitize(html, { ADD_TAGS: ['semantics', 'annotation', 'mstack', 'msline', 'msrow'], ADD_ATTR: ['linebreak', 'charalign', 'stackalign']});
     // Readd old annotation content.
     return html.replace(annotationRegex, annotation);
   }


### PR DESCRIPTION
## Description

Add some DOMPurify exception in order to avoid error when inserting some formula.

## Steps to reproduce

- Open a CKEditor5 demo.
- Type the following equation: `<math xmlns="http://www.w3.org/1998/Math/MathML"><mstack charalign="center" stackalign="right"><mn>2</mn><msrow><mo>+</mo><mn>3</mn></msrow><msline> </msline><mn>5</mn></mstack></math>`
- Once inserted, copy the equation and paste it using the keyboard.
- Check the pasted formula is exactly the same as the original one

---

[#taskid 44372](https://wiris.kanbanize.com/ctrl_board/2/cards/44372/details/) 
