### PR TITLE
fix(viewer): Fetch error on get configuration

### DIFF
--- a/packages/viewer/src/properties.ts
+++ b/packages/viewer/src/properties.ts
@@ -91,6 +91,7 @@ export class Properties {
         ["wirispluginperformance", "wiriseditormathmlattribute", "wiriscustomheaders"],
         Properties.instance.editorServicesRoot,
         Properties.instance.editorServicesExtension,
+        false,
       );
 
       // We'll always get a string from the wiriscustomheaders backend parameter. It needs to be converted to an object.
@@ -161,7 +162,7 @@ export class Properties {
         // So we call the configurationjson service assuming that the path is the one for the Java services.
         // If we get an answer, we know we are using the Java services,
         // otherwise, and since PHP has already been discarded, we'll set the services to wiris.net
-        await configurationJson(["wirispluginperformance"], path, "");
+        await configurationJson(["wirispluginperformance"], path, "", true);
 
         this.config.editorServicesRoot = path;
         this.config.editorServicesExtension = "";

--- a/packages/viewer/src/services.ts
+++ b/packages/viewer/src/services.ts
@@ -187,11 +187,22 @@ export async function latexToMathml(latex: string, url: string, extension: strin
  * @param {string} extension - Extension to add to the end of the serviceName (including the dot if necessary).
  * @returns {Promise<Response>} The configurationjson service response.
  */
-export async function configurationJson(variablekeys: string[], url: string, extension: string): Promise<any> {
+export async function configurationJson(
+  variablekeys: string[],
+  url: string,
+  extension: string,
+  check: boolean,
+): Promise<any> {
   const params = {
     variablekeys: variablekeys.join(","),
   };
 
-  const response = callService(params, "configurationjson", MethodType.Get, url, extension);
+  const response = await callService(params, "configurationjson", MethodType.Get, url, extension);
+
+  // Provide a warning to alert the users that the console error is an expected outcome,
+  // since this request only aims to be a check and does not expect to retrieve any data.
+  if (check && !response.ok) {
+    console.warn("Fetching the url: " + response.url + ", is expected to fail and handled. Don't panic!");
+  }
   return processJsonResponse(response);
 }


### PR DESCRIPTION
## Description

During the QA process, a console error was spotted. 
The error is due to a URL fetching where, when it fails, we can assume that the client will be using cloud and when it does not fail, we can assume that they will be using on-premises with Java.

This error is not possible to be removed, since it's handled by the browser, but we still want to let the user know that it won't impact negatively in any way. That's why this PR adds a warning for the specified check.

## Steps to reproduce

1. Open the viewer demo and validate that the warning appears.

---
