### PR TITLE
Add strict to ts-config

### DIFF
--- a/packages/viewer/src/app.ts
+++ b/packages/viewer/src/app.ts
@@ -48,7 +48,7 @@ async function main(w: Window): Promise<void> {
    * @param {MutationObserver} observer - Mutation observer to activate or reactivate every time the rendering root changes.
    */
   properties.render = async () => {
-    const element: HTMLElement = document.querySelector(properties.element);
+    const element: HTMLElement | null = document.querySelector(properties.element);
     if (element) {
       await renderLatex(properties, element);
       await renderMathML(properties, element);

--- a/packages/viewer/src/latex.ts
+++ b/packages/viewer/src/latex.ts
@@ -29,11 +29,11 @@ export async function renderLatex(properties: Properties, root: HTMLElement) {
  * @param {Node} node - Text node in which to search and replace LaTeX instances.
  */
 async function replaceLatexInTextNode(properties: Properties, node: Node) {
-  const textContent: string = node.textContent || "";
+  const textContent: string = node.textContent ?? "";
   let pos: number = 0;
 
-  while (pos < textContent.length) {
-    const nextLatexPosition: LatexPosition = getNextLatexPos(pos, textContent);
+  while (pos < textContent.length && node.nodeValue) {
+    const nextLatexPosition = getNextLatexPos(pos, textContent);
     if (nextLatexPosition) {
       // Get left non LaTeX text.
       const leftText: string = textContent.substring(pos, nextLatexPosition.start);
@@ -92,7 +92,7 @@ function findLatexTextNodes(root: any): Node[] {
  * @param {string} text - Text where the next latex it will be searched.
  * @
  */
-function getNextLatexPos(pos: number, text: string): LatexPosition {
+function getNextLatexPos(pos: number, text: string): LatexPosition | null {
   const firstLatexTags = text.indexOf("$$", pos);
   const secondLatexTags = firstLatexTags == -1 ? -1 : text.indexOf("$$", firstLatexTags + "$$".length);
   return firstLatexTags != -1 && secondLatexTags != -1 ? { start: firstLatexTags, end: secondLatexTags } : null;

--- a/packages/viewer/src/properties.ts
+++ b/packages/viewer/src/properties.ts
@@ -8,20 +8,20 @@ type Wirispluginperformance = "true" | "false";
 /**
  * Type representing all the configuration for the viewer.
  */
-export type Config = {
-  editorServicesRoot?: string;
-  editorServicesExtension?: string;
-  backendConfig?: {
-    wirispluginperformance?: Wirispluginperformance;
-    wiriseditormathmlattribute?: string;
-    wiriscustomheaders?: object;
+export interface Config {
+  editorServicesRoot: string;
+  editorServicesExtension: string;
+  backendConfig: {
+    wirispluginperformance: Wirispluginperformance;
+    wiriseditormathmlattribute: string;
+    wiriscustomheaders: object;
   };
-  dpi?: number;
-  element?: string;
-  lang?: string;
-  viewer?: Viewer;
-  zoom?: number;
-};
+  dpi: number;
+  element: string;
+  lang: string;
+  viewer: Viewer;
+  zoom: number;
+}
 
 /**
  * Fallback values for the configurations that are not set.
@@ -53,10 +53,10 @@ export class Properties {
   config: Config = defaultValues;
 
   /**
-   * Do not use this method. Instead, use {@link Properties.generate}.
-   * Constructors cannot be async so we make it private and force instantiation through an alternative static method.
+   * Private constructor to avoid multiple instances of the class.
+   * To instantiate the class, use the static method  {@link Properties.getInstance}.
    */
-  private new() {}
+  private constructor() {}
 
   static getInstance(): Properties {
     if (!Properties.instance) {
@@ -70,30 +70,17 @@ export class Properties {
    * Creates and sets up a new instance of class Properties
    */
   private async initialize(): Promise<void> {
+    if (!Properties.instance) {
+      console.error("Properties.instance is not set");
+      return;
+    }
     // Get URL parameters from <script>
     const pluginName = "WIRISplugins.js";
-    const script: HTMLScriptElement = document.querySelector(`script[src*="${pluginName}"]`);
+    const script: HTMLScriptElement | null = document.querySelector(`script[src*="${pluginName}"]`);
 
-    if (!!script) {
-      const pluginNamePosition: number = script.src.lastIndexOf(pluginName);
-      const params: string = script.src.substring(pluginNamePosition + pluginName.length);
-      const urlParams = new URLSearchParams(params);
-
-      if (urlParams.get("dpi") !== null && urlParams.get("dpi") !== undefined) {
-        Properties.instance.config.dpi = +urlParams.get("dpi");
-      }
-      if (urlParams.get("element") !== null && urlParams.get("element") !== undefined) {
-        Properties.instance.config.element = urlParams.get("element");
-      }
-      if (urlParams.get("lang") !== null && urlParams.get("lang") !== undefined) {
-        Properties.instance.config.lang = urlParams.get("lang");
-      }
-      if (urlParams.get("viewer") !== null && urlParams.get("viewer") !== undefined) {
-        Properties.instance.config.viewer = urlParams.get("viewer") as Viewer;
-      }
-      if (urlParams.get("zoom") !== null && urlParams.get("zoom") !== undefined) {
-        Properties.instance.config.zoom = +urlParams.get("zoom");
-      }
+    // If the absence of the script is an error maybe this should throw
+    if (script) {
+      this.setProperties(script, pluginName, Properties.instance);
     }
 
     Properties.instance.checkServices();
@@ -117,6 +104,43 @@ export class Properties {
       } else {
         throw e;
       }
+    }
+  }
+
+  /**
+   * Initialize properties from <script>
+   * @param script
+   * @param pluginName
+   * @param instance
+   */
+  private setProperties(script: HTMLScriptElement, pluginName: string, instance: Properties) {
+    const pluginNamePosition: number = script.src.lastIndexOf(pluginName);
+    const params: string = script.src.substring(pluginNamePosition + pluginName.length);
+    const urlParams = new URLSearchParams(params);
+
+    const dpi = urlParams.get("dpi");
+    if (dpi !== null && dpi !== undefined) {
+      instance.config.dpi = +dpi;
+    }
+
+    const element = urlParams.get("element");
+    if (element !== null && element !== undefined) {
+      instance.config.element = element;
+    }
+
+    const lang = urlParams.get("lang");
+    if (lang !== null && lang !== undefined) {
+      instance.config.lang = lang;
+    }
+
+    const viewer = urlParams.get("viewer");
+    if (viewer !== null && viewer !== undefined) {
+      instance.config.viewer = viewer as Viewer;
+    }
+
+    const zoom = urlParams.get("zoom");
+    if (zoom !== null && zoom !== undefined) {
+      instance.config.zoom = +zoom;
     }
   }
 

--- a/packages/viewer/src/retro.ts
+++ b/packages/viewer/src/retro.ts
@@ -29,6 +29,11 @@ export function bypassEncapsulation(properties: Properties, w: Window) {
   }
 }
 
+interface MathMLPosition {
+  nextElement: Node;
+  safeMML: string;
+}
+
 /**
  * This class is a compatibility layer with the old Viewer.
  * See haxe/src-haxe/com/wiris/js/JsPluginViewer.hx in in the repo wiris/plugins previous to commit df1248a.
@@ -58,12 +63,12 @@ class JsPluginViewer {
    * Please consider using {@link renderLatex} or {@link renderMathML}.
    */
   parseSafeMathMLElement(element: HTMLElement, asynchronously?: boolean, callbackFunc?: () => void): void {
-    var mathmlPositions = [];
+    var mathmlPositions: MathMLPosition[] = [];
     JsPluginViewer.getMathMLPositionsAtElementAndChildren(element, mathmlPositions);
     for (let i = 0; i < mathmlPositions.length; i++) {
       var mathmlPosition = mathmlPositions[i];
       var newNode = document.createElement("math");
-      mathmlPosition.nextElement.parentNode.insertBefore(newNode, mathmlPosition.nextElement);
+      mathmlPosition.nextElement.parentNode?.insertBefore(newNode, mathmlPosition.nextElement);
       newNode.outerHTML = JsPluginViewer.decodeSafeMathML(mathmlPosition.safeMML);
     }
   }
@@ -148,7 +153,7 @@ class JsPluginViewer {
     // We are replacing $ by & when its part of an entity for retrocompatibility.
     // Now, the standard is replace § by &.
     var returnValue = "";
-    var currentEntity = null;
+    var currentEntity: string | null = null;
 
     var i = 0;
     while (i < inputCopy.length) {
@@ -176,7 +181,7 @@ class JsPluginViewer {
     return returnValue;
   }
 
-  private static getMathMLPositionsAtElementAndChildren(element: Node, mathmlPositions) {
+  private static getMathMLPositionsAtElementAndChildren(element: Node, mathmlPositions: MathMLPosition[]) {
     JsPluginViewer.getMathMLPositionsAtNode(element, mathmlPositions);
     // Copy current children because DOM will be changed and element.childNodes won't be
     // consistent on call getMathMLPositionsAtElementAndChildren().
@@ -194,22 +199,23 @@ class JsPluginViewer {
     if (node.nodeType == 3) {
       var startMathmlTag = safeXMLCharacters.tagOpener + "math";
       var endMathmlTag = safeXMLCharacters.tagOpener + "/math" + safeXMLCharacters.tagCloser;
-      var start = node.textContent.indexOf(startMathmlTag);
+      var start = node.textContent?.indexOf(startMathmlTag) ?? -1;
       var end = 0;
       while (start != -1) {
-        end = node.textContent.indexOf(endMathmlTag, start + startMathmlTag.length);
+        end = node.textContent?.indexOf(endMathmlTag, start + startMathmlTag.length) ?? -1;
 
         if (end == -1) break;
 
-        var nextMathML = node.textContent.indexOf(startMathmlTag, end + endMathmlTag.length);
+        var nextMathML = node.textContent?.indexOf(startMathmlTag, end + endMathmlTag.length) ?? -1;
 
         if (nextMathML >= 0 && end > nextMathML) break;
 
-        var safeMathml = node.textContent.substring(start, end + endMathmlTag.length);
+        var safeMathml = node.textContent?.substring(start, end + endMathmlTag.length);
 
-        node.textContent = node.textContent.substring(0, start) + node.textContent.substring(end + endMathmlTag.length);
+        node.textContent =
+          (node.textContent?.substring(0, start) ?? "") + node.textContent?.substring(end + endMathmlTag.length);
         node = (node as Text).splitText(start);
-        start = node.textContent.indexOf(startMathmlTag);
+        start = node.textContent?.indexOf(startMathmlTag) ?? -1;
 
         mathmlPositions.push({
           safeMML: safeMathml,

--- a/packages/viewer/tsconfig.json
+++ b/packages/viewer/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     /* Basic Options */
     "target": "ES5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,


### PR DESCRIPTION
## Description

- Add `strict: true` to the `tsconfig.json` file in the viewer package to enforce stricter typing. This will lead to more robust code and help catch potential bugs at compile time.

## Steps to reproduce
### Dev deployment
- Check the dev deploy [here](https://integrations.wiris.kitchen/fix/use-strict/html/viewer/), it should show the demo viewer and work as expected. 

### Locally
- run: `nx build viewer && nx start html-viewer`, the code should compile and work as expected

## Warning
- Setting strict to true has revealed a number of errors. Resolving some of these is innocuous, but addressing others involves assumptions that are not clear about what the code should do in certain cases. 

---

[#taskid X](https://wiris.kanbanize.com/ctrl_board/2/cards/X/details/) (*Waiting for the card to be created*)
