### PR TITLE
Make Staging workflow run when publish workflow completes

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,7 +7,12 @@
 name: Deploy staging
 
 # Controls when the action will run
-on: push
+on:
+  push:
+  workflow_run:
+    workflows: ["Publish"]
+    types:
+      - completed
 
 # Array of jobs to run in this workflow
 jobs:
@@ -18,7 +23,7 @@ jobs:
       branches: ${{ steps.get_branches.outputs.branches }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
## Description

When we manually trigger the publish workflow, it makes a commit and pushes it to master, but the push event will not trigger another workflow. This is a built-in GitHub restriction to prevent infinite workflow loops.

For that reason, we don't have staging up to date on the master branch, and is usually broken due to our release process. 

This PR adds a configuration to the staging workflow to force running it automatically when the publish one completes.

## Type of Change

- [X] Feature (non-breaking change which adds functionality)

## How should be tested?

This will be validated in the next release. Check that the changes are well written
