### PR TITLE
Upgrade DOMPurify library 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Last release of this project was 18th of March 2024.
   - fix(ck5): Add some DOMPurify exception in order to avoid error when inserting some formula. #KB-44372
   - fix: Avoid TypeError when the selected node don't have some properties. #KB-44268
   - fix(ck4): Place formula in the correct position after inserting italics (or bold or underlined) text in a new line. #KB-43453
+  - feat: Upgrade DOMPurify library to avoid deletion of some MathML tags by error. #KB-44328
 
 ### 8.8.3 2024-03-18
 

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -48,7 +48,7 @@
     "webpack-cli": "^5.0.0"
   },
   "dependencies": {
-    "dompurify": "^2.3.9",
+    "dompurify": "^3.0.10",
     "raw-loader": "^4.0.2",
     "uuid": "^8.3.2"
   }


### PR DESCRIPTION
## Description

Upgrade DOMPurify library to avoid deletion of some MathML tags by error.

## Steps to reproduce

Edit this MathML in e.g. CKEditor5:

```
<math xmlns="http://www.w3.org/1998/Math/MathML">
 <mmultiscripts>
   <msubsup>
     <mi>c</mi>
     <mi>h</mi>
     <mi>h</mi>
   </msubsup>
   <mprescripts/>
   <mi>h</mi>
   <mi>h</mi>
 </mmultiscripts>
</math>
```
Then check `mmultiscripts` tag is not be deleted

---

[#taskid 44328](https://wiris.kanbanize.com/ctrl_board/2/cards/44328/details/)
