### PR TITLE
feat: Add "none" tag to supported MathML tags in Util class

### DIFF
--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -432,7 +432,7 @@ export default class Util {
     let annotation = html.match(annotationRegex);
     // Sanitize html code without removing our supported MathML tags and attributes.
     html = DOMPurify.sanitize(html, {
-      ADD_TAGS: ["semantics", "annotation", "mstack", "msline", "msrow"],
+      ADD_TAGS: ["semantics", "annotation", "mstack", "msline", "msrow", "none"],
       ADD_ATTR: ["linebreak", "charalign", "stackalign"],
     });
     // Readd old annotation content.


### PR DESCRIPTION
## Description

> Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. Include, if necessary, a description of the proposed solution and the reasoning behind it.

When a formula with a superscript is added and then updated, it transforms to a subscript. The none tag, differentiates both and was deleted by dompurify.

- **Related Kanbanize Card:** [Link to KB-50069](https://wiris.kanbanize.com/ctrl_board/2/cards/50069/details/)
- **Related GitHub Issue:** Closes #1001 

## Type of Change

> Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code follows the style guidelines of this project ( Run `yarn lint` to check)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes

## How should be tested? (Manual or Automated Tests)

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

Add a formula with a superscript, move it around with drag and drop. Formula should be the same.

- **Manual tests:** I have tested this changes manually.






