### PR TITLE
feat(demos): Destroy MathType when the editor is destroyed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ app.*.js
 **/environments/environment.prod.ts
 **/git-data.json
 .env
+
+# Ignores all .hot-update.js files
+**.hot-update.js

--- a/packages/ckeditor4/plugin.src.js
+++ b/packages/ckeditor4/plugin.src.js
@@ -67,6 +67,10 @@ export class CKEditor4Integration extends IntegrationModel {
         "cke_button__ckeditor_wiris_formulaeditorchemistry",
       )[0].style.display = "none";
     }
+    // Change the destroy behavior to also destroy the Mathtype instance.
+    editor.on('destroy', () => {
+      this.destroy();
+    });
   }
 
   /**

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -726,17 +726,30 @@ export default class IntegrationModel {
    * Remove events to formulas in the DOM target.
    */
   removeEvents() {
-    const eventTarget = this.isIframe
-      ? this.target.contentWindow.document
-      : this.target;
+    const eventTarget = this.isIframe && this.target.contentWindow?.document ? this.target.contentWindow.document : this.target;
+
+    if (!eventTarget) {
+      return;
+    }
+
     Util.removeElementEvents(eventTarget);
   }
 
   /**
-   * Remove events and set this.editorObject to null in order to prevent memory leaks.
+   * Remove events, modals and set this.editorObject to null in order to prevent memory leaks.
    */
   destroy() {
     this.removeEvents();
+    // Destroy modal dialog if exists.
+    if (this.core.modalDialog) {
+      this.core.modalDialog.destroy();
+    }
+
+    // Remove offline modal dialog if exists.
+    if (this.offlineModal) {
+      this.offlineModal.remove();
+    }
+
     this.editorObject = null;
   }
 

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -612,6 +612,19 @@ export default class ModalDialog {
 
     Core.globalListeners.fire("onModalClose", {});
   }
