### PR TITLE
fix: prevent from change to wrong rtl state

### DIFF
--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -182,7 +182,9 @@ export default class ContentManager {
       this.editor = window.com.wiris.jsEditor.JsEditor.newInstance(this.editorAttributes);
       this.editor.insertInto(this.modalDialogInstance.contentContainer);
       this.editor.focus();
-      if (this.modalDialogInstance.rtl) {
+
+      // `editor.action("rtl");` toggles the RTL mode based on the current state, it doesn't just switch to RTL.
+      if (this.modalDialogInstance.rtl && !this.editor.getEditorModel().isRTL()) {
         this.editor.action("rtl");
       }
       // Setting div in rtl in case of it's activated.


### PR DESCRIPTION
## Description

Fix the issue where, in some cases, switching the text direction causes the editor to display in LTR mode, even though it is already in RTL mode.

This issue is exposed in the Tiny 7 plugin's demo, so the fix will solve the error in the plugin demo.

- **Related Kanbanize Card:** [Link to KB-56039](https://wiris.kanbanize.com/ctrl_board/2/cards/56039/details/)

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code follows the style guidelines of this project ( Run `yarn lint` to check)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes

## How should be tested? (Manual or Automated Tests)

[To reproduce error! Needs to be tested on another branch!]

1. Open html-integrations/demos/html/tinymce7/src/app.js

2. Change the language to Arabic by adding:

```
tinymce.init ({
mathTypeParameters: {
  editorParameters: { language: 'ar' },
}
```

3. Force TinyMCE 7 to display in RTL mode by adding

```
tinymce.init ({
directionality: "rtl",
```

4. You’ll notice that when MathType opens, it appears in LTR mode, while it should be RTL

5. Retest with the current version — this issue no longer occurs