### PR TITLE
Update `exports` in `package.json` and bump `ckeditor5` and `ckeditor5-dev-build-tools` packages.

### DIFF
--- a/packages/ckeditor5/package.json
+++ b/packages/ckeditor5/package.json
@@ -35,8 +35,8 @@
   "type": "module",
   "exports": {
     ".": "./src/plugin.js",
-    "./dist/*.css": "./dist/*.css",
     "./dist/*": "./dist/*",
+    "./browser/*": null,
     "./src/*": "./src/*",
     "./theme/*": "./theme/*",
     "./package.json": "./package.json"
@@ -50,10 +50,10 @@
     "@wiris/mathtype-html-integration-devkit": "1.17.3"
   },
   "devDependencies": {
-    "@ckeditor/ckeditor5-dev-build-tools": "^40.2.0",
-    "ckeditor5": ">=42.0.0"
+    "@ckeditor/ckeditor5-dev-build-tools": "^42.0.0",
+    "ckeditor5": ">=43.0.0"
   },
   "peerDependencies": {
-    "ckeditor5": ">=42.0.0"
+    "ckeditor5": ">=43.0.0"
   }
 }


### PR DESCRIPTION
## Description

⚠️  This PR is a prepared to work with new release of CKEditor5 in v43.0.0 (that will be released within a dew days). ⚠️ 

What has changed:
1. The global names for the `ckeditor5` and `ckeditor5-premium-features` packages in the UMD builds have been changed to `CKEDITOR` and `CKEDITOR_PREMIUM_FEATURES`, respectively.
2. Update the `exports` field in `package.json` to fix potential issues with loading CSS in older bundlers.

## Steps to reproduce

_If this PR solves a bug, include a short summary of the bug and the steps to reproduce it._

---

Closes #X (_Associated GitHub issue, if any_)

[#taskid X](https://wiris.kanbanize.com/ctrl_board/2/cards/X/details/) (_Associated Kanbanize card, if any_)
