### PR TITLE
 KB-45700: Update Telemeter Tracking to Utilize Promises

### DIFF
--- a/packages/ckeditor5/src/integration.js
+++ b/packages/ckeditor5/src/integration.js
@@ -376,7 +376,7 @@ export default class CKEditor5Integration extends IntegrationModel {
         ...payload,
       });
     } catch (error) {
-      console.error("Error tracking OPENED_MTCT_EDITOR", error);
+      console.error("Error tracking INSERTED_FORMULA", error);
     }
 
     /* Due to PLUGINS-1329, we add the onChange event to the CK4 insertFormula.

--- a/packages/ckeditor5/src/integration.js
+++ b/packages/ckeditor5/src/integration.js
@@ -370,12 +370,13 @@ export default class CKEditor5Integration extends IntegrationModel {
         !payload[key] ? delete payload[key] : {};
     });
 
+    // Call Telemetry service to track the event.
     try {
       Telemeter.telemeter.track("INSERTED_FORMULA", {
         ...payload,
       });
-    } catch (err) {
-      console.error(err);
+    } catch (error) {
+      console.error("Error tracking OPENED_MTCT_EDITOR", error);
     }
 
     /* Due to PLUGINS-1329, we add the onChange event to the CK4 insertFormula.

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -512,13 +512,15 @@ export default class ContentManager {
     }
 
     let trigger = this.dbclick ? "formula" : "button";
+
+    // Call Telemetry service to track the event.
     try {
       Telemeter.telemeter.track("OPENED_MTCT_EDITOR", {
         toolbar: toolbar,
         trigger: trigger,
       });
-    } catch (err) {
-      console.error(err);
+    } catch (error) {
+      console.error("Error tracking OPENED_MTCT_EDITOR", error);
     }
 
     Core.globalListeners.fire("onModalOpen", {});

--- a/packages/devkit/src/core.src.js
+++ b/packages/devkit/src/core.src.js
@@ -606,16 +606,17 @@ export default class Core {
       if (key === "mathml_origin" || key === "editor_origin")
         !payload[key] ? delete payload[key] : {};
     });
-
-    try {
+    
+   // Call Telemetry service to track the event.
+   try {
       Telemeter.telemeter.track("INSERTED_FORMULA", {
-        ...payload,
-      });
-    } catch (err) {
-      console.error(err);
-    }
+       ...payload,
+     });
+   } catch (error) {
+     console.error("Error tracking INSERTED_FORMULA", error);
+   }
   }
-
+  
   /**
    * Opens a modal dialog containing MathType editor..
    * @param {HTMLElement} target - The target HTMLElement where formulas should be inserted.

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -219,7 +219,7 @@ export default class IntegrationModel {
     // TODO: Move to Core constructor.
     this.core.setEnvironment(this.environment);
 
-    // No internet conection modal.
+    // No internet connection modal.
     let attributes = {};
     attributes.class = attributes.id = "wrs_modal_offline";
     this.offlineModal = Util.createElement("div", attributes);

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -710,7 +710,7 @@ export default class IntegrationModel {
       eventTarget,
       (element, event) => {
         this.doubleClickHandler(element, event);
-        // Avoid creating the doublick listener more than once for each element.
+        // Avoid creating the double click listener more than once for each element.
         event.stopImmediatePropagation();
       },
       (element, event) => {

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -309,20 +309,20 @@ export default class ModalDialog {
    * object. No logic about the content should be placed here,
    * contentElement.submitAction is the responsible of the content logic.
    */
