### PR TITLE
Render the formula that is not been cached in html-viewer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Last release of this project was 17th of April 2024.
 
+### Unreleased
+  - fix(viewer): Render the formula that is not been cached. #KB-44942
+
 ### 8.9.0 2024-04-17
 
   - fix(ck5): Add some DOMPurify exception in order to avoid error when inserting some formula. #KB-44372

--- a/demos/html/viewer/src/app.js
+++ b/demos/html/viewer/src/app.js
@@ -1,38 +1,39 @@
-import git from 'resources/git-data.json'
+import git from 'resources/git-data.json';
 import './static/style.css';
 
-document.addEventListener("DOMContentLoaded", function onDomLoad() {
-    document.getElementById('content').value = document.getElementsByTagName('main')[0].innerHTML;
-    document.getElementById('git_commit').innerText = git.hash;    
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('content').value = document.getElementsByTagName('main')[0].innerHTML;
+  document.getElementById('git_commit').innerText = git.hash;
 });
 
 // Show the version number of the viewer
 fetch('node_modules/@wiris/mathtype-viewer/package.json')
-    .then(response => response.json())
-    .then(({ version }) => document.getElementById('version').innerText = version);
+  .then((response) => response.json())
+  .then(({ version }) => {
+    document.getElementById('version').innerText = version;
+  });
 
-document.getElementById('viewer_form').addEventListener('submit', (e) => {
-    event.preventDefault();
-    // Accessing form data using the event object
-    const formData = new FormData(event.target);
+document.getElementById('viewer_form').addEventListener('submit', () => {
+  event.preventDefault(); // eslint-disable-line no-restricted-globals
+  // Accessing form data using the event object
+  const formData = new FormData(event.target); // eslint-disable-line no-restricted-globals
 
-    const config = {
-        backendConfig: {
-        wiriseditormathmlattribute: wiriseditormathmlattribute.value,
-        wirispluginperformance: wirispluginperformance.value === 'on',
-        },
-        dpi: dpi.value,
-        editorServicesExtension: '',
-        editorServicesRoot: editorServicesRoot.value,
-        element: element.value,
-        lang: lang.value,
-        viewer: viewer.value,
-        zoom: zoom.value,
-    }
+  const config = {
+    backendConfig: {
+      wiriseditormathmlattribute: wiriseditormathmlattribute.value,
+      wirispluginperformance: (wirispluginperformance.checked) ? 'true' : 'false',
+    },
+    dpi: dpi.value,
+    editorServicesExtension: '',
+    editorServicesRoot: editorServicesRoot.value,
+    element: element.value,
+    lang: lang.value,
+    viewer: viewer.value,
+    zoom: zoom.value,
+  };
 
-    window.viewer.properties.config = config;
+  window.viewer.properties.config = config;
 
-    document.getElementsByTagName('main')[0].innerHTML = document.getElementById('content').value;
-    com.wiris.js.JsPluginViewer.parseElement(document.getElementsByTagName('main')[0]);
+  document.getElementsByTagName('main')[0].innerHTML = document.getElementById('content').value;
+  window.com.wiris.js.JsPluginViewer.parseElement(document.getElementsByTagName('main')[0]);
 });
-      

--- a/packages/viewer/src/mathml.ts
+++ b/packages/viewer/src/mathml.ts
@@ -69,16 +69,11 @@ export async function renderMathML(properties: Properties, root: HTMLElement): P
 
     let result;
 
+    // Transform mml to img.
     if (properties.wirispluginperformance === 'true') {
-      // Transform mml to img.
       result = await showImage(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
     } else {
-      // createimage returns the URL to showimage of the corresponding image
-      let url = await createImage(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
-      // This line is necessary due to a bug in how the services interoperate.
-      // TODO fix the causing bug
-      url = url.replace('pluginsapp', 'plugins/app');
-      result = await processJsonResponse(fetch(url));
+      result = await createImage(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
     }
 
     // Set img properties.

--- a/packages/viewer/src/services.ts
+++ b/packages/viewer/src/services.ts
@@ -153,9 +153,10 @@ export async function createImage(mml: string, lang: string, url: string, extens
     'lang': lang,
   }
 
-  const response = callService(params, 'createimage', MethodType.Get, url, extension);
-  return (await response).text();
-};
+  // POST request to get the corresponding image
+  const response = callService(params, 'showimage', MethodType.Post, url, extension);
+  return processJsonResponse(response);
+  };
 
 /**
  * Calls the latex2mathml service with the given LaTeX and returns the received Response object.


### PR DESCRIPTION
## Description

Render the formula that is not been cached in html-viewer.

## Steps to reproduce

- On the html-integration project build the viewer with nx build viewer
- Then start the viewer demo using with nx start html-viewer
- With `wirispluginperformance` checkbox `cheked` - On the content textarea update a non cached formula and press submit button
- With `wirispluginperformance` checkbox `uncheked` - On the content textarea update a non cached formula and press submit button
- Make sure there is not console error and the non-cached  formula must be rendered

---

[#taskid 44942](https://wiris.kanbanize.com/ctrl_board/2/cards/44942/details/) 
