### PR TITLE
fix(froala): Editor bug with Wirisformulas paste behavior

### DIFF
--- a/demos/html/froala/package.json
+++ b/demos/html/froala/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wiris/mathtype-froala": "*",
     "@wiris/mathtype-html-integration-devkit": "*",
-    "froala-editor": "~4.1.4"
+    "froala-editor": "^4.2.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^12.0.2",


### PR DESCRIPTION
Avoided froala cleanup functions on paste to conserve image attributes, improved legacy code.

(Chore): Change naming and more comments

## Description

The Froala Editor has a built-in cleanup process that removes unwanted HTML tags and attributes from the content. However, this cleanup process can cause issues when dealing with Wirisformulas. To prevent these issues, the code attaches a function to the 'paste.beforeCleanup' event of the Froala Editor. This event is triggered before the cleanup process starts. The regex looks for img tags that have a class attribute containing the word 'Wirisformula'. If a match is found, meaning a Wiris formula is detected, tells the Froala Editor to skip the cleanup process, thus preserving the Wiris formulas in their original state.

## Steps to reproduce

To reproduce
- Copy and paste a mathtype formula or something containing a mathtype formula
- Paste the content into the editor
[Test on Froala 4.2.0](https://integrations.wiris.kitchen/KB-46612/html/froala/)
[Test on Froala 4.1.4](https://integrations.wiris.kitchen/KB-46612-FR44/html/froala/)

Issues
- Initially, a pop-up loading window containing the text "Uploading" will appear (Click away to close it)
- Then a console error will trigger (Atob)
- If Froala => 4.2 the paste behavior will paste 2 times the original content and induce a buggy state that makes everything copy 2 times 

---
This closes branch #KB-46612-FR44

[#taskid 46612](https://wiris.kanbanize.com/ctrl_board/2/cards/46612/details/)

