### PR TITLE
Implement focus protection for MathType modal dialog

### DIFF
--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -5,6 +5,9 @@ import Listeners from "./listeners";
 import MathML from "./mathml";
 import Util from "./util";
 import Telemeter from "./telemeter";
+import focusProtection from "./focusprotection";
+
+const { protect } = focusProtection;
 
 export default class ContentManager {
   /**
@@ -501,6 +504,11 @@ export default class ContentManager {
       if (this.mathML && !this.mathML.includes('<annotation encoding="application/json">') && !this.isNewElement) {
         this.openHandOnKeyboardMathML(this.mathML, this.editor);
       }
+    }
+    if (this.integrationModel.isMoodle) {
+
+      // Apply focus protection to prevent focus loss when the modal is open.
+      protect(this.container, this.overlay, this.contentContainer);
     }
   }
 

--- a/packages/devkit/src/contentmanager.js
+++ b/packages/devkit/src/contentmanager.js
@@ -5,9 +5,6 @@ import Listeners from "./listeners";
 import MathML from "./mathml";
 import Util from "./util";
 import Telemeter from "./telemeter";
-import focusProtection from "./focusprotection";
-
-const { protect } = focusProtection;
 
 export default class ContentManager {
   /**
@@ -504,11 +501,6 @@ export default class ContentManager {
       if (this.mathML && !this.mathML.includes('<annotation encoding="application/json">') && !this.isNewElement) {
         this.openHandOnKeyboardMathML(this.mathML, this.editor);
       }
-    }
-    if (this.integrationModel.isMoodle) {
-
-      // Apply focus protection to prevent focus loss when the modal is open.
-      protect(this.container, this.overlay, this.contentContainer);
     }
   }
 

--- a/packages/devkit/src/focusprotection.js
+++ b/packages/devkit/src/focusprotection.js
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2024 WIRIS. All rights reserved.
+ */
+
+/**
+ * This module provides protection against external focus management scripts
+ * that might interfere with the MathType editor modal.
+ */
+
+/**
+ * FocusProtection class provides methods to prevent external scripts from
+ * interfering with the focus of the MathType modal dialog.
+ */
+export default class FocusProtection {
+  /**
+   * Initialize focus protection on the given modal element.
+   *
+   * @param {HTMLElement} modalElement - The modal element to protect
+   * @param {HTMLElement} overlayElement - The overlay element of the modal (not used in current implementation)
+   * @param {HTMLElement} editorElement - The editor element inside the modal
+   */
+  static protect(modalElement, overlayElement, editorElement) {
+    if (!modalElement || !overlayElement || !editorElement) {
+      console.warn("FocusProtection: Missing required elements");
+      return;
+    }
+
+    // Apply the focus protection
+    FocusProtection._applyFocusProtection(modalElement, editorElement);
+  }
+
+  /**
+   * Apply focus protection by overriding focus-related methods
+   *
+   * @param {HTMLElement} modalElement - The modal element
+   * @param {HTMLElement} editorElement - The editor element to keep focused
+   * @private
+   */
+  static _applyFocusProtection(modalElement, editorElement) {
+    // Store original focus methods to be able to restore them
+    const originalElementFocus = HTMLElement.prototype.focus;
+    const originalElementBlur = HTMLElement.prototype.blur;
+
+    // Override the focus method for all elements
+    HTMLElement.prototype.focus = function (...args) {
+      // If the modal is open and this is not part of the modal, prevent focus
+      if (modalElement.style.display !== "none" && !modalElement.contains(this) && this !== document.body) {
+        // If some external script is trying to focus another element, prevent it
+        // and restore focus to the editor
+        if (editorElement) {
+          // Use the original focus method to avoid infinite recursion
+          originalElementFocus.apply(editorElement, args);
+        }
+        return;
+      }
+
+      // Otherwise, allow the focus to happen
+      originalElementFocus.apply(this, args);
+    };
+
+    // Store the methods to remove them when the modal is closed
+    modalElement.originalElementFocus = originalElementFocus;
+    modalElement.originalElementBlur = originalElementBlur;
+  }
+
+  /**
+   * Remove focus protection from the modal
+   *
+   * @param {HTMLElement} modalElement - The modal element to unprotect
+   */
+  static unprotect(modalElement) {
+    if (!modalElement) {
+      return;
+    }
+
+    // Restore original focus methods
+    if (modalElement.originalElementFocus) {
+      HTMLElement.prototype.focus = modalElement.originalElementFocus;
+      delete modalElement.originalElementFocus;
+    }
+
+    if (modalElement.originalElementBlur) {
+      HTMLElement.prototype.blur = modalElement.originalElementBlur;
+      delete modalElement.originalElementBlur;
+    }
+  }
+}

--- a/packages/devkit/src/focusprotection.js
+++ b/packages/devkit/src/focusprotection.js
@@ -1,9 +1,4 @@
 /**
- * @license
- * Copyright 2024 WIRIS. All rights reserved.
- */
-
-/**
  * This module provides protection against external focus management scripts
  * that might interfere with the MathType editor modal.
  */

--- a/packages/devkit/src/focusprotection.js
+++ b/packages/devkit/src/focusprotection.js
@@ -9,10 +9,12 @@
  */
 
 /**
- * FocusProtection class provides methods to prevent external scripts from
+ * focusProtection function creates and returns methods to prevent external scripts from
  * interfering with the focus of the MathType modal dialog.
+ *
+ * @returns {Object} An object with protect and unprotect methods.
  */
-export default class FocusProtection {
+const focusProtection = () => {
   /**
    * Initialize focus protection on the given modal element.
    *
@@ -20,15 +22,15 @@ export default class FocusProtection {
    * @param {HTMLElement} overlayElement - The overlay element of the modal (not used in current implementation)
    * @param {HTMLElement} editorElement - The editor element inside the modal
    */
-  static protect(modalElement, overlayElement, editorElement) {
+  const protect = (modalElement, overlayElement, editorElement) => {
     if (!modalElement || !overlayElement || !editorElement) {
       console.warn("FocusProtection: Missing required elements");
       return;
     }
 
     // Apply the focus protection
-    FocusProtection._applyFocusProtection(modalElement, editorElement);
-  }
+    overrideFocusBehavior(modalElement, editorElement);
+  };
 
   /**
    * Apply focus protection by overriding focus-related methods
@@ -37,7 +39,7 @@ export default class FocusProtection {
    * @param {HTMLElement} editorElement - The editor element to keep focused
    * @private
    */
-  static _applyFocusProtection(modalElement, editorElement) {
+  const overrideFocusBehavior = (modalElement, editorElement) => {
     // Store original focus methods to be able to restore them
     const originalElementFocus = HTMLElement.prototype.focus;
     const originalElementBlur = HTMLElement.prototype.blur;
@@ -62,14 +64,14 @@ export default class FocusProtection {
     // Store the methods to remove them when the modal is closed
     modalElement.originalElementFocus = originalElementFocus;
     modalElement.originalElementBlur = originalElementBlur;
-  }
+  };
 
   /**
    * Remove focus protection from the modal
    *
    * @param {HTMLElement} modalElement - The modal element to unprotect
    */
-  static unprotect(modalElement) {
+  const unprotect = (modalElement) => {
     if (!modalElement) {
       return;
     }
@@ -84,5 +86,12 @@ export default class FocusProtection {
       HTMLElement.prototype.blur = modalElement.originalElementBlur;
       delete modalElement.originalElementBlur;
     }
-  }
-}
+  };
+
+  return {
+    protect,
+    unprotect,
+  };
+};
+
+export default focusProtection;

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -19,9 +19,7 @@ import minsIcon from "../styles/icons/general/mins_icon.svg"; //eslint-disable-l
 import minsHoverIcon from "../styles/icons/hover/mins_icon_h.svg"; //eslint-disable-line
 import maxIcon from "../styles/icons/general/max_icon.svg"; //eslint-disable-line
 import maxHoverIcon from "../styles/icons/hover/max_icon_h.svg"; //eslint-disable-line
-const FocusProtection = focusProtection();
-
-const isMoodle = !!(typeof M === "object" && M !== null);
+const { unprotect } = focusProtection();
 
 /**
  * @typedef {Object} DeviceProperties
@@ -546,22 +544,10 @@ export default class ModalDialog {
     if (!ContentManager.isEditorLoaded()) {
       const listener = Listeners.newListener("onLoad", () => {
         this.contentManager.onOpen(this);
-
-        if (isMoodle) {
-        
-          // Apply focus protection after editor is loaded
-          FocusProtection.protect(this.container, this.overlay, this.contentContainer);
-        }
       });
       this.contentManager.addListener(listener);
     } else {
       this.contentManager.onOpen(this);
-
-      if (isMoodle) {
-      
-        // Apply focus protection immediately if editor is already loaded
-        FocusProtection.protect(this.container, this.overlay, this.contentContainer);
-      }
     }
   }
 
@@ -574,7 +560,7 @@ export default class ModalDialog {
    */
   async close(trigger) {
     // Remove focus protection before closing
-    FocusProtection.unprotect(this.container);
+    unprotect(this.container);
 
     this.removeClass("wrs_maximized");
     this.removeClass("wrs_minimized");
@@ -603,7 +589,7 @@ export default class ModalDialog {
    */
   destroy() {
     // Remove focus protection before destroying
-    FocusProtection.unprotect(this.container);
+    unprotect(this.container);
 
     // Close modal window.
     this.close();

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -556,8 +556,9 @@ export default class ModalDialog {
       this.contentManager.addListener(listener);
     } else {
       this.contentManager.onOpen(this);
-      // Detect Moodle environment
+
       if (isMoodle) {
+      
         // Apply focus protection immediately if editor is already loaded
         FocusProtection.protect(this.container, this.overlay, this.contentContainer);
       }

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -19,7 +19,7 @@ import minsIcon from "../styles/icons/general/mins_icon.svg"; //eslint-disable-l
 import minsHoverIcon from "../styles/icons/hover/mins_icon_h.svg"; //eslint-disable-line
 import maxIcon from "../styles/icons/general/max_icon.svg"; //eslint-disable-line
 import maxHoverIcon from "../styles/icons/hover/max_icon_h.svg"; //eslint-disable-line
-const { unprotect } = focusProtection();
+const { unprotect, protect } = focusProtection();
 
 /**
  * @typedef {Object} DeviceProperties
@@ -543,12 +543,31 @@ export default class ModalDialog {
 
     if (!ContentManager.isEditorLoaded()) {
       const listener = Listeners.newListener("onLoad", () => {
-        this.contentManager.onOpen(this);
+        this.displayEditor();
       });
       this.contentManager.addListener(listener);
     } else {
-      this.contentManager.onOpen(this);
+      this.displayEditor();
     }
+  }
+
+  /**
+   * Prepares and displays the editor in the modal.
+   *
+   * This method is responsible for displaying the MathType editor inside the modal container.
+   *
+   * For Moodle environments, it applies focus protection to prevent external scripts
+   * from hijacking focus away from the editor while it's open. This is particularly
+   * important in Moodle which may have its own focus management scripts.
+   * @returns {void}
+   */
+  displayEditor() {
+    if (this.contentManager.integrationModel.isMoodle) {
+      protect(this.container, this.overlay, this.contentContainer);
+    }
+
+    // Initialize and open the editor using the contentManager.
+    this.contentManager.onOpen(this);
   }
 
   /**

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -544,14 +544,18 @@ export default class ModalDialog {
     if (!ContentManager.isEditorLoaded()) {
       const listener = Listeners.newListener("onLoad", () => {
         this.contentManager.onOpen(this);
-        // Apply focus protection after editor is loaded
-        FocusProtection.protect(this.container, this.overlay, this.contentContainer);
+        if (integrationModelProperties.isMoodle) {
+          // Apply focus protection after editor is loaded
+          FocusProtection.protect(this.container, this.overlay, this.contentContainer);
+        }
       });
       this.contentManager.addListener(listener);
     } else {
       this.contentManager.onOpen(this);
-      // Apply focus protection immediately if editor is already loaded
-      FocusProtection.protect(this.container, this.overlay, this.contentContainer);
+      if (integrationModelProperties.isMoodle) {
+        // Apply focus protection immediately if editor is already loaded
+        FocusProtection.protect(this.container, this.overlay, this.contentContainer);
+      }
     }
   }
 
@@ -592,8 +596,10 @@ export default class ModalDialog {
    * Closes modal window and destroys the object.
    */
   destroy() {
-    // Remove focus protection before destroying
-    FocusProtection.unprotect(this.container);
+    if (integrationModelProperties.isMoodle) {
+      // Remove focus protection before destroying
+      FocusProtection.unprotect(this.container);
+    }
 
     // Close modal window.
     this.close();

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -8,6 +8,7 @@ import ContentManager from "./contentmanager";
 import Telemeter from "./telemeter";
 import IntegrationModel from "./integrationmodel";
 import Core from "./core.src";
+import FocusProtection from "./focusprotection";
 
 import closeIcon from "../styles/icons/general/close_icon.svg"; //eslint-disable-line
 import closeHoverIcon from "../styles/icons/hover/close_icon_h.svg"; //eslint-disable-line
@@ -543,10 +544,14 @@ export default class ModalDialog {
     if (!ContentManager.isEditorLoaded()) {
       const listener = Listeners.newListener("onLoad", () => {
         this.contentManager.onOpen(this);
+        // Apply focus protection after editor is loaded
+        FocusProtection.protect(this.container, this.overlay, this.contentContainer);
       });
       this.contentManager.addListener(listener);
     } else {
       this.contentManager.onOpen(this);
+      // Apply focus protection immediately if editor is already loaded
+      FocusProtection.protect(this.container, this.overlay, this.contentContainer);
     }
   }
 
@@ -558,6 +563,9 @@ export default class ModalDialog {
    * @returns {Promise<void>} A promise that resolves when the modal is closed.
    */
   async close(trigger) {
+    // Remove focus protection before closing
+    FocusProtection.unprotect(this.container);
+
     this.removeClass("wrs_maximized");
     this.removeClass("wrs_minimized");
     this.removeClass("wrs_stack");
@@ -584,6 +592,9 @@ export default class ModalDialog {
    * Closes modal window and destroys the object.
    */
   destroy() {
+    // Remove focus protection before destroying
+    FocusProtection.unprotect(this.container);
+
     // Close modal window.
     this.close();
     // Remove listeners and destroy the object.

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -548,8 +548,8 @@ export default class ModalDialog {
         this.contentManager.onOpen(this);
 
         if (isMoodle) {
+        
           // Apply focus protection after editor is loaded
-
           FocusProtection.protect(this.container, this.overlay, this.contentContainer);
         }
       });

--- a/packages/devkit/src/modal.js
+++ b/packages/devkit/src/modal.js
@@ -8,8 +8,7 @@ import ContentManager from "./contentmanager";
 import Telemeter from "./telemeter";
 import IntegrationModel from "./integrationmodel";
 import Core from "./core.src";
-import FocusProtection from "./focusprotection";
-
+import focusProtection from "./focusprotection";
 import closeIcon from "../styles/icons/general/close_icon.svg"; //eslint-disable-line
 import closeHoverIcon from "../styles/icons/hover/close_icon_h.svg"; //eslint-disable-line
 import fullsIcon from "../styles/icons/general/fulls_icon.svg"; //eslint-disable-line
@@ -20,6 +19,9 @@ import minsIcon from "../styles/icons/general/mins_icon.svg"; //eslint-disable-l
 import minsHoverIcon from "../styles/icons/hover/mins_icon_h.svg"; //eslint-disable-line
 import maxIcon from "../styles/icons/general/max_icon.svg"; //eslint-disable-line
 import maxHoverIcon from "../styles/icons/hover/max_icon_h.svg"; //eslint-disable-line
+const FocusProtection = focusProtection();
+
+const isMoodle = !!(typeof M === "object" && M !== null);
 
 /**
  * @typedef {Object} DeviceProperties
@@ -544,15 +546,18 @@ export default class ModalDialog {
     if (!ContentManager.isEditorLoaded()) {
       const listener = Listeners.newListener("onLoad", () => {
         this.contentManager.onOpen(this);
-        if (integrationModelProperties.isMoodle) {
+
+        if (isMoodle) {
           // Apply focus protection after editor is loaded
+
           FocusProtection.protect(this.container, this.overlay, this.contentContainer);
         }
       });
       this.contentManager.addListener(listener);
     } else {
       this.contentManager.onOpen(this);
-      if (integrationModelProperties.isMoodle) {
+      // Detect Moodle environment
+      if (isMoodle) {
         // Apply focus protection immediately if editor is already loaded
         FocusProtection.protect(this.container, this.overlay, this.contentContainer);
       }
@@ -596,10 +601,8 @@ export default class ModalDialog {
    * Closes modal window and destroys the object.
    */
   destroy() {
-    if (integrationModelProperties.isMoodle) {
-      // Remove focus protection before destroying
-      FocusProtection.unprotect(this.container);
-    }
+    // Remove focus protection before destroying
+    FocusProtection.unprotect(this.container);
 
     // Close modal window.
     this.close();


### PR DESCRIPTION
## Description

Introduce a focus protection mechanism to prevent external scripts from interfering with the MathType modal dialog's focus management. This enhancement ensures that focus remains on the editor when the modal is active.

- **Related Kanbanize Card:** [Link to KB-56852](https://wiris.kanbanize.com/ctrl_board/2/cards/56852/details/)

## Type of Change

> Please delete options that are not relevant.

- [x] Feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (non-breaking change that doesn't add any functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation only)
- [ ] Refactoring (non-breaking change that improves the code structure)

## Checklist

- [x] My code follows the style guidelines of this project ( Run `yarn lint` to check)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes

## How should be tested? (Manual or Automated Tests)

> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce,also list any relevant details for your test configuration.

- **Manual tests:** I have tested this changes manually.
