### PR TITLE
Fix/ck5 broken tests

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -46,6 +46,7 @@ jobs:
         env:
           CKEDITOR4_API_KEY: ${{ secrets.CKEDITOR4_API_KEY }}
           FROALA_API_KEY: ${{ secrets.FROALA_API_KEY }}
+          CK5_LICENSE_KEY: ${{ secrets.CK5_LICENSE_KEY }}
 
       - name: Build tinymce8 packages
         if: matrix.editor == 'tinymce8'


### PR DESCRIPTION
## Description

The e2e tests are passing, but not in CK5, since we introduced a license key as a secret.


- **Related Kanbanize Card:** [Link to KB-65692](https://wiris.kanbanize.com/ctrl_board/2/cards/65692/details/)

## Type of Change

> Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How should be tested? (Manual or Automated Tests)
Check that CI works as expected and CK5 tets are not failing
