### PR TITLE
Improve viewer integration services detection

### DIFF
--- a/packages/viewer/src/properties.ts
+++ b/packages/viewer/src/properties.ts
@@ -58,10 +58,10 @@ export class Properties {
    */
   private new() {}
 
-  static getInstance(): Properties {
+  static async getInstance(): Promise<Properties> {
     if (!Properties.instance) {
       Properties.instance = new Properties();
-      Properties.instance.initialize();
+      await Properties.instance.initialize();
     }
     return Properties.instance;
   }

--- a/packages/viewer/src/services.ts
+++ b/packages/viewer/src/services.ts
@@ -57,7 +57,8 @@ export async function callService(
   try {
     const url = new URL(serviceName + extension, serverURL);
 
-    const properties = Properties.getInstance();
+    // Getting the configuration is asynchronous since we make some requests.
+    const properties = await Properties.getInstance();
     const headers = {
       "Content-type": "application/x-www-form-urlencoded; charset=utf-8",
       ...properties.config.backendConfig.wiriscustomheaders,


### PR DESCRIPTION
## Description

This pull request improves the way we detect whether the user is making use of the integration services or, in its absence, wiris.net.

Prior to the development, we used a hard-coded string to identify the route where the integration services were hosted. That is a correct approach for the PHP ones, but in Java the user can change their location, making it impossible to detect since it did not match the Java hard-coded string.

The approach is to make a request to the current viewer URL, if we are not on PHP and receive an answer, it means that the client is using the Java integration services. Otherwise, it will default to wiris.net.

## Steps to reproduce

Case 1:
1. Using Plugins, deploy a Java demo with the instructions in the `build/docker` folder.
2. It should load properly the viewer from the location where the integration services are. Calls are not made to wiris.net, but to localhost.

Case 2:
1. Build and start a viewer demo with the html-integrations.
2. Check that the mentioned request to validate if we are in Java fails, and the following requests are made to wiris.net.

---

[#taskid 45038](https://wiris.kanbanize.com/ctrl_board/2/cards/45038/details/)
