### PR TITLE
Fix/parse viewer namespaced mathml

### DIFF
--- a/packages/viewer/src/mathml.ts
+++ b/packages/viewer/src/mathml.ts
@@ -79,10 +79,10 @@ export async function renderMathML(properties: Properties, root: HTMLElement): P
 
   // Fixed to get all possible math elements, including namespaced ones.
   const allMathElements = [
-    ...root.getElementsByTagName("math"),           // Standard <math>
-    ...root.getElementsByTagNameNS("*", "math"),    // Any valid namespaced math
-    ...root.querySelectorAll("m\\:math"),           // CSS: <m:math> (literal colon)
-    ...root.querySelectorAll("mml\\:math"),         // CSS: <mml:math> (literal colon)
+    ...root.getElementsByTagName("math"), // Standard <math>
+    ...root.getElementsByTagNameNS("*", "math"), // Any valid namespaced math
+    ...root.querySelectorAll("m\\:math"), // CSS: <m:math> (literal colon)
+    ...root.querySelectorAll("mml\\:math"), // CSS: <mml:math> (literal colon)
   ];
 
   for (const mathElement of allMathElements) {


### PR DESCRIPTION
## Description

### Problem
The MathType viewer only detected standard <math> elements, missing namespaced variants like <m:math> and <mml:math> commonly found in XML Documents.

### Solution
Enhanced the MathML selector in the renderMathML function to detect multiple MathML element formats:

- Standard <math> elements
- Properly namespaced elements using getElementsByTagNameNS("*", "math")
- Namespaced elements with literal colons using CSS selectors (m:math, mml:math)

This ensures mathematical formulas are rendered regardless of the namespace prefix used, improving compatibility with various document sources without breaking existing functionality.

- **Related Kanbanize Card:** NONE
- **Related GitHub Issue:** NONE

## Type of Change

- Feature (non-breaking change which adds functionality)

## Checklist

- [ x ] My code follows the style guidelines of this project ( Run `yarn lint` to check)
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ N/A ] I have made corresponding changes to the documentation (if applicable)
- [ x ] My changes generate no new warnings or errors
- [ N/A ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ x ] New and existing unit tests pass locally with my changes

## How should be tested? (Manual or Automated Tests)

- **Manual tests:**
- The demo in this repository works as expected.
- I have tested this changes manually by checking an Arbortext generated DITA XML file renders MathML properly in [this demo](https://github.com/jguillen-at-wiris/mt-display-engine-demo).

Feel free to consider adding that demo to the current viewer demo in this repository.
