### PR TITLE
Clicking in and out of the focus of the CKEditor causes unnecessary calls to render

### DIFF
--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -418,15 +418,13 @@ export default class MathType extends Plugin {
       "get",
       (e) => {
         let output = e.return;
-
         // CKEditor 5 replaces all the time the &lt; and &gt; for < and >, which our render can't understand.
         // We replace the values inserted for CKEditor5 to be able to render the formulas with the mentioned characters.
         output = output.replaceAll('"<"', '"&lt;"').replaceAll('">"', '"&gt;"').replaceAll("><<", ">&lt;<");
 
-        // Ckeditor retrieves editor data and removes the image information on the formulas
-        // We transform all the retrieved data to images and then we Parse the data.
-        let imageFormula = Parser.initParse(output);
-        e.return = Parser.endParse(imageFormula);
+        // This line cleans all the semantics stuff, including the handwritten data points and returns the MathML IF there is any.
+        // For text or latex formulas, it returns the original output.
+        e.return = MathML.removeSemantics(output, "application/json");
       },
       { priority: "low" },
     );

--- a/packages/ckeditor5/src/plugin.js
+++ b/packages/ckeditor5/src/plugin.js
@@ -418,10 +418,6 @@ export default class MathType extends Plugin {
       "get",
       (e) => {
         let output = e.return;
-        // CKEditor 5 replaces all the time the &lt; and &gt; for < and >, which our render can't understand.
-        // We replace the values inserted for CKEditor5 to be able to render the formulas with the mentioned characters.
-        output = output.replaceAll('"<"', '"&lt;"').replaceAll('">"', '"&gt;"').replaceAll("><<", ">&lt;<");
-
         // This line cleans all the semantics stuff, including the handwritten data points and returns the MathML IF there is any.
         // For text or latex formulas, it returns the original output.
         e.return = MathML.removeSemantics(output, "application/json");


### PR DESCRIPTION
## Description

Clicking in and out of the focus of the CKEditor causes unnecessary calls to render (showimage) when using our last version of MathType for CKEditor and the editor.getData() function.

## Steps to reproduce
[Check This ](https://codesandbox.io/p/devbox/uat-wiris-8-9-1-n3d55q)

## Solution
Remove unnecessary calls to our image services

---

[#48217 X](https://wiris.kanbanize.com/ctrl_board/2/cards/48217/details/) 
