### PR TITLE
Fix froala buttons title translation

### DIFF
--- a/demos/html/froala/index.html
+++ b/demos/html/froala/index.html
@@ -4,7 +4,7 @@
     <title>Demo Froala on HTML</title>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <script src="./dist/froala-editor/froala_editor.pkgd.min.js"></script>
-    <!-- <script type="text/javascript" src="node_modules/froala-editor/js/languages/de.js"></script> -->
+    <!-- <script type="text/javascript" src="./dist/froala-editor/languages/de.js"></script> -->
     <script src="node_modules/@wiris/mathtype-froala/wiris.js"></script>
   </head>
   <body>

--- a/packages/froala/wiris.src.js
+++ b/packages/froala/wiris.src.js
@@ -106,23 +106,37 @@ export class FroalaIntegration extends IntegrationModel {
     const chemTypeId = `wirisChemistry-${editor.id}`;
 
     // Hide MathType toolbar button if is disabled by config.
-    if (!Configuration.get("editorEnabled")) {
+    if (Configuration.get("editorEnabled")) {
+      // Translate the button title
+      const mathButton = document.getElementById(mathTypeId);
+
+      if (!mathButton) {
+        return
+      }
+
+      mathButton.title = StringManager.get("insert_math", editor.opts.language);
+    }
+    else {
       FroalaEditor.ICONS.wirisEditor = null;
       FroalaEditor.COMMANDS.wirisEditor = null;
       document.getElementById(mathTypeId).classList.add("fr-hidden");
-    } else {
-      // Translate the button title
-      document.getElementById(mathTypeId).title = StringManager.get("insert_math", editor.opts.language);
     }
 
     // Hide ChemType toolbar button if is disabled by config.
-    if (!Configuration.get("chemEnabled")) {
+    if (Configuration.get("chemEnabled")) {
+      // Translate the button title
+      const chemButton = document.getElementById(chemTypeId);
+
+      if (!chemButton) {
+        return
+      }
+
+      chemButton.title = StringManager.get("insert_chem", editor.opts.language);
+    }
+    else {
       FroalaEditor.ICONS.wirisChemistry = null;
       FroalaEditor.COMMANDS.wirisChemistry = null;
       document.getElementById(chemTypeId).classList.add("fr-hidden");
-    } else {
-      // Translate the button title
-      document.getElementById(chemTypeId).title = StringManager.get("insert_chem", editor.opts.language);
     }
   }
 


### PR DESCRIPTION
## Description

Disabling any of the buttons wirisEditor or wirisChemistry on the toolbarButtons list of Froala, will crash the init of Froala. This does not happen with both buttons added to the toolbarButtons option of the Froala editor.

The issue was solved by checking that the button existed before changing it's contents.

- **Related Kanbanize Card:** [Link to KB-57875](https://wiris.kanbanize.com/ctrl_board/2/cards/57875/details/)

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should be tested?

1. Change Froala's language:
     * Uncomment the line 7 on the `demos/html/froala/index.html` file.
     *Uncomment the line 39 on the `demos/html/froala/src/app.js` file.
2. Remove `wirisEditor` or `wirisChemistry` from the toolbarButtons on the Froala's demo js-
3. Build and start the demo with `nx build froala` and `nx start html-froala`
4. The demo should start without the button removed, should work as expected, and the button's title should be in Deutsch.