### PR TITLE
fix: Sanitize vulnerability

### DIFF
--- a/packages/devkit/src/util.js
+++ b/packages/devkit/src/util.js
@@ -450,16 +450,34 @@ export default class Util {
    * @static
    */
   static htmlSanitize(html) {
-    const annotationRegex = /\<annotation.+\<\/annotation\>/;
+    const annotationRegex = /(<annotation [^>]*>)([\s\S]*?)(<\/annotation>)/i;
     // Get all the annotation content including the tags.
     const annotation = html.match(annotationRegex);
+
     // Sanitize html code without removing our supported MathML tags and attributes.
     html = DOMPurify.sanitize(html, {
       ADD_TAGS: ["semantics", "annotation", "mstack", "msline", "msrow", "none"],
       ADD_ATTR: ["linebreak", "charalign", "stackalign"],
     });
-    // Readd old annotation content.
-    return html.replace(annotationRegex, annotation);
+
+    if (annotation) {
+      const startTag = annotation[1];
+      const content = annotation[2];
+      const endTag = annotation[3];
+
+      // Encode strictly <, >, and & to their HTML entities to force the browser to render any HTML as text.
+      const safeContent = content
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;");
+
+      const safeAnnotation = startTag + safeContent + endTag;
+
+      // Re-insert the safely encoded annotation content.
+      html = html.replace(annotationRegex, safeAnnotation);
+    }
+
+    return html;
   }
 
   /**


### PR DESCRIPTION
## Description

Fix HTML sanitize to encode characters so that they are treated as regular text instread of HTML.

- **Related Kanbanize Card:** [Link to KB-72074](https://wiris.kanbanize.com/ctrl_board/2/cards/72074/details/)

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## How should be tested? 

Since all integrations are affected, open any of them:

1. Validate that the insertion and edition of LaTeX and Handwritten formulas work as expected
