### PR TITLE
fix: TinyMCE7 sanitization

### DIFF
--- a/demos/html/tinymce7/src/app.js
+++ b/demos/html/tinymce7/src/app.js
@@ -23,6 +23,8 @@ tinymce.init({
   // This option allows us to introduce mathml formulas
   extended_valid_elements: "*[.*]",
   valid_elements: "*[*]",
+  // This option disables the DOMPurify library, which is used to sanitize the content.
+  // It's necessary when you want to initialize the editor with a content that contains handwritten formulas.
   xss_sanitization: false,
   // We recommend to set 'draggable_modal' to true to avoid overlapping issues
   // with the different UI modal dialog windows implementations between core and third-party plugins on TinyMCE.

--- a/demos/html/tinymce7/src/app.js
+++ b/demos/html/tinymce7/src/app.js
@@ -23,6 +23,7 @@ tinymce.init({
   // This option allows us to introduce mathml formulas
   extended_valid_elements: "*[.*]",
   valid_elements: "*[*]",
+  xss_sanitization: false,
   // We recommend to set 'draggable_modal' to true to avoid overlapping issues
   // with the different UI modal dialog windows implementations between core and third-party plugins on TinyMCE.
   // @see: https://github.com/wiris/html-integrations/issues/134#issuecomment-905448642

--- a/packages/tinymce7/README.md
+++ b/packages/tinymce7/README.md
@@ -66,6 +66,7 @@ Easily include quality math equations in your documents and digital content.
 
 ## Known issues
 
+- When loading the page with initial content, TinyMCE 7 removes the `<semantics>` tag. This tag is the one that identifies formulas as Handwriting. To bypass their sanitization and allow the `<semantics>` tag the initial content, add the following configuration to you TinyMCE instance: `xss_sanitization: false`. Checkout [more information here](https://github.com/tinymce/tinymce/issues/10114).
 - The editor's caret is lost when inserting a new formula on Safari with ChemType [#486](https://github.com/wiris/html-integrations/issues/486)
 
 ## Services


### PR DESCRIPTION
## Description

TinyMCE does a filtering when there's an initial content to be inserted. This filter does not accept many of the MathML tags, that's why we use options such as `valid_elements` and `extended_valid_elements`. But this seems to not be enough because TinyMCE keeps removing the `<semantics>` tag. 

That is because they do not want to accept it in any case as it is a potential issue. The only solution is to disable their sanitization, in case we would like to keep the information on the handwriting formulas when they are set as initial content.

Check [this report to the TinyMCE GitHub](https://github.com/tinymce/tinymce/issues/10114) to find more information.

This PR will remove the sanitization for our development and staging demos and will add the information of this issue so that the client are aware of it, while TinyMCE does not provide any other solution.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project ( Run `yarn lint` to check)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes

## How should be tested?

Build and start the TinyMCE 7 demo and validate that the handwriting formulas open in handwriting mode.
