### PR TITLE
Fix/use strict

### DIFF
--- a/packages/viewer/src/app.ts
+++ b/packages/viewer/src/app.ts
@@ -49,7 +49,7 @@ async function main(w: Window): Promise<void> {
    * @param {MutationObserver} observer - Mutation observer to activate or reactivate every time the rendering root changes.
    */
   properties.render = async () => {
-    const element: HTMLElement = document.querySelector(properties.element);
+    const element: HTMLElement | null = document.querySelector(properties.element);
     if (element) {
       await renderLatex(properties, element);
       await renderMathML(properties, element);

--- a/packages/viewer/src/latex.ts
+++ b/packages/viewer/src/latex.ts
@@ -34,13 +34,18 @@ async function replaceLatexInTextNode(properties: Properties, node: Node) {
   let pos: number = 0;
 
   while (pos < textContent.length) {
-    const nextLatexPosition: LatexPosition = getNextLatexPos(pos, textContent);
+    const nextLatexPosition = getNextLatexPos(pos, textContent);
     if (nextLatexPosition) {
       // Get left non LaTeX text.
       const leftText: string = textContent.substring(pos, nextLatexPosition.start);
       const leftTextNode = document.createTextNode(leftText);
       // Create a node with left text.
       node.parentNode?.insertBefore(leftTextNode, node);
+
+      // Not sure if this should return or continue
+      if(node.nodeValue === null) {
+        return;
+      }
       node.nodeValue = node.nodeValue.substring(pos, nextLatexPosition.start);
 
       // Get LaTeX text.
@@ -96,7 +101,7 @@ function findLatexTextNodes(root: any): Node[] {
  * @param {string} text - Text where the next latex it will be searched.
  * @
  */
-function getNextLatexPos(pos: number, text: string): LatexPosition {
+function getNextLatexPos(pos: number, text: string): LatexPosition | null{
   const firstLatexTags = text.indexOf('$$', pos);
   const secondLatexTags = firstLatexTags == -1 ? -1 : text.indexOf('$$', firstLatexTags + '$$'.length);
   return firstLatexTags != -1 && secondLatexTags != -1 ? {'start': firstLatexTags, 'end': secondLatexTags} : null;

--- a/packages/viewer/src/latex.ts
+++ b/packages/viewer/src/latex.ts
@@ -30,10 +30,10 @@ export async function renderLatex(properties: Properties, root: HTMLElement) {
  * @param {Node} node - Text node in which to search and replace LaTeX instances.
  */
 async function replaceLatexInTextNode(properties: Properties, node: Node) {
-  const textContent: string = node.textContent || '';
+  const textContent: string = node.textContent ?? '';
   let pos: number = 0;
 
-  while (pos < textContent.length) {
+  while (pos < textContent.length && node.nodeValue) {
     const nextLatexPosition = getNextLatexPos(pos, textContent);
     if (nextLatexPosition) {
       // Get left non LaTeX text.
@@ -41,12 +41,7 @@ async function replaceLatexInTextNode(properties: Properties, node: Node) {
       const leftTextNode = document.createTextNode(leftText);
       // Create a node with left text.
       node.parentNode?.insertBefore(leftTextNode, node);
-
-      // Not sure if this should return or continue
-      if(node.nodeValue === null) {
-        return;
-      }
-      node.nodeValue = node.nodeValue.substring(pos, nextLatexPosition.start);
+      node.nodeValue = node.nodeValue.substring(pos, nextLatexPosition.start); 
 
       // Get LaTeX text.
       const latex = textContent.substring(nextLatexPosition.start + '$$'.length, nextLatexPosition.end);
@@ -97,6 +92,7 @@ function findLatexTextNodes(root: any): Node[] {
 
 /**
  * Returns an object {start, end} with the start and end latex position.
+ * It is guaranteed that start !== end or result is null
  * @param {number} pos - Current position inside the text.
  * @param {string} text - Text where the next latex it will be searched.
  * @

--- a/packages/viewer/src/mathml.ts
+++ b/packages/viewer/src/mathml.ts
@@ -83,7 +83,6 @@ export async function renderMathML(properties: Properties, root: HTMLElement): P
 
     // Set img properties.
     const img = await setImageProperties(properties, result, mml);
-    // const fragment = document.createRange().createContextualFragment(data.result.content);
 
     // Replace the MathML for the generated formula image.
     mathElement.parentNode?.replaceChild(img, mathElement);
@@ -124,7 +123,7 @@ async function setImageProperties(properties: Properties, data: FormulaData, mml
         const { text } = await mathml2accessible(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
         data.alt = text;
       }
-      img.alt = data.alt || '';
+      img.alt = data.alt ?? '';
     } catch {
       img.alt = 'Alternative text not available';
     }

--- a/packages/viewer/src/mathml.ts
+++ b/packages/viewer/src/mathml.ts
@@ -124,7 +124,7 @@ async function setImageProperties(properties: Properties, data: FormulaData, mml
         const { text } = await mathml2accessible(mml, properties.lang, properties.editorServicesRoot, properties.editorServicesExtension);
         data.alt = text;
       }
-      img.alt = data.alt;
+      img.alt = data.alt || '';
     } catch {
       img.alt = 'Alternative text not available';
     }

--- a/packages/viewer/src/properties.ts
+++ b/packages/viewer/src/properties.ts
@@ -26,7 +26,7 @@ export type Config = {
 /**
  * Fallback values for the configurations that are not set.
  */
-const defaultValues: Config = {
+const defaultValues: Required<Config> = {
   editorServicesRoot: 'https://www.wiris.net/demo/plugins/app/',
   editorServicesExtension: '',
   backendConfig: {
@@ -58,6 +58,7 @@ export class Properties {
    * Constructors cannot be async so we make it private and force instantiation through an alternative static method.
    */
   private new() {}
+  
 
   static getInstance(): Properties {
     if (!Properties.instance) {
@@ -71,33 +72,46 @@ export class Properties {
    * Creates and sets up a new instance of class Properties
    */
   private async initialize(): Promise<void> {
+
+    if(!Properties.instance){
+      console.error('Properties instance is not set');
+      return
+    }
+
     // Get URL parameters from <script>
     const pluginName = 'WIRISplugins.js';
-    const script: HTMLScriptElement = document.querySelector(`script[src*="${pluginName}"]`);
+    const script: HTMLScriptElement | null = document.querySelector(`script[src*="${pluginName}"]`);
 
     if (!!script) {
       const pluginNamePosition: number = script.src.lastIndexOf(pluginName);
       const params: string = script.src.substring(pluginNamePosition + pluginName.length);
       const urlParams = new URLSearchParams(params);
 
-      if (urlParams.get('dpi') !== null && urlParams.get('dpi') !== undefined) {
-        Properties.instance.config.dpi = +urlParams.get('dpi');
+      const dpi = urlParams.get('dpi');
+      if (dpi !== null && dpi !== undefined) {
+        Properties.instance.config.dpi = +dpi;
       }
-      if (urlParams.get('element') !== null && urlParams.get('element') !== undefined) {
-        Properties.instance.config.element = urlParams.get('element');
+      const element = urlParams.get('element');
+      if (element !== null && element !== undefined) {
+        Properties.instance.config.element = element;
       }
-      if (urlParams.get('lang') !== null && urlParams.get('lang') !== undefined) {
-        Properties.instance.config.lang = urlParams.get('lang');
+      const lang = urlParams.get('lang');
+      if (lang !== null && lang !== undefined) {
+        Properties.instance.config.lang = lang;
       }
-      if (urlParams.get('viewer') !== null && urlParams.get('viewer') !== undefined) {
-        Properties.instance.config.viewer = (urlParams.get('viewer') as Viewer);
+
+      const viewer = urlParams.get('viewer');
+      if (viewer !== null && viewer !== undefined) {
+        Properties.instance.config.viewer = (viewer as Viewer);
       }
-      if (urlParams.get('zoom') !== null && urlParams.get('zoom') !== undefined) {
-        Properties.instance.config.zoom = +urlParams.get('zoom');
+
+      const zoom = urlParams.get('zoom');
+      if (zoom !== null && zoom) {
+        Properties.instance.config.zoom = +zoom;
       }
     }
 
-    Properties.instance.checkServices();
+    Properties.instance?.checkServices();
 
     // Get backend parameters calling the configurationjson service
     try {
@@ -108,7 +122,7 @@ export class Properties {
       );
 
       // We'll always get a string from the wiriscustomheaders backend parameter. It needs to be converted to an object. 
-      Properties.instance.config.backendConfig.wiriscustomheaders = Util.convertStringToObject(Properties.instance.config.backendConfig.wiriscustomheaders);
+      Properties.instance.config.backendConfig!.wiriscustomheaders = Util.convertStringToObject(Properties.instance.config.backendConfig?.wiriscustomheaders);
     } catch(e) {
       if (e instanceof StatusError) {
         // Do nothing; leave default values.
@@ -250,11 +264,15 @@ export class Properties {
    * - true, by default.
    */
   get wirispluginperformance(): Wirispluginperformance {
-    return this.config.backendConfig.wirispluginperformance ||
-      defaultValues.backendConfig.wirispluginperformance;
+    return this.config.backendConfig?.wirispluginperformance ||
+      defaultValues.backendConfig.wirispluginperformance as Wirispluginperformance;
   }
 
   set wirispluginperformance(wirispluginperformance: Wirispluginperformance) {
+    if(!this.config.backendConfig){
+      console.error('Cannot set wirispluginperformance if backendConfig is not set');
+      return;
+    }
     this.config.backendConfig.wirispluginperformance = wirispluginperformance;
     this.render();
   }
@@ -266,11 +284,15 @@ export class Properties {
    * - data-mathml, by default.
    */
   get wiriseditormathmlattribute(): string {
-    return this.config.backendConfig.wiriseditormathmlattribute ||
-      defaultValues.backendConfig.wiriseditormathmlattribute;
+    return this.config.backendConfig?.wiriseditormathmlattribute ||
+      defaultValues.backendConfig.wiriseditormathmlattribute as string;
   }
 
   set wiriseditormathmlattribute(wiriseditormathmlattribute: string) {
+    if(!this.config.backendConfig){
+      console.error('Cannot set wiriseditormathmlattribute if backendConfig is not set');
+      return;
+    }
     this.config.backendConfig.wiriseditormathmlattribute = wiriseditormathmlattribute;
     this.render();
   }

--- a/packages/viewer/src/properties.ts
+++ b/packages/viewer/src/properties.ts
@@ -8,7 +8,7 @@ type Wirispluginperformance = 'true' | 'false';
 /**
  * Type representing all the configuration for the viewer.
  */
-export type Config = {
+export interface Config {
   editorServicesRoot?: string,
   editorServicesExtension?: string,
   backendConfig?: {
@@ -23,10 +23,15 @@ export type Config = {
   zoom?: number,
 };
 
+/** Sets all fields and subfields of Config mandatory*/
+type MandatoryConfig = {
+  [K in keyof Config]-?: Required<Config[K]>
+};
 /**
  * Fallback values for the configurations that are not set.
+ * All properties are set to mandatory to guarantee a default value (and avoid checking at runtime to make the compiler happy )
  */
-const defaultValues: Required<Config> = {
+const defaultValues: MandatoryConfig = {
   editorServicesRoot: 'https://www.wiris.net/demo/plugins/app/',
   editorServicesExtension: '',
   backendConfig: {
@@ -54,16 +59,16 @@ export class Properties {
   config: Config = defaultValues;
 
   /**
-   * Do not use this method. Instead, use {@link Properties.generate}.
-   * Constructors cannot be async so we make it private and force instantiation through an alternative static method.
+   * Private constructor to avoid multiple instances of the class.
+   * To instantiate the class, use the static method  {@link Properties.getInstance}.
    */
-  private new() {}
+  private constructor(){}
   
 
-  static getInstance(): Properties {
+  static async getInstance(): Promise<Properties> {
     if (!Properties.instance) {
       Properties.instance = new Properties();
-      Properties.instance.initialize();
+      await Properties.instance.initialize();
     }
     return Properties.instance;
   }
@@ -74,7 +79,7 @@ export class Properties {
   private async initialize(): Promise<void> {
 
     if(!Properties.instance){
-      console.error('Properties instance is not set');
+      console.error('Properties.instance is not set');
       return
     }
 
@@ -82,7 +87,7 @@ export class Properties {
     const pluginName = 'WIRISplugins.js';
     const script: HTMLScriptElement | null = document.querySelector(`script[src*="${pluginName}"]`);
 
-    if (!!script) {
+    if (script) {
       const pluginNamePosition: number = script.src.lastIndexOf(pluginName);
       const params: string = script.src.substring(pluginNamePosition + pluginName.length);
       const urlParams = new URLSearchParams(params);
@@ -265,7 +270,7 @@ export class Properties {
    */
   get wirispluginperformance(): Wirispluginperformance {
     return this.config.backendConfig?.wirispluginperformance ||
-      defaultValues.backendConfig.wirispluginperformance as Wirispluginperformance;
+      defaultValues.backendConfig.wirispluginperformance;
   }
 
   set wirispluginperformance(wirispluginperformance: Wirispluginperformance) {
@@ -285,7 +290,7 @@ export class Properties {
    */
   get wiriseditormathmlattribute(): string {
     return this.config.backendConfig?.wiriseditormathmlattribute ||
-      defaultValues.backendConfig.wiriseditormathmlattribute as string;
+      defaultValues.backendConfig.wiriseditormathmlattribute;
   }
 
   set wiriseditormathmlattribute(wiriseditormathmlattribute: string) {

--- a/packages/viewer/src/properties.ts
+++ b/packages/viewer/src/properties.ts
@@ -9,29 +9,25 @@ type Wirispluginperformance = "true" | "false";
  * Type representing all the configuration for the viewer.
  */
 export interface Config {
-  editorServicesRoot?: string;
-  editorServicesExtension?: string;
-  backendConfig?: {
-    wirispluginperformance?: Wirispluginperformance;
-    wiriseditormathmlattribute?: string;
-    wiriscustomheaders?: object;
+  editorServicesRoot: string;
+  editorServicesExtension: string;
+  backendConfig: {
+    wirispluginperformance: Wirispluginperformance;
+    wiriseditormathmlattribute: string;
+    wiriscustomheaders: object;
   };
-  dpi?: number;
-  element?: string;
-  lang?: string;
-  viewer?: Viewer;
-  zoom?: number;
+  dpi: number;
+  element: string;
+  lang: string;
+  viewer: Viewer;
+  zoom: number;
 }
 
-/** Sets all fields and subfields of Config mandatory*/
-type MandatoryConfig = {
-  [K in keyof Config]-?: Required<Config[K]>;
-};
 /**
  * Fallback values for the configurations that are not set.
  * All properties are set to mandatory to guarantee a default value (and avoid checking at runtime to make the compiler happy )
  */
-const defaultValues: MandatoryConfig = {
+const defaultValues: Config = {
   editorServicesRoot: "https://www.wiris.net/demo/plugins/app/",
   editorServicesExtension: "",
   backendConfig: {
@@ -91,7 +87,7 @@ export class Properties {
       this.setProperties(script, pluginName, Properties.instance);
     }
 
-    Properties.instance?.checkServices();
+    Properties.instance.checkServices();
 
     // Get backend parameters calling the configurationjson service
     try {
@@ -106,7 +102,7 @@ export class Properties {
       );
 
       // We'll always get a string from the wiriscustomheaders backend parameter. It needs to be converted to an object.
-      Properties.instance.config.backendConfig!.wiriscustomheaders =
+      Properties.instance.config.backendConfig.wiriscustomheaders =
         Util.convertStringToObject(
           Properties.instance.config.backendConfig?.wiriscustomheaders
         );
@@ -176,7 +172,7 @@ export class Properties {
   }
 
   get editorServicesRoot(): string {
-    return this.config.editorServicesRoot || defaultValues.editorServicesRoot;
+    return this.config.editorServicesRoot ?? defaultValues.editorServicesRoot;
   }
 
   set editorServicesRoot(editorServicesRoot: string) {
@@ -186,7 +182,7 @@ export class Properties {
 
   get editorServicesExtension(): string {
     return (
-      this.config.editorServicesExtension ||
+      this.config.editorServicesExtension ??
       defaultValues.editorServicesExtension
     );
   }
@@ -227,7 +223,7 @@ export class Properties {
    * - none, by default.
    */
   get viewer(): Viewer {
-    return this.config.viewer || defaultValues.viewer;
+    return this.config.viewer;
   }
 
   set viewer(viewer: Viewer) {
@@ -242,7 +238,7 @@ export class Properties {
    * - 96, by default.
    */
   get dpi(): number {
-    return this.config.dpi || defaultValues.dpi;
+    return this.config.dpi ?? defaultValues.dpi;
   }
 
   set dpi(dpi: number) {
@@ -257,7 +253,7 @@ export class Properties {
    * - 1, by default.
    */
   get zoom(): number {
-    return this.config.zoom || defaultValues.zoom;
+    return this.config.zoom;
   }
 
   set zoom(zoom: number) {
@@ -272,7 +268,7 @@ export class Properties {
    * - 'body', by default.
    */
   get element(): string {
-    return this.config.element || defaultValues.element;
+    return this.config.element;
   }
 
   set element(element: string) {
@@ -288,8 +284,7 @@ export class Properties {
    */
   get wirispluginperformance(): Wirispluginperformance {
     return (
-      this.config.backendConfig?.wirispluginperformance ||
-      defaultValues.backendConfig.wirispluginperformance
+      this.config.backendConfig.wirispluginperformance 
     );
   }
 
@@ -312,8 +307,7 @@ export class Properties {
    */
   get wiriseditormathmlattribute(): string {
     return (
-      this.config.backendConfig?.wiriseditormathmlattribute ||
-      defaultValues.backendConfig.wiriseditormathmlattribute
+      this.config.backendConfig.wiriseditormathmlattribute
     );
   }
 

--- a/packages/viewer/src/retro.ts
+++ b/packages/viewer/src/retro.ts
@@ -30,7 +30,7 @@ export function bypassEncapsulation(properties: Properties, w: Window) {
 }
 
 interface MathMLPosition {
-  nextElement: Element;
+  nextElement: Node;
   safeMML: string;
 }
 
@@ -182,7 +182,7 @@ class JsPluginViewer {
     return returnValue;
   }
 
-  private static getMathMLPositionsAtElementAndChildren(element: Node, mathmlPositions) {
+  private static getMathMLPositionsAtElementAndChildren(element: Node, mathmlPositions: MathMLPosition[]) {
     JsPluginViewer.getMathMLPositionsAtNode(element, mathmlPositions);
     // Copy current children because DOM will be changed and element.childNodes won't be
     // consistent on call getMathMLPositionsAtElementAndChildren().
@@ -195,7 +195,7 @@ class JsPluginViewer {
     }
   }
 
-  private static getMathMLPositionsAtNode(node: Node, mathmlPositions) {
+  private static getMathMLPositionsAtNode(node: Node, mathmlPositions: MathMLPosition[] ) {
     var safeXMLCharacters = JsCharacters.getSafeXMLCharacters();
     if(node.nodeType == 3) {
       var startMathmlTag = safeXMLCharacters.tagOpener + "math";
@@ -218,7 +218,7 @@ class JsPluginViewer {
         start = node.textContent?.indexOf(startMathmlTag) as number;
 
         mathmlPositions.push({
-          safeMML: safeMathml,
+          safeMML: safeMathml || "",
           nextElement: node
         });
       }

--- a/packages/viewer/src/retro.ts
+++ b/packages/viewer/src/retro.ts
@@ -200,14 +200,14 @@ class JsPluginViewer {
     if(node.nodeType == 3) {
       var startMathmlTag = safeXMLCharacters.tagOpener + "math";
       var endMathmlTag = safeXMLCharacters.tagOpener + "/math" + safeXMLCharacters.tagCloser;
-      var start = node.textContent?.indexOf(startMathmlTag) as number;
+      var start = node.textContent?.indexOf(startMathmlTag) || -1;
       var end = 0;
       while(start != -1) {
-        end = node.textContent?.indexOf(endMathmlTag,start + startMathmlTag.length) as number;
+        end = node.textContent?.indexOf(endMathmlTag,start + startMathmlTag.length) || -1;
 
         if(end == -1) break;
 
-        var nextMathML = node.textContent?.indexOf(startMathmlTag,end + endMathmlTag.length) as number;
+        var nextMathML = node.textContent?.indexOf(startMathmlTag,end + endMathmlTag.length) || -1;
 
         if(nextMathML >= 0 && end > nextMathML) break;
 
@@ -215,7 +215,7 @@ class JsPluginViewer {
 
         node.textContent = (node.textContent?.substring(0,start) as string) + node.textContent?.substring(end + endMathmlTag.length);
         node = (node as Text).splitText(start);
-        start = node.textContent?.indexOf(startMathmlTag) as number;
+        start = node.textContent?.indexOf(startMathmlTag) || -1;
 
         mathmlPositions.push({
           safeMML: safeMathml || "",

--- a/packages/viewer/src/retro.ts
+++ b/packages/viewer/src/retro.ts
@@ -29,6 +29,11 @@ export function bypassEncapsulation(properties: Properties, w: Window) {
   }
 }
 
+interface MathMLPosition {
+  nextElement: Element;
+  safeMML: string;
+}
+
 /**
  * This class is a compatibility layer with the old Viewer.
  * See haxe/src-haxe/com/wiris/js/JsPluginViewer.hx in in the repo wiris/plugins previous to commit df1248a.
@@ -48,6 +53,7 @@ class JsPluginViewer {
 
     return JsPluginViewer.instance;
   }
+  
 
   /**
    * Render all the formulas written in SafeMathML inside the given element.
@@ -58,13 +64,13 @@ class JsPluginViewer {
    * Please consider using {@link renderLatex} or {@link renderMathML}.
    */
   parseSafeMathMLElement(element: HTMLElement, asynchronously?: boolean, callbackFunc?: () => void): void {
-    var mathmlPositions: Element[] = [];
+    var mathmlPositions: MathMLPosition[] = [];
     JsPluginViewer.getMathMLPositionsAtElementAndChildren(element, mathmlPositions);
     for (let i = 0; i < mathmlPositions.length; i++) {
       var mathmlPosition = mathmlPositions[i];
       var newNode = document.createElement("math");
-      mathmlPosition.parentNode?.insertBefore(newNode, mathmlPosition.nextElementSibling);
-      newNode.outerHTML = JsPluginViewer.decodeSafeMathML(mathmlPosition.getAttribute("safeMML") as string);
+      mathmlPosition.nextElement.parentNode?.insertBefore(newNode, mathmlPosition.nextElement);
+      newNode.outerHTML = JsPluginViewer.decodeSafeMathML(mathmlPosition.safeMML);
     }
   }
 

--- a/packages/viewer/src/retro.ts
+++ b/packages/viewer/src/retro.ts
@@ -200,22 +200,22 @@ class JsPluginViewer {
     if(node.nodeType == 3) {
       var startMathmlTag = safeXMLCharacters.tagOpener + "math";
       var endMathmlTag = safeXMLCharacters.tagOpener + "/math" + safeXMLCharacters.tagCloser;
-      var start = node.textContent?.indexOf(startMathmlTag) || -1;
+      var start = node.textContent?.indexOf(startMathmlTag) ?? -1;
       var end = 0;
       while(start != -1) {
-        end = node.textContent?.indexOf(endMathmlTag,start + startMathmlTag.length) || -1;
+        end = node.textContent?.indexOf(endMathmlTag,start + startMathmlTag.length) ?? -1;
 
         if(end == -1) break;
 
-        var nextMathML = node.textContent?.indexOf(startMathmlTag,end + endMathmlTag.length) || -1;
+        var nextMathML = node.textContent?.indexOf(startMathmlTag,end + endMathmlTag.length) ?? -1;
 
         if(nextMathML >= 0 && end > nextMathML) break;
 
         var safeMathml = node.textContent?.substring(start,end + endMathmlTag.length);
 
-        node.textContent = (node.textContent?.substring(0,start) as string) + node.textContent?.substring(end + endMathmlTag.length);
+        node.textContent = (node.textContent?.substring(0,start) ?? "") + node.textContent?.substring(end + endMathmlTag.length);
         node = (node as Text).splitText(start);
-        start = node.textContent?.indexOf(startMathmlTag) || -1;
+        start = node.textContent?.indexOf(startMathmlTag) ?? -1;
 
         mathmlPositions.push({
           safeMML: safeMathml || "",

--- a/packages/viewer/src/retro.ts
+++ b/packages/viewer/src/retro.ts
@@ -58,13 +58,13 @@ class JsPluginViewer {
    * Please consider using {@link renderLatex} or {@link renderMathML}.
    */
   parseSafeMathMLElement(element: HTMLElement, asynchronously?: boolean, callbackFunc?: () => void): void {
-    var mathmlPositions = [];
+    var mathmlPositions: Element[] = [];
     JsPluginViewer.getMathMLPositionsAtElementAndChildren(element, mathmlPositions);
     for (let i = 0; i < mathmlPositions.length; i++) {
       var mathmlPosition = mathmlPositions[i];
       var newNode = document.createElement("math");
-      mathmlPosition.nextElement.parentNode.insertBefore(newNode, mathmlPosition.nextElement);
-      newNode.outerHTML = JsPluginViewer.decodeSafeMathML(mathmlPosition.safeMML);
+      mathmlPosition.parentNode?.insertBefore(newNode, mathmlPosition.nextElementSibling);
+      newNode.outerHTML = JsPluginViewer.decodeSafeMathML(mathmlPosition.getAttribute("safeMML") as string);
     }
   }
 
@@ -149,7 +149,7 @@ class JsPluginViewer {
     // We are replacing $ by & when its part of an entity for retrocompatibility.
     // Now, the standard is replace § by &.
     var returnValue = '';
-    var currentEntity = null;
+    var currentEntity: string | null = null;
 
     var i = 0;
     while (i < inputCopy.length) {
@@ -194,22 +194,22 @@ class JsPluginViewer {
     if(node.nodeType == 3) {
       var startMathmlTag = safeXMLCharacters.tagOpener + "math";
       var endMathmlTag = safeXMLCharacters.tagOpener + "/math" + safeXMLCharacters.tagCloser;
-      var start = node.textContent.indexOf(startMathmlTag);
+      var start = node.textContent?.indexOf(startMathmlTag) as number;
       var end = 0;
       while(start != -1) {
-        end = node.textContent.indexOf(endMathmlTag,start + startMathmlTag.length);
+        end = node.textContent?.indexOf(endMathmlTag,start + startMathmlTag.length) as number;
 
         if(end == -1) break;
 
-        var nextMathML = node.textContent.indexOf(startMathmlTag,end + endMathmlTag.length);
+        var nextMathML = node.textContent?.indexOf(startMathmlTag,end + endMathmlTag.length) as number;
 
         if(nextMathML >= 0 && end > nextMathML) break;
 
-        var safeMathml = node.textContent.substring(start,end + endMathmlTag.length);
+        var safeMathml = node.textContent?.substring(start,end + endMathmlTag.length);
 
-        node.textContent = node.textContent.substring(0,start) + node.textContent.substring(end + endMathmlTag.length);
+        node.textContent = (node.textContent?.substring(0,start) as string) + node.textContent?.substring(end + endMathmlTag.length);
         node = (node as Text).splitText(start);
-        start = node.textContent.indexOf(startMathmlTag);
+        start = node.textContent?.indexOf(startMathmlTag) as number;
 
         mathmlPositions.push({
           safeMML: safeMathml,

--- a/packages/viewer/src/services.ts
+++ b/packages/viewer/src/services.ts
@@ -54,7 +54,7 @@ export async function callService(query: object, serviceName: string, method: Me
     const properties = Properties.getInstance();
     const headers = {
       'Content-type': 'application/x-www-form-urlencoded; charset=utf-8',
-      ...properties.config.backendConfig.wiriscustomheaders
+      ...properties.config.backendConfig?.wiriscustomheaders
     }
 
     const init: RequestInit = {

--- a/packages/viewer/src/services.ts
+++ b/packages/viewer/src/services.ts
@@ -51,7 +51,7 @@ export async function callService(query: object, serviceName: string, method: Me
   try {
     const url = new URL(serviceName + extension, serverURL);
 
-    const properties = Properties.getInstance();
+    const properties = await Properties.getInstance();
     const headers = {
       'Content-type': 'application/x-www-form-urlencoded; charset=utf-8',
       ...properties.config.backendConfig?.wiriscustomheaders

--- a/packages/viewer/tsconfig.json
+++ b/packages/viewer/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     /* Basic Options */
     "target": "ES5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */


### PR DESCRIPTION
## Description

- Add `strict: true` to the `tsconfig.json` file in the viewer package to enforce stricter typing. This will lead to more robust code and help catch potential bugs at compile time.

## Steps to reproduce
### Dev deployment
- Check the dev deploy [here](https://integrations.wiris.kitchen/fix/use-strict/html/viewer/), it should show the demo viewer and work as expected. 

### Locally
- run: `nx build viewer && nx start html-viewer`, the code should compile and work as expected

## Warning
- Setting strict to true has revealed a number of errors. Resolving some of these is innocuous, but addressing others involves assumptions that are not clear about what the code should do in certain cases. 

---

[#taskid X](https://wiris.kanbanize.com/ctrl_board/2/cards/X/details/) (*Waiting for the card to be created*)
