### PR TITLE
fix: Export CK5 Wiris classes

### DIFF
--- a/packages/ckeditor5/src/index.js
+++ b/packages/ckeditor5/src/index.js
@@ -1,3 +1,6 @@
 import MathType from "./plugin.js";
+import CKEditor5Integration from "./integration.js";
+import { MathTypeCommand, ChemTypeCommand } from "./commands.js";
 
 export default MathType;
+export { CKEditor5Integration, MathTypeCommand, ChemTypeCommand };


### PR DESCRIPTION
## Description

When CKEditor5 updated their installation methods, we had to adapt to those. In the process, we lost the export of most classes.

- **Related Kanbanize Card:** [Link to KB-54691](https://wiris.kanbanize.com/ctrl_board/2/cards/54691/details/)
- **Related GitHub Issue:** Closes #1008

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code follows the style guidelines of this project ( Run `yarn lint` to check)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes

## How should be tested?

Validate that the `CKEditor5Integration`, `MathTypeCommand` and `ChemTypeCommand` are available to import when using MathType for CKEditor5.