### PR TITLE
Added missing Dutch translation keys;

### DIFF
--- a/packages/devkit/lang/strings.json
+++ b/packages/devkit/lang/strings.json
@@ -562,6 +562,9 @@
   "nl": {
     "latex": "LaTeX",
     "cancel": "Annuleren",
+    "accept": "Invoegen",
+    "manual": "Handmatig",
+    "insert_math": "Een wiskundige vergelijking invoegen - MathType",
     "insert_chem": "Een scheikundige formule invoegen - ChemType",
     "minimize": "Minimaliseer",
     "maximize": "Maximaliseer",


### PR DESCRIPTION
## Description

Added the missing Dutch translations keys:
- "manual"
- "insert_math"
- "accept"


## Steps to reproduce

When setting the language to 'nl', the following kind of warnings are logged to the console: `Unknown key insert_math for language nl in StringManager.`

---
