### PR TITLE
Improve viewer behaviour on errors

### DIFF
--- a/demos/html/viewer/src/app.js
+++ b/demos/html/viewer/src/app.js
@@ -35,8 +35,7 @@ document.getElementById("viewer_form").addEventListener("submit", () => {
 
   window.viewer.properties.config = config;
 
-  document.getElementsByTagName("main")[0].innerHTML =
-    document.getElementById("content").value;
+  document.getElementsByTagName("main")[0].innerHTML = document.getElementById("content").value;
   window.com.wiris.js.JsPluginViewer.parseElement(
     document.getElementsByTagName("main")[0],
   );

--- a/packages/viewer/src/mathml.ts
+++ b/packages/viewer/src/mathml.ts
@@ -76,22 +76,21 @@ export async function renderMathML(
   for (const mathElement of [...root.getElementsByTagName("math")]) {
     const mml = htmlEntitiesToXmlEntities(mathElement.outerHTML);
     try {
-      let result;
+      let imgSource;
 
       // Transform mml to img.
       if (properties.wirispluginperformance === 'true') {
-        result = await showImage(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
+        imgSource = await showImage(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
       } else {
-        result = await createImage(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
+        imgSource = await createImage(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
       }
 
       // Set img properties.
-      const img = await setImageProperties(properties, result, mml);
-
+      const img = await setImageProperties(properties, imgSource, mml);
       // Replace the MathML for the generated formula image.
       mathElement.parentNode?.replaceChild(img, mathElement);
     } catch {
-      console.log(`Cannot render ${mml}: invalid MathML format.`);
+      console.error(`Cannot render ${mml}: invalid MathML format.`);
       continue;
     }
   }

--- a/packages/viewer/src/mathml.ts
+++ b/packages/viewer/src/mathml.ts
@@ -3,7 +3,6 @@ import {
   showImage,
   createImage,
   mathml2accessible,
-  processJsonResponse,
 } from "./services";
 import { htmlEntitiesToXmlEntities, corruptMathML } from "./utils";
 import MathML from "@wiris/mathtype-html-integration-devkit/src/mathml";
@@ -98,7 +97,6 @@ export async function renderMathML(
 
     // Set img properties.
     const img = await setImageProperties(properties, result, mml);
-    // const fragment = document.createRange().createContextualFragment(data.result.content);
 
     // Replace the MathML for the generated formula image.
     mathElement.parentNode?.replaceChild(img, mathElement);

--- a/packages/viewer/src/mathml.ts
+++ b/packages/viewer/src/mathml.ts
@@ -75,31 +75,25 @@ export async function renderMathML(
 
   for (const mathElement of [...root.getElementsByTagName("math")]) {
     const mml = htmlEntitiesToXmlEntities(mathElement.outerHTML);
+    try {
+      let result;
 
-    let result;
+      // Transform mml to img.
+      if (properties.wirispluginperformance === 'true') {
+        result = await showImage(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
+      } else {
+        result = await createImage(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
+      }
 
-    // Transform mml to img.
-    if (properties.wirispluginperformance === "true") {
-      result = await showImage(
-        mml,
-        properties.lang,
-        properties.editorServicesRoot,
-        properties.editorServicesExtension,
-      );
-    } else {
-      result = await createImage(
-        mml,
-        properties.lang,
-        properties.editorServicesRoot,
-        properties.editorServicesExtension,
-      );
+      // Set img properties.
+      const img = await setImageProperties(properties, result, mml);
+
+      // Replace the MathML for the generated formula image.
+      mathElement.parentNode?.replaceChild(img, mathElement);
+    } catch {
+      console.log(`Cannot render ${mml}: invalid MathML format.`);
+      continue;
     }
-
-    // Set img properties.
-    const img = await setImageProperties(properties, result, mml);
-
-    // Replace the MathML for the generated formula image.
-    mathElement.parentNode?.replaceChild(img, mathElement);
   }
 }
 
@@ -107,7 +101,7 @@ export async function renderMathML(
  * Returns an image formula containing all MathType properties.
  * @param {Properties} properties - Properties of the viewer.
  * @param {FormulaData} data - Object containing image values.
- * @param {string} mml - The MathML of the formula image beeing created.
+ * @param {string} mml - The MathML of the formula image being created.
  * @returns {Promise<HTMLImageElement>} - Formula image.
  */
 async function setImageProperties(

--- a/packages/viewer/src/services.ts
+++ b/packages/viewer/src/services.ts
@@ -193,14 +193,8 @@ export async function createImage(
     lang: lang,
   };
 
-  // POST request to get the corresponding image
-  const response = callService(
-    params,
-    "showimage",
-    MethodType.Post,
-    url,
-    extension,
-  );
+  // POST request to retrieve the corresponding image.
+  const response = callService(params, 'showimage', MethodType.Post, url, extension);
   return processJsonResponse(response);
 }
 


### PR DESCRIPTION
## Description

To alllow Viewers to accept multiple MathML inputs and not halt execution of remaining formulas if one MathML format encounters an error.

## Steps to reproduce

1. Visit https://htmledit.squarefree.com/
2. Paste the following HTML, which contains a malformed mathml in the third equation:
```
<script src="https://integrations.wiris.kitchen/KB-43208/html/viewer/node_modules/@wiris/mathtype-viewer/dist/WIRISplugins.js?viewer=image"></script>
<h3>Hi! We're testing the Wiris viewer!</h3>

<p>LaTeX formula:
$$4 - 2 = 2$$
</p>
<p>MathML formula: <math xmlns="http://www.w3.org/1998/Math/MathML"><msqrt><mi>x</mi></msqrt></math></p>

<p>MathML formula:
<math>
<mn>2</mn>
<mo>+</mo>
mn>2</mn>
<mo=<s/mo>
<mn>4/mn
</math>
</p>
<p>LaTeX formula:
$$4 - 2 = 2$$
</p>
<p>MathML formula: <math xmlns="http://www.w3.org/1998/Math/MathML"><msqrt><mi>x</mi></msqrt></math></p>
```
3. All formula (except the 3rd (problematic)) will be renderer

---
[#taskid 43208](https://wiris.kanbanize.com/ctrl_board/2/cards/43208/details/)
