### PR TITLE
fix: update demo with lastest tiny updates

### DIFF
--- a/demos/html/tinymce6/src/app.js
+++ b/demos/html/tinymce6/src/app.js
@@ -19,8 +19,6 @@ tinymce.init({
     tiny_mce_wiris: `${window.location.href}dist/plugin.min.js`,
   },
 
-  // This option allows us to introduce mathml formulas
-  extended_valid_elements: "*[.*]",
   // We recommend to set 'draggable_modal' to true to avoid overlapping issues
   // with the different UI modal dialog windows implementations between core and third-party plugins on TinyMCE.
   // @see: https://github.com/wiris/html-integrations/issues/134#issuecomment-905448642

--- a/demos/html/tinymce7/package.json
+++ b/demos/html/tinymce7/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@wiris/mathtype-html-integration-devkit": "*",
     "@wiris/mathtype-tinymce7": "*",
-    "tinymce": "^7.7.0"
+    "tinymce": "^7.8.0"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^12.0.2",

--- a/demos/html/tinymce7/src/app.js
+++ b/demos/html/tinymce7/src/app.js
@@ -24,6 +24,11 @@ tinymce.init({
   // This option prevents the DOMPurify library from filtering wiris MathML tags.
   // It's necessary when you want to initialize the editor with a content that contains handwritten formulas.
   allow_mathml_annotation_encodings: ["wiris", "application/json"],
+
+  // Those options are necessary to allow the additional MathML tags to be saved in the editor.
+  extended_mathml_elements: [ "semantics" ],
+  extended_mathml_attributes: [ "linebreak" ],
+
   // We recommend to set 'draggable_modal' to true to avoid overlapping issues
   // with the different UI modal dialog windows implementations between core and third-party plugins on TinyMCE.
   // @see: https://github.com/wiris/html-integrations/issues/134#issuecomment-905448642

--- a/demos/html/tinymce7/src/app.js
+++ b/demos/html/tinymce7/src/app.js
@@ -23,11 +23,11 @@ tinymce.init({
   valid_elements: "*[*]",
   // This option prevents the DOMPurify library from filtering wiris MathML tags.
   // It's necessary when you want to initialize the editor with a content that contains handwritten formulas.
-  allow_mathml_annotation_encodings: ["wiris", "application/json"],
+  allow_mathml_annotation_encodings: ["application/json"],
 
   // Those options are necessary to allow the additional MathML tags to be saved in the editor.
-  extended_mathml_elements: [ "semantics" ],
-  extended_mathml_attributes: [ "linebreak" ],
+  extended_mathml_elements: [ "semantics", "annotation", "mstack", "msline", "msrow", "none" ],
+  extended_mathml_attributes: [ "linebreak", "charalign", "stackalign" ],
 
   // We recommend to set 'draggable_modal' to true to avoid overlapping issues
   // with the different UI modal dialog windows implementations between core and third-party plugins on TinyMCE.

--- a/demos/html/tinymce7/src/app.js
+++ b/demos/html/tinymce7/src/app.js
@@ -18,17 +18,6 @@ tinymce.init({
   license_key: "gpl",
   external_plugins: { tiny_mce_wiris: `${window.location.href}dist/plugin.min.js` },
 
-  // This option allows us to introduce mathml formulas
-  extended_valid_elements: "*[.*]",
-  valid_elements: "*[*]",
-  // This option prevents the DOMPurify library from filtering wiris MathML tags.
-  // It's necessary when you want to initialize the editor with a content that contains handwritten formulas.
-  allow_mathml_annotation_encodings: ["application/json"],
-
-  // Those options are necessary to allow the additional MathML tags to be saved in the editor.
-  extended_mathml_elements: [ "semantics", "annotation", "mstack", "msline", "msrow", "none" ],
-  extended_mathml_attributes: [ "linebreak", "charalign", "stackalign" ],
-
   // We recommend to set 'draggable_modal' to true to avoid overlapping issues
   // with the different UI modal dialog windows implementations between core and third-party plugins on TinyMCE.
   // @see: https://github.com/wiris/html-integrations/issues/134#issuecomment-905448642

--- a/packages/tinymce6/README.md
+++ b/packages/tinymce6/README.md
@@ -43,10 +43,6 @@ Easily include quality math equations in your documents and digital content.
      // @see: https://github.com/wiris/html-integrations/issues/134#issuecomment-905448642
      draggable_modal: true,
 
-     // This option allows you to introduce mathml formulas with wiris plugins.
-     // Not enabling this, will provide formulas from beeing created and rendered.
-     extended_valid_elements: "*[.*]",
-
      // You could set a different language for MathType editor:
      // language: 'fr_FR',
      // mathTypeParameters: {

--- a/packages/tinymce6/editor_plugin.src.js
+++ b/packages/tinymce6/editor_plugin.src.js
@@ -255,6 +255,12 @@ export const currentInstance = null;
         integrationModelProperties.integrationParameters = editor.options.get("mathTypeParameters");
       }
 
+      // This option allows us to introduce MathML formulas.
+      editor.options.register("extended_valid_elements", {
+        processor: "string",
+        default: "*[.*]",
+      });
+
       integrationModelProperties.scriptName = "plugin.min.js";
       integrationModelProperties.environment = {};
 

--- a/packages/tinymce7/README.md
+++ b/packages/tinymce7/README.md
@@ -47,8 +47,8 @@ Easily include quality math equations in your documents and digital content.
      allow_mathml_annotation_encodings: ["wiris", "application/json"],
 
      // Those options are necessary to allow the additional MathML tags to be saved in the editor.
-     extended_mathml_elements: [ "semantics" ],
-     extended_mathml_attributes: [ "linebreak" ],
+     extended_mathml_elements: [ "semantics", "annotation", "mstack", "msline", "msrow", "none" ],
+     extended_mathml_attributes: [ "linebreak", "charalign", "stackalign" ],
      // You could set a different language for MathType editor:
      // language: 'fr_FR',
      // mathTypeParameters: {

--- a/packages/tinymce7/README.md
+++ b/packages/tinymce7/README.md
@@ -20,7 +20,7 @@ Easily include quality math equations in your documents and digital content.
    npm install @wiris/mathtype-tinymce7
    ```
 
-   > MathType is fully compatible with TinyMCE 7 from version 7.6.0.
+   > MathType is fully compatible with TinyMCE 7 from version 7.8.0.
 
 2. Add the plugin as an external plugin:
 
@@ -46,6 +46,9 @@ Easily include quality math equations in your documents and digital content.
      // It's necessary when you want to initialize the editor with a content that contains handwritten formulas.
      allow_mathml_annotation_encodings: ["wiris", "application/json"],
 
+     // Those options are necessary to allow the additional MathML tags to be saved in the editor.
+     extended_mathml_elements: [ "semantics" ],
+     extended_mathml_attributes: [ "linebreak" ],
      // You could set a different language for MathType editor:
      // language: 'fr_FR',
      // mathTypeParameters: {

--- a/packages/tinymce7/README.md
+++ b/packages/tinymce7/README.md
@@ -38,17 +38,6 @@ Easily include quality math equations in your documents and digital content.
      // @see: https://github.com/wiris/html-integrations/issues/134#issuecomment-905448642
      draggable_modal: true,
 
-     // This option allows you to introduce mathml formulas with wiris plugins.
-     // Not enabling this, will provide formulas from being created and rendered.
-     extended_valid_elements: "*[.*]",
-     valid_elements: "*[*]",
-     // This option prevents the DOMPurify library from filtering wiris MathML tags.
-     // It's necessary when you want to initialize the editor with a content that contains handwritten formulas.
-     allow_mathml_annotation_encodings: ["application/json"],
-
-     // Those options are necessary to allow the additional MathML tags to be saved in the editor.
-     extended_mathml_elements: [ "semantics", "annotation", "mstack", "msline", "msrow", "none" ],
-     extended_mathml_attributes: [ "linebreak", "charalign", "stackalign" ],
      // You could set a different language for MathType editor:
      // language: 'fr_FR',
      // mathTypeParameters: {

--- a/packages/tinymce7/README.md
+++ b/packages/tinymce7/README.md
@@ -44,7 +44,7 @@ Easily include quality math equations in your documents and digital content.
      valid_elements: "*[*]",
      // This option prevents the DOMPurify library from filtering wiris MathML tags.
      // It's necessary when you want to initialize the editor with a content that contains handwritten formulas.
-     allow_mathml_annotation_encodings: ["wiris", "application/json"],
+     allow_mathml_annotation_encodings: ["application/json"],
 
      // Those options are necessary to allow the additional MathML tags to be saved in the editor.
      extended_mathml_elements: [ "semantics", "annotation", "mstack", "msline", "msrow", "none" ],

--- a/packages/tinymce7/editor_plugin.src.js
+++ b/packages/tinymce7/editor_plugin.src.js
@@ -255,6 +255,34 @@ export const currentInstance = null;
         integrationModelProperties.integrationParameters = editor.options.get("mathTypeParameters");
       }
 
+      // This option allows us to introduce MathML formulas.
+      editor.options.register("extended_valid_elements", {
+        processor: "string",
+        default: "*[.*]",
+      });
+
+      // This option allows all elements and attributes.
+      editor.options.register("valid_elements", {
+        processor: "string",
+        default: "*[*]",
+      });
+
+      // Those options prevent the DOMPurify library from filtering Wiris MathML tags.
+      editor.options.register("allow_mathml_annotation_encodings", {
+        processor: "array",
+        default: ["application/json"],
+      });
+
+      editor.options.register("extended_mathml_elements", {
+        processor: "array",
+        default: ["semantics", "annotation", "mstack", "msline", "msrow", "none"],
+      });
+
+      editor.options.register("extended_mathml_attributes", {
+        processor: "array",
+        default: ["linebreak", "charalign", "stackalign"],
+      });
+
       integrationModelProperties.scriptName = "plugin.min.js";
       integrationModelProperties.environment = {};
 

--- a/packages/tinymce7/editor_plugin.src.js
+++ b/packages/tinymce7/editor_plugin.src.js
@@ -267,7 +267,7 @@ export const currentInstance = null;
         default: "*[*]",
       });
 
-      // Those options prevent the DOMPurify library from filtering Wiris MathML tags.
+      // Those options prevent the DOMPurify library from filtering Wiris MathML tags and attributes.
       editor.options.register("allow_mathml_annotation_encodings", {
         processor: "array",
         default: ["application/json"],


### PR DESCRIPTION
## Description
Update the demo and documentation to include the workaround for using extended_mathml_elements, extended_mathml_attributes.

These changes are made to ensure that MathML generated by MathType works correctly during both editing and viewing in TinyMCE 7, following it's 7.8 [release note](https://www.tiny.cloud/docs/tinymce/latest/7.8.0-release-notes/#new-extended_mathml_attributes-and-extended_mathml_elements-options).

- **Related Kanbanize Card:** [Link to KB-55936](https://wiris.kanbanize.com/ctrl_board/2/cards/55936/details/)

## Type of Change

> Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update (changes to documentation only)

## Checklist

- [x] My code follows the style guidelines of this project ( Run `yarn lint` to check)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes

## How should be tested? (Manual or Automated Tests)

1. Launch tinycme 7' demo.
2. Try to add formulas with linebreak. For example: 
```<math style="font-family:'Times New Roman'" xmlns="http://www.w3.org/1998/Math/MathML"><mi>A</mi><mi>B</mi><mo>=</mo><mi>A</mi><mi>C</mi><mo>,</mo><mspace linebreak="newline"/><mspace/><mspace/><mspace/><mspace/><mspace/><mspace/><mspace/><mspace/><mi>A</mi><mi>K</mi><mo>=</mo><mi>A</mi><mi>H</mi><mo>,</mo><mspace linebreak="newline"/><mspace/><mspace/><mspace/><mspace/><mspace/><mspace/><mspace/><mspace/><mi>B</mi><mi>K</mi><mo>=</mo><mi>C</mi><mi>H</mi><mo>&#xA0;</mo><mo>?</mo><mi mathvariant="normal">&#x3C0;</mi></math>```
3. Ensure the MathML is not sanitized
