### PR TITLE
Render the formula that is not been cached in html-viewer

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -180,10 +180,9 @@ jobs:
 
               # Then, for every specific editor copy all the resources that are loaded at runtime
 
-              # For all demos except the viewer, copy dist
-              if [ "${{ matrix.editor }}" != "viewer" ]; then
-                aws s3 cp demos/html/${{ matrix.editor }}/dist s3://wiris-integrations-staging-html/${{ matrix.branch }}/html/${{ matrix.editor }}/dist --recursive
-              fi
+              # For all demos copy dist
+              aws s3 cp demos/html/${{ matrix.editor }}/dist s3://wiris-integrations-staging-html/${{ matrix.branch }}/html/${{ matrix.editor }}/dist --recursive
+              
               if [ "${{ matrix.editor }}" = "ckeditor4" ]; then
                 aws s3 cp demos/html/${{ matrix.editor }}/node_modules/@wiris/mathtype-ckeditor4/icons/chem.png s3://wiris-integrations-staging-html/${{ matrix.branch }}/html/${{ matrix.editor }}/node_modules/@wiris/mathtype-ckeditor4/icons/chem.png
                 aws s3 cp demos/html/${{ matrix.editor }}/node_modules/@wiris/mathtype-ckeditor4/icons/formula.png s3://wiris-integrations-staging-html/${{ matrix.branch }}/html/${{ matrix.editor }}/node_modules/@wiris/mathtype-ckeditor4/icons/formula.png

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Last release of this project was 5th of February 2024.
 ### Unreleased
   - feat: Add new 'Commit hash' field to html-viewer demo. #KB-44411
+  - fix(viewer): Render the formula that is not been cached.
 
 ### 8.8.2 2024-02-05
 

--- a/demos/html/viewer/src/app.js
+++ b/demos/html/viewer/src/app.js
@@ -15,11 +15,10 @@ document.getElementById('viewer_form').addEventListener('submit', (e) => {
     event.preventDefault();
     // Accessing form data using the event object
     const formData = new FormData(event.target);
-
     const config = {
         backendConfig: {
         wiriseditormathmlattribute: wiriseditormathmlattribute.value,
-        wirispluginperformance: wirispluginperformance.value === 'on',
+        wirispluginperformance: (wirispluginperformance.checked) ? 'true' : 'false',
         },
         dpi: dpi.value,
         editorServicesExtension: '',

--- a/demos/html/viewer/src/app.js
+++ b/demos/html/viewer/src/app.js
@@ -3,12 +3,11 @@ import './static/style.css';
 
 document.addEventListener("DOMContentLoaded", function onDomLoad() {
     document.getElementById('content').value = document.getElementsByTagName('main')[0].innerHTML;
-    document.getElementById('git_commit').innerText = git.hash;
-    
-  });
+    document.getElementById('git_commit').innerText = git.hash;    
+});
 
-  // Show the version number of the viewer
-  fetch('node_modules/@wiris/mathtype-viewer/package.json')
+// Show the version number of the viewer
+fetch('node_modules/@wiris/mathtype-viewer/package.json')
     .then(response => response.json())
     .then(({ version }) => document.getElementById('version').innerText = version);
 

--- a/packages/viewer/src/mathml.ts
+++ b/packages/viewer/src/mathml.ts
@@ -68,16 +68,11 @@ export async function renderMathML(properties: Properties, root: HTMLElement): P
 
     let result;
 
+    // Transform mml to img.
     if (properties.wirispluginperformance === 'true') {
-      // Transform mml to img.
       result = await showImage(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
     } else {
-      // createimage returns the URL to showimage of the corresponding image
-      let url = await createImage(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
-      // This line is necessary due to a bug in how the services interoperate.
-      // TODO fix the causing bug
-      url = url.replace('pluginsapp', 'plugins/app');
-      result = await processJsonResponse(fetch(url));
+      result = await createImage(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
     }
 
     // Set img properties.

--- a/packages/viewer/src/services.ts
+++ b/packages/viewer/src/services.ts
@@ -147,8 +147,20 @@ export async function createImage(mml: string, lang: string, url: string, extens
     'lang': lang,
   }
 
-  const response = callService(params, 'createimage', MethodType.Get, url, extension);
-  return (await response).text();
+  // Send createimage request
+  const response = callService(params, 'createimage', MethodType.Post, url, extension);
+
+  // createimage returns the URL to showimage of the corresponding image
+  let showImageUrl = await (await response).text();
+
+  // This line is necessary due to a bug in how the services interoperate.
+  // TODO fix the causing bug
+  showImageUrl = showImageUrl.replace('pluginsapp', 'plugins/app');
+
+  // POST request to get the corresponding image
+  const showImageResponse = callService(params, 'showimage', MethodType.Post, showImageUrl, extension);
+
+  return processJsonResponse(showImageResponse);
 };
 
 /**


### PR DESCRIPTION
## Description

Render the formula that is not been cached in html-viewer.

## Steps to reproduce

- On the html-integration project build the viewer with nx build viewer
- Then start the viewer demo using with nx start html-viewer
- With `wirispluginperformance` checkbox `cheked` - On the content textarea update a non cached formula and press submit button
- With `wirispluginperformance` checkbox `uncheked` - On the content textarea update a non cached formula and press submit button
- Make sure there is not console error and the non-cached  formula must be rendered

---

[#taskid 44942](https://wiris.kanbanize.com/ctrl_board/2/cards/44942/details/) 