+  /**
+    * Closes modal window and destroys the object.
+    */
+  destroy() {
+    // Close modal window.
+    this.close();
+    // Remove listeners and destroy the object.
+    this.removeListeners();
+    this.overlay.remove();
+    this.container.remove();
+    // Reset properties to allow open again.
+    this.properties.created = false;
+  }
 
   /**
    * Sets the website scale to one.

--- a/packages/froala/wiris.src.js
+++ b/packages/froala/wiris.src.js
@@ -66,6 +66,12 @@ export class FroalaIntegration extends IntegrationModel {
       }.bind(this, this.editorObject),
     );
 
+    // Change the destroy behavior to also destroy the Mathtype instance.
+    this.editorObject.events.on('destroy', () => {
+      // Destroy the MathType plugin.
+      this.destroy();
+    });
+
     /**
      * Update editor parameters.
      * The integration could contain an object with editor parameters.
@@ -390,17 +396,10 @@ export class FroalaIntegration extends IntegrationModel {
     const selectedImage = this.image.get();
     // Value can be undefined.
     if (selectedImage) {
-      if (
-        ($btn.parent()[0].hasAttribute("class") &&
-          $btn.parent()[0].getAttribute("class").indexOf("fr-buttons") ===
-            -1) ||
-        (selectedImage[0] &&
-          (selectedImage[0].classList.contains(
-            Configuration.get("imageClassName"),
-          ) ||
-            selectedImage.hasClass(Configuration.get("imageClassName"))))
-      ) {
-        // Is a MathType image.
+      if (($btn.parent()[0].hasAttribute('class') && $btn.parent()[0].getAttribute('class').indexOf('fr-buttons') === -1) ||
+      (selectedImage[0] && (selectedImage[0].classList.contains(Configuration.get('imageClassName')) ||
+      // Is a MathType image.
+      selectedImage.hasClass(Configuration.get('imageClassName'))))) {
         // Show MathType icons if previously were hidden.
         $btn.removeClass("fr-hidden");
         // Disable resize box.

--- a/packages/generic/wirisplugin-generic.src.js
+++ b/packages/generic/wirisplugin-generic.src.js
@@ -45,6 +45,16 @@ export function wrsInitEditor(target, toolbar, mathtypeProperties) {
 }
 
 /**
+ * Destroys the current instance of the editor and the toolbar.
+ * @param instance - The current instance of the editor.
+ * @returns {void}
+ */
+export function wrsDestroyEditor(instance) {
+  instance.toolbar.innerHTML = '';
+  instance.destroy();
+}
+
+/**
  * Gets the html content of the Generic editor and parses it to transform the latex
  * $$$$ into a mathml image
  * @param {HTMLElement} target - DOM target, in this integration the editable iframe

--- a/packages/tinymce5/editor_plugin.src.js
+++ b/packages/tinymce5/editor_plugin.src.js
@@ -413,7 +413,18 @@ export const currentInstance = null;
         WirisPlugin.instances[editor.id].initParsed = true;
       };
 
-      if ("onInit" in editor) {
+      // Change the destroy behavior to also destroy the MathType instance.
+      const destroy = editor.destroy;
+
+      editor.destroy = function () {
+        WirisPlugin.instances[editor.id].listeners.fire('onDestroy', {});
+
+        // Destroy the Mathtype instance.
+        WirisPlugin.instances[editor.id].destroy();
+        destroy.call(editor);
+      };
+
+      if ('onInit' in editor) {
         editor.onInit.add(onInit);
       } else {
         editor.on("init", () => {

--- a/packages/tinymce6/editor_plugin.src.js
+++ b/packages/tinymce6/editor_plugin.src.js
@@ -408,6 +408,17 @@ export const currentInstance = null;
         // PLUGINS-1070: We set this variable out of condition to parse content after.
         WirisPlugin.instances[editor.id].initParsed = true;
       };
+      
+      // Change the destroy behavior to also destroy the MathType instance.
+      const destroy = editor.destroy;
+      
+      editor.destroy = function () {
+        WirisPlugin.instances[editor.id].listeners.fire('onDestroy', {});
+        
+        // Destroy the Mathtype instance.
+        WirisPlugin.instances[editor.id].destroy();
+        destroy.call(editor);
+      };
 
       if ("onInit" in editor) {
         editor.onInit.add(onInit);


### PR DESCRIPTION
## Description

This fix ensures that when the editor is closed all the MathType remainings (Modal, Events, Instances) are removed from the DOM.

The issue is fixed on #KB-44922 
The branch #KB-44922-test adds additional tools to test the fix.

## Steps to reproduce
Follow the next steps to reproduce.
* The next steps should reproduce under the next editors
  * [Ckeditor4](https://integrations.wiris.kitchen/KB-44922-test/html/ckeditor4/)
  * [Ckeditor5](https://integrations.wiris.kitchen/KB-44922-test/html/ckeditor5/)
  * [Froala](https://integrations.wiris.kitchen/KB-44922-test/html/froala/)
  * [TinyMCE4](https://integrations.wiris.kitchen/KB-44922-test/html/tinymce4/)
  * [TinyMCE5](https://integrations.wiris.kitchen/KB-44922-test/html/tinymce5/)
  * [Generic](https://integrations.wiris.kitchen/KB-44922-test/html/generic/)


1. Open the editor
2. Open the MathType modal
3. Destroy an editor without closing the MathType modal and using the destroy method
4. Using the developer tools check if the MathType modal is still on the DOM
5. [Expected] The MathType modal should be removed from the DOM
6. [Optional] Try creating and destroying the editor multiple times to check if the issue is fixed


## Causes

The issue is caused because the MathType modal is not being removed from the DOM when the editor is destroyed.

---

[#taskid 44922](https://wiris.kanbanize.com/ctrl_board/2/cards/44922/details/)
[#Child of taskid 44564](https://wiris.kanbanize.com/ctrl_board/2/cards/44564/details/)
