### PR TITLE
Fix blocking double click event

### DIFF
--- a/demos/html/ckeditor4/src/app.js
+++ b/demos/html/ckeditor4/src/app.js
@@ -32,7 +32,7 @@ CKEDITOR.replace("editor", {
       name: "wirisplugins",
       items: ["ckeditor_wiris_formulaEditor", "ckeditor_wiris_formulaEditorChemistry"],
     },
-    { name: "others" },
+    { name: "others", items: ["Image"] },
   ],
 
   licenseKey: process.env.CKEDITOR4_API_KEY || "",

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wiris/mathtype-html-integration-devkit",
-  "version": "1.17.8",
+  "version": "1.17.11",
   "description": "Allows to integrate MathType Web into any JavaScript HTML WYSIWYG rich text editor.",
   "keywords": [
     "chem",

--- a/packages/devkit/src/integrationmodel.js
+++ b/packages/devkit/src/integrationmodel.js
@@ -668,7 +668,8 @@ export default class IntegrationModel {
       (element, event) => {
         this.doubleClickHandler(element, event);
         // Avoid creating the double click listener more than once for each element.
-        event.stopImmediatePropagation();
+        // This also allows CKEditor4 to add their own double click listener.
+        event.preventDefault();
       },
       (element, event) => {
         this.mousedownHandler(element, event);


### PR DESCRIPTION
## Description

The code in the _integrationmodel.js_ line **653** blocks other plugins from getting the double click event
```

// Avoid creating the doublick listener more than once for each element.
event.stopImmediatePropagation();
```

This code was introduced due to the development of telemetry.

This PR fixes the issue by replacing the `stopImmediatePropagation()` with `preventDefault()`, which only cancels the default browser behavior but still allows other registered event listeners to execute, so CKEditor4 and other plugins continue working normally.

In this PR it's also added the image plugin to CKEditor4 demos permanently.

In this PR it was also included a bug where the devkit version was not properly updated, providing us to reliably test changes made on the devkit locally.

- **Related Kanbanize Card:** [Link to KB-46220](https://wiris.kanbanize.com/ctrl_board/2/cards/46220/details/)
- **Related GitHub Issue:** Closes #912 and #1057

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code follows the style guidelines of this project ( Run `yarn lint` to check)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] New and existing unit tests pass locally with my changes

## How should be tested? 

* Go to this branch CKEditor4 staging demo.
* Double-click a formula and validate it works properly.
* Insert an image (not a formula).
* Double-click the image and validate that the image plugin is triggered and working properly.