-  submitAction() {
+  async submitAction() {
     if (typeof this.contentManager.submitAction !== "undefined") {
       this.contentManager.submitAction();
     }
 
+    // Call Telemetry service to track the event.
     try {
-      Telemeter.telemeter.track("CLOSED_MTCT_EDITOR", {
+      await Telemeter.telemeter.track("CLOSED_MTCT_EDITOR", {
         toolbar: this.contentManager.toolbar,
-        trigger: "mtct_insert",
+        trigger: "mtct_close",
       });
-    } catch (err) {
-      console.error(err);
+    } catch (error) {
+      console.error("Error tracking CLOSED_MTCT_EDITOR", error);
     }
-
     this.close();
   }
 
@@ -331,47 +331,31 @@ export default class ModalDialog {
    * contentElement has implemented hasChanges method, a confirm popup
    * will be shown if hasChanges returns true.
    */
-  cancelAction() {
-    // opening a existing formula editor when trying to open a new one
-    if (typeof this.contentManager.hasChanges === "undefined") {
-      // Set temporal image to null to prevent loading
-      // an existent formula when strarting one from scrath. Make focus come back too.
+  async cancelAction() {
+    // opening an existing formula editor when trying to open a new one
+    if (typeof this.contentManager.hasChanges === "undefined" || !this.contentManager.hasChanges()) {
       IntegrationModel.setActionsOnCancelButtons();
-
+      // Call Telemetry service to track the event.
       try {
-        Telemeter.telemeter.track("CLOSED_MTCT_EDITOR", {
+        await Telemeter.telemeter.track("CLOSED_MTCT_EDITOR", {
           toolbar: this.contentManager.toolbar,
           trigger: "mtct_close",
         });
-      } catch (err) {
-        console.error(err);
+      } catch (error) {
+        console.error("Error tracking CLOSED_MTCT_EDITOR", error);
       }
-
-      this.close();
-    } else if (!this.contentManager.hasChanges()) {
-      IntegrationModel.setActionsOnCancelButtons();
-
-      try {
-        Telemeter.telemeter.track("CLOSED_MTCT_EDITOR", {
-          toolbar: this.contentManager.toolbar,
-          trigger: "mtct_close",
-        });
-      } catch (err) {
-        console.error(err);
-      }
-
       this.close();
     } else {
-      this.showPopUpMessage();
-
+      // Call Telemetry service to track the event.
       try {
         Telemeter.telemeter.track("CLOSED_MTCT_EDITOR", {
           toolbar: this.contentManager.toolbar,
           trigger: "mtct_close",
         });
-      } catch (err) {
-        console.error(err);
+      } catch (error) {
+        console.error("Error tracking CLOSED_MTCT_EDITOR", error);
       }
+      this.showPopUpMessage();
     }
   }
 

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -254,12 +254,8 @@ export default class ModalDialog {
     };
 
     const callbacks = {
-      closeCallback: () => {
-        this.close();
-      },
-      cancelCallback: () => {
-        this.focus();
-      },
+      closeCallback: () => { this.close("mtc_close"); },
+      cancelCallback: () => { this.focus(); },
     };
 
     const popupupProperties = {

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -79,9 +79,6 @@ export default class ModalDialog {
       isDesktop: !isMobile && !isIOS && !isAndroid,
     };
 
-    // Trigger to tell the telemetry tracking the action to be tracked.
-    this.closeTrigger = null;
-
     this.properties = {
       created: false,
       state: "",
@@ -306,6 +303,7 @@ export default class ModalDialog {
     return this.contentManager;
   }
 
+
   /**
    * This method is called when the modal object has been submitted. Calls
    * contentElement submitAction method - if exists - and closes the modal
@@ -316,8 +314,8 @@ export default class ModalDialog {
     if (typeof this.contentManager.submitAction !== "undefined") {
       this.contentManager.submitAction();
     }
-    this.closeTrigger = 'mtc_insert';
-    await this.close();
+
+    await this.close('mtc_insert');
   }
 
   /**
@@ -329,8 +327,7 @@ export default class ModalDialog {
   async cancelAction() {
     if (typeof this.contentManager.hasChanges === "undefined" || !this.contentManager.hasChanges()) {
       IntegrationModel.setActionsOnCancelButtons();
-      this.closeTrigger = "mtc_close";
-      await this.close();
+      await this.close("mtc_close");
     } else {
       this.showPopUpMessage();
     }
@@ -596,7 +593,7 @@ export default class ModalDialog {
    * If a close trigger is defined, it tracks the telemetry event 'CLOSED_MTCT_EDITOR' with the trigger.
    * @returns {Promise<void>} A promise that resolves when the modal is closed.
    */
-  async close() {
+  async close(trigger) {
     this.removeClass("wrs_maximized");
     this.removeClass("wrs_minimized");
     this.removeClass("wrs_stack");
@@ -606,16 +603,15 @@ export default class ModalDialog {
     this.properties.open = false;
 
 
-    if (this.closeTrigger) {
+    if (trigger) {
       try {
         await Telemeter.telemeter.track("CLOSED_MTCT_EDITOR", {
           toolbar: this.contentManager.toolbar,
-          trigger: this.closeTrigger,
+          trigger: trigger,
         });
       } catch (error) {
         console.error("Error tracking CLOSED_MTCT_EDITOR", error);
       }
-      this.closeTrigger = null
     }
 
     Core.globalListeners.fire("onModalClose", {});
@@ -1503,22 +1499,25 @@ export default class ModalDialog {
    * Recalculating scale for modal when the browser is resized.
    */
   recalculateScale() {
-    let sizeModificated = false;
+    let sizeModified = false;
+
     if (parseInt(this.container.style.width, 10) > 580) {
       this.container.style.width = `${Math.min(parseInt(this.container.style.width, 10), window.innerWidth - this.scrollbarWidth)}px`;
-      sizeModificated = true;
+      sizeModified = true;
     } else {
       this.container.style.width = "580px";
       sizeModificated = true;
     }
+
     if (parseInt(this.container.style.height, 10) > 338) {
       this.container.style.height = `${Math.min(parseInt(this.container.style.height, 10), window.innerHeight)}px`;
-      sizeModificated = true;
+      sizeModified = true;
     } else {
       this.container.style.height = "338px";
       sizeModificated = true;
     }
-    if (sizeModificated) {
+
+    if (sizeModified) {
       this.recalculateSize();
     }
   }

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -330,9 +330,13 @@ export default class ModalDialog {
    * This method is called when the modal object has been cancelled. If
    * contentElement has implemented hasChanges method, a confirm popup
    * will be shown if hasChanges returns true.
+   *
+   ** The function was changed to async to ensure that telemetry tracking is completed before closing the modal.
    */
   async cancelAction() {
-    // opening an existing formula editor when trying to open a new one
+    // Opening a existing formula editor when trying to open a new one.
+    // Set temporal image to null to prevent loading an existent formula when starting one from scratch.
+    // Make focus come back too.
     if (typeof this.contentManager.hasChanges === "undefined" || !this.contentManager.hasChanges()) {
       IntegrationModel.setActionsOnCancelButtons();
       // Call Telemetry service to track the event.
@@ -348,7 +352,7 @@ export default class ModalDialog {
     } else {
       // Call Telemetry service to track the event.
       try {
-        Telemeter.telemeter.track("CLOSED_MTCT_EDITOR", {
+        await Telemeter.telemeter.track("CLOSED_MTCT_EDITOR", {
           toolbar: this.contentManager.toolbar,
           trigger: "mtct_close",
         });

--- a/packages/devkit/src/popupmessage.js
+++ b/packages/devkit/src/popupmessage.js
@@ -156,7 +156,7 @@ export default class PopUpMessage {
     if (typeof this.callbacks.cancelCallback !== "undefined") {
       this.callbacks.cancelCallback();
       // Set temporal image to null to prevent loading
-      // an existent formula when strarting one from scrath. Make focus come back too.
+      // an existent formula when starting one from scratch. Make focus come back too.
       // IntegrationModel.setActionsOnCancelButtons();
     }
   }

--- a/packages/generic/wirisplugin-generic.src.js
+++ b/packages/generic/wirisplugin-generic.src.js
@@ -132,6 +132,7 @@ export default class GenericIntegration extends IntegrationModel {
      *
      * @param {string} toolbar The MT/CT button clicked from the toolbar: 'general' for the MathType and 'chemistry' for the ChemType
      * @param {string} trigger 'mtct_insert' when the modal is closed due to inserting or modifying a formula. 'mtct_close' otherwise
+     ** The function was changed to async to ensure that telemetry tracking is completed before closing the modal.
      */
     async wrsClosedEditorModal(toolbar, trigger) {
       // Check that the manual string inputs contain the values we want, if not throw error.
@@ -193,7 +194,7 @@ export default class GenericIntegration extends IntegrationModel {
             ...payload,
           });
         } catch (error) {
-          console.error("Error tracking OPENED_MTCT_EDITOR", error);
+          console.error("Error tracking INSERTED_FORMULA", error);
         }
 
       } else {

--- a/packages/generic/wirisplugin-generic.src.js
+++ b/packages/generic/wirisplugin-generic.src.js
@@ -112,15 +112,17 @@ export default class GenericIntegration extends IntegrationModel {
         /^(button|formula)$/.test(trigger) &&
         /^(general|chemistry)$/.test(toolbar)
       ) {
+
+        // Call Telemetry service to track the event.
         try {
           Telemeter.telemeter.track("OPENED_MTCT_EDITOR", {
             toolbar: toolbar,
             trigger: trigger,
           });
-        } catch (err) {
-          trigger;
-          console.error(err);
+        } catch (error) {
+          console.error("Error tracking OPENED_MTCT_EDITOR", error);
         }
+
       } else {
         console.error("Invalid trigger or toolbar value for open editor modal");
       }
@@ -131,21 +133,23 @@ export default class GenericIntegration extends IntegrationModel {
      * @param {string} toolbar The MT/CT button clicked from the toolbar: 'general' for the MathType and 'chemistry' for the ChemType
      * @param {string} trigger 'mtct_insert' when the modal is closed due to inserting or modifying a formula. 'mtct_close' otherwise
      */
-    wrsClosedEditorModal(toolbar, trigger) {
+    async wrsClosedEditorModal(toolbar, trigger) {
       // Check that the manual string inputs contain the values we want, if not throw error.
       if (
         /^(mtct_insert|mtct_close)$/.test(trigger) &&
         /^(general|chemistry)$/.test(toolbar)
       ) {
-        // Call Telemetry service
+        // Call Telemetry service to track the event.
         try {
-          Telemeter.telemeter.track("CLOSED_MTCT_EDITOR", {
-            toolbar: toolbar,
-            trigger: trigger,
+          await Telemeter.telemeter.track("CLOSED_MTCT_EDITOR", {
+            toolbar: this.contentManager.toolbar,
+            trigger: "mtct_close",
           });
-        } catch (err) {
-          console.error(err);
+        } catch (error) {
+          console.error("Error tracking CLOSED_MTCT_EDITOR", error);
         }
+        this.close();
+
       } else {
         console.error(
           "Invalid trigger or toolbar value for close editor modal",
@@ -183,13 +187,15 @@ export default class GenericIntegration extends IntegrationModel {
             !payload[key] ? delete payload[key] : {};
         });
 
+        // Call Telemetry service to track the event.
         try {
           Telemeter.telemeter.track("INSERTED_FORMULA", {
             ...payload,
           });
-        } catch (err) {
-          console.error(err);
+        } catch (error) {
+          console.error("Error tracking OPENED_MTCT_EDITOR", error);
         }
+
       } else {
         console.error("Invalid toolbar or time input for insert formula");
       }

--- a/packages/generic/wirisplugin-generic.src.js
+++ b/packages/generic/wirisplugin-generic.src.js
@@ -106,7 +106,7 @@ export default class GenericIntegration extends IntegrationModel {
      * @param {string} trigger 'button' when the modal is opened by clicking the MathType or ChemType button from the toolbar
      *                         'formula' when the modal is opened by double-click on the formula
      */
-    wrsOpenedEditorModal(toolbar, trigger) {
+    async wrsOpenedEditorModal(toolbar, trigger) {
       // Check that the manual string inputs contain the values we want, if not throw error.
       if (
         /^(button|formula)$/.test(trigger) &&
@@ -115,7 +115,7 @@ export default class GenericIntegration extends IntegrationModel {
 
         // Call Telemetry service to track the event.
         try {
-          Telemeter.telemeter.track("OPENED_MTCT_EDITOR", {
+          await Telemeter.telemeter.track("OPENED_MTCT_EDITOR", {
             toolbar: toolbar,
             trigger: trigger,
           });
@@ -143,14 +143,12 @@ export default class GenericIntegration extends IntegrationModel {
 
       try {
         await Telemeter.telemeter.track("CLOSED_MTCT_EDITOR", {
-          toolbar: this.contentManager.toolbar,
-          trigger: "mtct_close",
+          toolbar: toolbar,
+          trigger: trigger,
         });
       } catch (error) {
         console.error("Error tracking CLOSED_MTCT_EDITOR", error);
       }
-
-      this.close();
     },
 
     /**
@@ -160,7 +158,7 @@ export default class GenericIntegration extends IntegrationModel {
      * @param {number} time The time passed since the MT/CT modal opened until the calling of this function
      * @param {string} toolbar The MT/CT button clicked from the toolbar: 'general' for the MathType and 'chemistry' for the ChemType
      */
-    wrsInsertedFormula(mathml_origin, mathml, time, toolbar) {
+    async wrsInsertedFormula(mathml_origin, mathml, time, toolbar) {
       const validToolbar = /^(general|chemistry)$/.test(toolbar);
       const validDate = !isNaN(new Date(time));
       // Check that the manual string inputs contain the values we want, if not throw error.
@@ -185,7 +183,7 @@ export default class GenericIntegration extends IntegrationModel {
 
         // Call Telemetry service to track the event.
         try {
-          Telemeter.telemeter.track("INSERTED_FORMULA", {
+          await Telemeter.telemeter.track("INSERTED_FORMULA", {
             ...payload,
           });
         } catch (error) {

--- a/packages/generic/wirisplugin-generic.src.js
+++ b/packages/generic/wirisplugin-generic.src.js
@@ -136,26 +136,21 @@ export default class GenericIntegration extends IntegrationModel {
      */
     async wrsClosedEditorModal(toolbar, trigger) {
       // Check that the manual string inputs contain the values we want, if not throw error.
-      if (
-        /^(mtct_insert|mtct_close)$/.test(trigger) &&
-        /^(general|chemistry)$/.test(toolbar)
-      ) {
-        // Call Telemetry service to track the event.
-        try {
-          await Telemeter.telemeter.track("CLOSED_MTCT_EDITOR", {
-            toolbar: this.contentManager.toolbar,
-            trigger: "mtct_close",
-          });
-        } catch (error) {
-          console.error("Error tracking CLOSED_MTCT_EDITOR", error);
-        }
-        this.close();
-
-      } else {
-        console.error(
-          "Invalid trigger or toolbar value for close editor modal",
-        );
+      if (!/^(mtct_insert|mtct_close)$/.test(trigger) || !/^(general|chemistry)$/.test(toolbar)) {
+        console.error("Invalid trigger or toolbar value for close editor modal");
+        return;
       }
+
+      try {
+        await Telemeter.telemeter.track("CLOSED_MTCT_EDITOR", {
+          toolbar: this.contentManager.toolbar,
+          trigger: "mtct_close",
+        });
+      } catch (error) {
+        console.error("Error tracking CLOSED_MTCT_EDITOR", error);
+      }
+
+      this.close();
     },
 
     /**


### PR DESCRIPTION
## Changes
` feat: update telemeter tracking to utilize promises. #KB-45700
`
## Description
This PR introduces a significant enhancement to our telemeter tracking functionality by transitioning all tracking actions to utilize promises. The motivation behind this change stems from a recent integration issue encountered with OnlyOffice.

## Steps to Reproduce:
1. Pull the `wiris/telemeter` repo.
2. Initiate the telemeter server by executing `cargo run` and ensure it's operational.
3. Navigate to `packages/devkit/src/Integrationmodel` on this branch.
4. Amend the code from `debug: false` to `debug: true`.
5. Execute `yarn && nx build generic && nx start html-generic` to build the generic editor.
6. Verify the connection of the generic editor to the telemeter server.
7. Interact with the generic editor by inserting formulas, closing, and reopening it.
8. Observe the telemetry actions being accurately tracked on the telemeter server.

## Commands to test generic telemetry

`WirisPlugin.GenericIntegration.telemeter.wrsOpenedEditorModal('button','chemistry')`

`WirisPlugin.GenericIntegration.telemeter.wrsClosedEditorModal('mtct_close','chemistry')`

`WirisPlugin.GenericIntegration.telemeter.wrsInsertedFormula('«math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«msqrt»«mi»x«/mi»«/msqrt»«/math»','«math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«msqrt»«mi»x«/mi»«/msqrt»«/math»',Date.now(),'chemistry')`


[Link to Task: #45700](https://wiris.kanbanize.com/ctrl_board/2/cards/45700/details/)
