### PR TITLE
fix: focus on proper editor when have multiples

### DIFF
--- a/packages/ckeditor4/plugin.src.js
+++ b/packages/ckeditor4/plugin.src.js
@@ -7,12 +7,12 @@ import StringManager from "@wiris/mathtype-html-integration-devkit/src/stringman
 import packageInfo from "./package.json";
 
 /**
- * This property contains all Froala Integration instances.
+ * This property contains all CKEditor4 Integration instances.
  * @type {Object}
  */
 export const instances = {};
 /**
- * This property contains the current Froala integration instance,
+ * This property contains the current CKEditor4 integration instance,
  * which is the instance of the active editor.
  * @class
  * @type {IntegrationModel}

--- a/packages/ckeditor5/src/integration.js
+++ b/packages/ckeditor5/src/integration.js
@@ -134,7 +134,10 @@ export default class CKEditor5Integration extends IntegrationModel {
   openNewFormulaEditor() {
     // Store the editor selection as it will be lost upon opening the modal
     this.core.editionProperties.selection = this.editorObject.editing.view.document.selection;
+
+    // Focus on the selected editor when multiple editor instances are present
     WirisPlugin.currentInstance = this;
+
     return super.openNewFormulaEditor();
   }
 

--- a/packages/ckeditor5/src/integration.js
+++ b/packages/ckeditor5/src/integration.js
@@ -134,7 +134,7 @@ export default class CKEditor5Integration extends IntegrationModel {
   openNewFormulaEditor() {
     // Store the editor selection as it will be lost upon opening the modal
     this.core.editionProperties.selection = this.editorObject.editing.view.document.selection;
-
+    WirisPlugin.currentInstance = this;
     return super.openNewFormulaEditor();
   }
 


### PR DESCRIPTION
## Description

> Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. Include, if necessary, a description of the proposed solution and the reasoning behind it.

When multiple CK5 editors are present on a page, the selected editor cannot be properly focused, leading to an incorrect caret position after editing.

- **Related Kanbanize Card:** [Link to KB-48969](https://wiris.kanbanize.com/ctrl_board/2/cards/https://wiris.kanbanize.com/ctrl_board/2/cards/48969/details/)

## Type of Change

> Please delete options that are not relevant.

- [ ] Feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that doesn't add any functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactoring (non-breaking change that improves the code structure)

## Checklist

- [X] My code follows the style guidelines of this project ( Run `yarn lint` to check)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes

## How should be tested? (Manual or Automated Tests)

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce,also list any relevant details for your test configuration.

- **Manual tests:** 
1.  I have set up a staging environment and configured multiple editors. https://integrations.wiris.kitchen/fix/KB-48969/jump-caret-test/html/ckeditor5/ 
2. Write text, write equations on MT or CT, then **write it down or exit without saving** while switching between multiple editors to ensure the caret position remains correct.






