### PR TITLE
Fix dismantle staging workflow

### DIFF
--- a/.github/workflows/dismantle-staging.yml
+++ b/.github/workflows/dismantle-staging.yml
@@ -37,7 +37,7 @@ jobs:
           # Check if branch name is in the file
           if grep -q -F "${{ matrix.branch }}" "${BRANCHES}"; then
             # Update local list of branches
-            sed -i '/^${{ github.event.ref }}$/d' "${BRANCHES}"
+            sed -i "\|^${{ github.event.ref }}$|d" "${BRANCHES}"
             # Upload updated file
             aws s3 cp "${BRANCHES}" "s3://wiris-integrations-staging-html/${BRANCHES}"
           fi


### PR DESCRIPTION
## Description

Dismantle staging workflow is not working when it finds branches with `/` brackets. 
This PR should fix the part of the workflow where it takes the branches on staging and removes them.

## Type of Change

> Please delete options that are not relevant.

- [ ] Feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that doesn't add any functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactoring (non-breaking change that improves the code structure)

## Checklist

- [X] My code follows the style guidelines of this project ( Run `yarn lint` to check)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings or errors

## How should be tested? (Manual or Automated Tests)

Once merged to master, we should validate it works by creating and removing a branch with `/`.
