### PR TITLE
fix: Remove unnecessary contentChanged event

### DIFF
--- a/packages/froala/wiris.src.js
+++ b/packages/froala/wiris.src.js
@@ -236,14 +236,13 @@ export class FroalaIntegration extends IntegrationModel {
 
   /** @inheritdoc */
   insertFormula(focusElement, windowTarget, mathml, wirisProperties) {
-    // Due to insertFormula adds an image using pure JavaScript functions,
-    // it is needed notificate to the editorObject that placeholder status
-    // has to be updated.
-    this.editorObject.events.trigger("contentChanged");
     const obj = super.insertFormula(focusElement, windowTarget, mathml, wirisProperties);
 
+    // Due to insertFormula adds an image using pure JavaScript functions,
+    // it is needed to notify the editorObject that placeholder status has to be updated.
     this.editorObject.placeholder.refresh();
     this.editorObject.undo.saveStep();
+
     return obj;
   }
 }


### PR DESCRIPTION
## Description

The `contentChanged` event is triggered before a formula is inserted, making the content of the event to not have the recent changes on the Froala editor. 

We need to remove our own trigger to the event, as Froala already triggers it any time there's new content on the editor.

- **Related Kanbanize Card:** [Link to KB-55127](https://wiris.kanbanize.com/ctrl_board/2/cards/55127/details/)

## Type of Change

> Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project ( Run `yarn lint` to check)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes

## How should be tested? (Manual or Automated Tests)

* On the Froala demo, listen to the Froala `contentChanged` event.
* Insert a formula
* Validate that the content changed payload has the formula.
