### PR TITLE
feat(viewer): detect mathml expression with break lines

### DIFF
--- a/packages/viewer/src/mathml.ts
+++ b/packages/viewer/src/mathml.ts
@@ -19,7 +19,7 @@ interface FormulaData {
  */
 function findSafeMathMLTextNodes(root: HTMLElement): Node[] {
   const nodeIterator: NodeIterator = document.createNodeIterator(root, NodeFilter.SHOW_TEXT, (node) =>
-    /«math(.*?)«\/math»/g.test(node.nodeValue || "") ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT,
+    /«math([\s\S]*?)«\/math»/g.test(node.nodeValue || "") ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT,
   );
   const safeNodes: Node[] = [];
 


### PR DESCRIPTION
``## Description

When rendering formulas with the viewer, if the MathML is broken by line breaks, tabs, or other special characters, it cannot be recognized as valid MathML and thus will not trigger showimage to render it.

This commit modifies the regex used to identify MathML, allowing it to tolerate the presence of such special characters within the MathML content.

- **Related Kanbanize Card:** [Link to KB-53148](https://wiris.kanbanize.com/ctrl_board/2/cards/53148/details/)

## Type of Change

> Please delete options that are not relevant.

- [X] Feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that doesn't add any functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactoring (non-breaking change that improves the code structure)

## Checklist

- [X] My code follows the style guidelines of this project ( Run `yarn lint` to check)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes

## How should be tested? (Manual or Automated Tests)

You can have the follow doc as example: render it with viewer in the production (https://integrations.wiris.kitchen/master/html/viewer/) you may see some equations are not rendered.

Then you can try with  current viewer, you can see they are rendered properly



```<h3>Definició d'espai vectorial</h3>
<p>Un conjunt «math
  xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»E«/mi»«mo»§#8800;«/mo»«mo»§#8709;«/mo»«/math»
  té estructura d’<strong><i>espai vectorial</i></strong> sobre el cos dels
  nombres reals, «math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi
  mathvariant=¨normal¨»§#8477;«/mi»«/math» , si hi ha definides dues operacions,
  una d’interna anomenada <i>suma</i> que representem per “+”, i una altra
  d’externa anomenada <i>producte</i> que representem per “·”, definides per:
</p>
<p align="center">«math
  xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mtable»«mtr»«mtd»«mo»+«/mo»«mo»:«/mo»«mi»E«/mi»«mo»§#215;«/mo»«mi»E«/mi»«/mtd»«mtd»«mo»§#8594;«/mo»«/mtd»«mtd»«mi»E«/mi»«/mtd»«/mtr»«mtr»«mtd»«mo»§#160;«/mo»«mo»§#160;«/mo»«mo»§#160;«/mo»«mo»§#160;«/mo»«mfenced»«mrow»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»,«/mo»«mover»«mi»v«/mi»«mo»§#8594;«/mo»«/mover»«/mrow»«/mfenced»«/mtd»«mtd»«mo»§#8614;«/mo»«/mtd»«mtd»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»+«/mo»«mover»«mi»v«/mi»«mo»§#8594;«/mo»«/mover»«mo»§#160;«/mo»«/mtd»«/mtr»«/mtable»«/math»
  «math
  xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mtable»«mtr»«mtd»«mo»§#183;«/mo»«mo»§#160;«/mo»«mo»:«/mo»«mo»§#160;«/mo»«mi
  mathvariant=¨normal¨»§#8477;«/mi»«mo»§#215;«/mo»«mi»E«/mi»«/mtd»«mtd»«mo»§#8594;«/mo»«/mtd»«mtd»«mi»E«/mi»«/mtd»«/mtr»«mtr»«mtd»«mo»§#160;«/mo»«mo»§#160;«/mo»«mo»§#160;«/mo»«mo»§#160;«/mo»«mo»§#160;«/mo»«mfenced»«mrow»«mi»§#955;«/mi»«mo»,«/mo»«mover»«mi»v«/mi»«mo»§#8594;«/mo»«/mover»«/mrow»«/mfenced»«/mtd»«mtd»«mo»§#8614;«/mo»«/mtd»«mtd»«mi»§#955;«/mi»«mover»«mi»v«/mi»«mo»§#8594;«/mo»«/mover»«mo»§#160;«/mo»«/mtd»«/mtr»«/mtable»«/math»
</p>
<p>i que satisfan les propietats següents:</p>
<p>    Pel que fa a l'operació interna,</p>
<ol>
  <li>«math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mfenced»«mrow»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»+«/mo»«mover»«mi»v«/mi»«mo»§#8594;«/mo»«/mover»«/mrow»«/mfenced»«mo»+«/mo»«mover»«mi»w«/mi»«mo»§#8594;«/mo»«/mover»«mo»=«/mo»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»+«/mo»«mfenced»«mrow»«mover»«mi»v«/mi»«mo»§#8594;«/mo»«/mover»«mo»+«/mo»«mover»«mi»w«/mi»«mo»§#8594;«/mo»«/mover»«/mrow»«/mfenced»«/math»
    per a tots els elements «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»,«/mo»«mo»§#160;«/mo»«mover»«mi»v«/mi»«mo»§#8594;«/mo»«/mover»«mo»,«/mo»«mo»§#160;«/mo»«mover»«mi»w«/mi»«mo»§#8594;«/mo»«/mover»«/math»
    <i></i><i></i><i> </i>de «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»E«/mi»«/math»<i> </i>(associativitat).
  </li>
  <li>«math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»+«/mo»«mover»«mi»v«/mi»«mo»§#8594;«/mo»«/mover»«mo»=«/mo»«mover»«mi»v«/mi»«mo»§#8594;«/mo»«/mover»«mo»+«/mo»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«/math»
    per a tots els elements «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»,«/mo»«mover»«mi»v«/mi»«mo»§#8594;«/mo»«/mover»«/math»de
    «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»E«/mi»«/math»<i> </i>(commutativitat).
  </li>
  <li>Existeix un element «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mover»«mn»0«/mn»«mo»§#8594;«/mo»«/mover»«/math»
    de «math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»E«/mi»«/math» tal
    que «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»+«/mo»«mover»«mn»0«/mn»«mo»§#8594;«/mo»«/mover»«mo»=«/mo»«mover»«mn»0«/mn»«mo»§#8594;«/mo»«/mover»«mo»+«/mo»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»=«/mo»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«/math»
    per a tots els elements «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«/math»
    de «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»E«/mi»«/math»<i> </i>(existència
    d'element neutre).</li>
  <li>Per a cada «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«/math»de
    «math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»E«/mi»«/math» existeix
    un element «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mo»-«/mo»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«/math»
    de «math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»E«/mi»«/math», tal
    que «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»+«/mo»«mfenced»«mrow»«mo
    lspace=¨mediummathspace¨
    rspace=¨mediummathspace¨»-«/mo»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«/mrow»«/mfenced»«mo»=«/mo»«mover»«mn»0«/mn»«mo»§#8594;«/mo»«/mover»«/math» (existència
    d'element contrari).</li>
</ol>
<p>Per tenir aquestes quatres propietats amb l’operació suma, el conjunt
  <i>E</i> té estructura de <em>grup abelià</em>.</p>
<p>    Pel que fa a l'operació externa,</p>
<ol>
  <li>«math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»§#955;«/mi»«mo»§#183;«/mo»«mfenced»«mrow»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»+«/mo»«mover»«mi»v«/mi»«mo»§#8594;«/mo»«/mover»«/mrow»«/mfenced»«mo»=«/mo»«mi»§#955;«/mi»«mo»§#183;«/mo»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»+«/mo»«mi»§#955;«/mi»«mo»§#183;«/mo»«mover»«mi»v«/mi»«mo»§#8594;«/mo»«/mover»«/math»per
    a tots «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»,«/mo»«mover»«mi»v«/mi»«mo»§#8594;«/mo»«/mover»«/math»de
    «math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»E«/mi»«/math» i per a
    tot «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»§#955;«/mi»«/math» de «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi
    mathvariant=¨normal¨»§#8477;«/mi»«/math».</li>
  <li>«math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mfenced»«mrow»«mi»§#955;«/mi»«mo»+«/mo»«mi»§#956;«/mi»«/mrow»«/mfenced»«mo»§#183;«/mo»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»=«/mo»«mi»§#955;«/mi»«mo»§#183;«/mo»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»+«/mo»«mi»§#956;«/mi»«mo»§#183;«/mo»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«/math»
    per a tot «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«/math»
    de «math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»E«/mi»«/math» i per
    a tot «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»§#955;«/mi»«mo»,«/mo»«mi»§#956;«/mi»«/math»
    de «math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi
    mathvariant=¨normal¨»§#8477;«/mi»«/math»..</li>
  <li>«math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mfenced»«mrow»«mi»§#955;«/mi»«mi»§#956;«/mi»«/mrow»«/mfenced»«mo»§#183;«/mo»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»=«/mo»«mi»§#955;«/mi»«mo»§#183;«/mo»«mfenced»«mrow»«mi»§#956;«/mi»«mo»§#183;«/mo»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«/mrow»«/mfenced»«/math»
    per a tot «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«/math»
    de «math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»E«/mi»«/math» i per
    a tot «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»§#955;«/mi»«mo»,«/mo»«mi»§#956;«/mi»«/math»
    de «math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi
    mathvariant=¨normal¨»§#8477;«/mi»«/math».</li>
  <li>«math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mn»1«/mn»«mo»§#183;«/mo»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«mo»=«/mo»«mover»«mi»u«/mi»«mo»§#8640;«/mo»«/mover»«/math»
    per a tot «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mover»«mi»u«/mi»«mo»§#8594;«/mo»«/mover»«/math»
    de «math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»E«/mi»«/math».</li>
</ol>
<p class="Sagniadetextindependent">A partir d’ara als elements de <i>E</i> els
  anomenem <i><strong>vectors</strong> i als de «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi
    mathvariant=¨normal¨»§#8477;«/mi»«/math» <strong>escalars</strong></i>. Si
  no hi ha confusió, el punt indicant producte d’un escalar per un vector es pot
  ometre.</p>
<h4>Exemples d'espais vectorials:</h4>
<ul>
  <li>El conjunt «math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«msup»«mi
    mathvariant=¨normal¨»§#8477;«/mi»«mi»n«/mi»«/msup»«mo»=«/mo»«mfenced
    open=¨{¨
    close=¨}¨»«mrow»«mfenced»«mrow»«msub»«mi»x«/mi»«mn»1«/mn»«/msub»«mo»,«/mo»«msub»«mi»x«/mi»«mn»2«/mn»«/msub»«mo»,«/mo»«mo»§#8230;«/mo»«mo»,«/mo»«msub»«mi»x«/mi»«mi»n«/mi»«/msub»«/mrow»«/mfenced»«mfrac
    bevelled=¨true¨»«mrow»«/mrow»«mrow»«/mrow»«/mfrac»«msub»«mi»x«/mi»«mn»1«/mn»«/msub»«mo»,«/mo»«msub»«mi»x«/mi»«mn»2«/mn»«/msub»«mo»,«/mo»«mo»§#8230;«/mo»«mo»,«/mo»«msub»«mi»x«/mi»«mi»n«/mi»«/msub»«mo»§#8712;«/mo»«mi
    mathvariant=¨normal¨»§#8477;«/mi»«/mrow»«/mfenced»«/math» amb les operacions
  </li>
</ul>
<p style="padding-left: 60px;">- Suma «math
  xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mfenced»«mrow»«msub»«mi»x«/mi»«mn»1«/mn»«/msub»«mo»,«/mo»«msub»«mi»x«/mi»«mn»2«/mn»«/msub»«mo»,«/mo»«mo»§#8230;«/mo»«mo»,«/mo»«msub»«mi»x«/mi»«mi»n«/mi»«/msub»«/mrow»«/mfenced»«mo»+«/mo»«mfenced»«mrow»«msub»«mi»y«/mi»«mn»1«/mn»«/msub»«mo»,«/mo»«msub»«mi»y«/mi»«mn»2«/mn»«/msub»«mo»,«/mo»«mo»§#8230;«/mo»«mo»,«/mo»«msub»«mi»y«/mi»«mi»n«/mi»«/msub»«/mrow»«/mfenced»«mo»=«/mo»«mfenced»«mrow»«msub»«mi»x«/mi»«mn»1«/mn»«/msub»«mo»+«/mo»«msub»«mi»y«/mi»«mn»1«/mn»«/msub»«mo»,«/mo»«msub»«mi»x«/mi»«mn»2«/mn»«/msub»«mo»+«/mo»«msub»«mi»y«/mi»«mn»2«/mn»«/msub»«mo»,«/mo»«mo»§#8230;«/mo»«mo»,«/mo»«msub»«mi»x«/mi»«mi»n«/mi»«/msub»«mo»+«/mo»«msub»«mi»y«/mi»«mi»n«/mi»«/msub»«/mrow»«/mfenced»«/math»
</p>
<p style="padding-left: 60px;">- Producte per escalars «math
  xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»§#955;«/mi»«mfenced»«mrow»«msub»«mi»x«/mi»«mn»1«/mn»«/msub»«mo»,«/mo»«msub»«mi»x«/mi»«mn»2«/mn»«/msub»«mo»,«/mo»«mo»§#8230;«/mo»«mo»,«/mo»«msub»«mi»x«/mi»«mi»n«/mi»«/msub»«/mrow»«/mfenced»«mo»=«/mo»«mfenced»«mrow»«mi»§#955;«/mi»«msub»«mi»x«/mi»«mn»1«/mn»«/msub»«mo»,«/mo»«mi»§#955;«/mi»«msub»«mi»x«/mi»«mn»2«/mn»«/msub»«mo»,«/mo»«mo»§#8230;«/mo»«mo»,«/mo»«mi»§#955;«/mi»«msub»«mi»x«/mi»«mi»n«/mi»«/msub»«/mrow»«/mfenced»«/math»
</p>
<ul>
  <li>El conjunt de polinomis amb coeficients reals de grau igual o més petit
    que un determinat natural «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»n«/mi»«/math», amb les
    operacions: suma de polinomis i producte d'un escalar per un polinomi. </li>
  <li>El conjunt «math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi
    mathvariant=¨normal¨»§#8450;«/mi»«/math» dels nombres complexos amb les
    operacions de suma i producte per escalars usual en el conjunt dels nombres
    complexos. </li>
  <li>El conjunt de les matrius d’ordre «math
    xmlns=¨http://www.w3.org/1998/Math/MathML¨»«mi»m«/mi»«mo»§#215;«/mo»«mi»n«/mi»«/math» (amb
    les operacions que coneixeu de suma de matrius i producte d'una matriu per
    un escalar).</li>
</ul>
<p>En aquest curs ens centrarem bàsicament en dos espais vectorials:</p>
<ul>
  <li>«math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«msup»«mi
    mathvariant=¨normal¨»§#8477;«/mi»«mn»2«/mn»«/msup»«mo»=«/mo»«mfenced
    open=¨{¨
    close=¨}¨»«mrow»«mfenced»«mrow»«mi»x«/mi»«mo»,«/mo»«mi»y«/mi»«/mrow»«/mfenced»«mfrac
    bevelled=¨true¨»«mrow»«/mrow»«mrow»«/mrow»«/mfrac»«mi»x«/mi»«mo»,«/mo»«mi»y«/mi»«mo»§#8712;«/mo»«mi
    mathvariant=¨normal¨»§#8477;«/mi»«/mrow»«/mfenced»«/math»</li>
  <li>«math xmlns=¨http://www.w3.org/1998/Math/MathML¨»«msup»«mi
    mathvariant=¨normal¨»§#8477;«/mi»«mn»3«/mn»«/msup»«mo»=«/mo»«mfenced
    open=¨{¨
    close=¨}¨»«mrow»«mfenced»«mrow»«mi»x«/mi»«mo»,«/mo»«mi»y«/mi»«mo»,«/mo»«mi»z«/mi»«/mrow»«/mfenced»«mfrac
    bevelled=¨true¨»«mrow»«/mrow»«mrow»«/mrow»«/mfrac»«mi»x«/mi»«mo»,«/mo»«mi»y«/mi»«mo»,«/mo»«mi»z«/mi»«mo»§#8712;«/mo»«mi
    mathvariant=¨normal¨»§#8477;«/mi»«/mrow»«/mfenced»«/math»</li>
</ul>```